### PR TITLE
Improve error messages with Latexmk is not found.

### DIFF
--- a/lib/latex.coffee
+++ b/lib/latex.coffee
@@ -28,8 +28,11 @@ module.exports =
       @destroyProgressIndicator()
       if statusCode == 0
         @showResult()
+      else if statusCode == 127 # Command not found, help user troubleshoot.
+        path = new LatexmkBuilder().constructPath()
+        @showError("TeXification failed! Latexmk not found. (Path: '#{path}'.) Adjust your path in latex settings pane...")
       else
-        @showError("TeXification failed! Check the log file for more info...")
+        @showError("TeXification failed with status code #{statusCode}! Check the log file for more info...")
 
     return
 


### PR DESCRIPTION
Not being an atom expert, I ran into some trouble getting the latex
plugin to build my document. It was very hard for me to figure out from
the error messages that I simply needed to update the Tex Path setting
of the plugin. With this modification, users should be able to resolve
the same problem faster.

I kept the modification as simple as possible so it will need updating
as more builders are added.
