### PR TITLE
Error status indicator.

### DIFF
--- a/lib/error-indicator-view.coffee
+++ b/lib/error-indicator-view.coffee
@@ -1,0 +1,10 @@
+{View} = require "atom"
+
+module.exports =
+class ErrorIndicatorView extends View
+  @content: ->
+    @div class: "latex-error-indicator inline-block", =>
+      @span "Latex Compilation Error"
+
+  destroy: ->
+    @remove()

--- a/lib/latex.coffee
+++ b/lib/latex.coffee
@@ -2,6 +2,7 @@ path = require "path"
 
 LatexmkBuilder = require "./builders/latexmk"
 ProgressIndicatorView = require "./progress-indicator-view"
+ErrorIndicatorView = require "./error-indicator-view"
 
 module.exports =
   configDefaults:
@@ -23,6 +24,8 @@ module.exports =
 
     builder = @getBuilder()
     args = builder.constructArgs(file.path)
+    
+    @destroyErrorIndicator()
     @showProgressIndicator()
     proc = builder.run args, (statusCode) =>
       @destroyProgressIndicator()
@@ -61,6 +64,7 @@ module.exports =
   showError: (error) ->
     # TODO: Introduce proper error and warning handling.
     console.error error unless atom.inSpecMode()
+    @showErrorIndicator()
 
   showProgressIndicator: ->
     return @indicator if @indicator?
@@ -69,6 +73,17 @@ module.exports =
     atom.workspaceView.statusBar?.prependRight(@indicator)
     @indicator
 
+  showErrorIndicator: ->
+    return @errorIndicator if @errorIndicator?
+
+    @errorIndicator = new ErrorIndicatorView
+    atom.workspaceView.statusBar?.prependRight(@errorIndicator)
+    @errorIndicator
+
   destroyProgressIndicator: ->
     @indicator?.destroy()
     @indicator = null
+
+  destroyErrorIndicator: ->
+    @errorIndicator?.destroy()
+    @errorIndicator = null

--- a/stylesheets/latex.less
+++ b/stylesheets/latex.less
@@ -21,6 +21,10 @@
   }
 }
 
+.latex-error-indicator {
+  color: red;
+}
+
 @-webkit-keyframes dot {
   0% { opacity: 0; }
   50% { opacity: 0.1; }


### PR DESCRIPTION
Hi, I admittedly thrown this together in a little time so it may not be as good as it is required for a merge request, but I sorely miss the feature it provides: it shows to the user if the compilation was ok without requiring her/him to open the developer console.

If it is indeed good enough to be merged it can be used to provide a nice place for invoking the error logs. By making the ErrorIndicatorView listening for clicks one can open a new editor page showing the error log. I'm willing to work on this if you think this is useful. 

By the way, thanks for the package. I surely hope it evolves fast to incorporate a number of neat features presents in other editors. 
