### PR TITLE
Implementing open-pdf support.

### DIFF
--- a/lib/latex.coffee
+++ b/lib/latex.coffee
@@ -3,6 +3,7 @@ LatexmkBuilder = require "./builders/latexmk"
 MasterTexFinder = require "./master-tex-finder"
 ProgressIndicatorView = require "./progress-indicator-view"
 ErrorIndicatorView = require "./error-indicator-view"
+PdfOpeners = require "./pdf-openers/pdf-openers"
 
 module.exports =
   configDefaults:
@@ -65,7 +66,7 @@ module.exports =
 
   showResult: (result) ->
     # TODO: Display a more visible success message.
-    console.info "Output file path: #{result?.outputFilePath}" unless atom.inSpecMode()
+    PdfOpeners.getOpener()?.open(result.outputFilePath) if result? && !atom.inSpecMode()
     console.info "Success!" unless atom.inSpecMode()
 
   showError: (error) ->

--- a/lib/pdf-openers/pdf-opener.coffee
+++ b/lib/pdf-openers/pdf-opener.coffee
@@ -1,0 +1,13 @@
+path = require "path"
+
+module.exports =
+class PdfOpener
+  # Opens the given pdf file using an external viewer. This method is async.
+  #
+  # @param fileName: the file to be opened
+  # @param error: (optional) a function taking the error structure (as returned
+  #   by child_process#exec) and the stderr of the child process and
+  #   handling the error report to the user
+  # @param next: (optional) a function that will be called if the opening is successful
+  open: (filePath, errorHandler, next) ->
+    throw "Implement this into subclasses"

--- a/lib/pdf-openers/pdf-openers.coffee
+++ b/lib/pdf-openers/pdf-openers.coffee
@@ -1,0 +1,14 @@
+PreviewAppPdfOpener = require "./preview-app-pdf-opener"
+{platform} = require "os"
+
+module.exports =
+class PdfOpeners
+  # Returns an appropriate pdf-opener given the current OS, available applications
+  # and user preferences.
+  # TODO: implement it properly. Currently it works only on OS X.
+  @getOpener: ->
+    switch platform()
+      when "darwin" then new PreviewAppPdfOpener()
+      else
+        console.info("opening pdfs is still not supported on your platform")
+        null

--- a/lib/pdf-openers/preview-app-pdf-opener.coffee
+++ b/lib/pdf-openers/preview-app-pdf-opener.coffee
@@ -1,0 +1,13 @@
+PdfOpener = require "./pdf-opener"
+{exec} = require "child_process"
+
+
+module.exports =
+class PreviewAppPdfOpener extends PdfOpener
+  open: (filePath, errorHandler, next) ->
+    exec "open -a Preview " + filePath, (error, stdout, stderr) ->
+      if error?
+        errorHandler(error, stderr) if errorHandler?
+        return
+
+      next() if next?

--- a/spec/pdf-openers/pdf-openers-spec.coffee
+++ b/spec/pdf-openers/pdf-openers-spec.coffee
@@ -1,0 +1,7 @@
+{platform} = require "os"
+PdfOpeners = require "../../lib/pdf-openers/pdf-openers"
+
+describe "PdfOpeners", ->
+  describe "getOpener", ->
+    it "supports OS X", ->
+      expect(PdfOpeners.getOpener()).toNotBe(null) if platform() == "darwin"

--- a/spec/pdf-openers/preview-app-pdf-opener-spec.coffee
+++ b/spec/pdf-openers/preview-app-pdf-opener-spec.coffee
@@ -1,0 +1,24 @@
+PreviewAppPdfOpener = require "../../lib/pdf-openers/preview-app-pdf-opener"
+
+describe "PreviewAppPdfOpener", ->
+  describe "open", ->
+    it "calls the given error handler if the file is not found", ->
+      opener = new PreviewAppPdfOpener()
+      error = null
+      stderr = null
+
+      errorHandler = (err, errOutput) ->
+        error = err
+        stderr = errOutput
+
+      runs ->
+        opener.open("dummy-file-name.pdf", errorHandler, () -> return )
+
+      waitsFor (->
+        error != null
+        ), "the error handler was not called", 500
+
+      runs ->
+        expect(error).toNotBe(null)
+        expect(error.code).toNotEqual(0)
+        expect(stderr).toMatch(/dummy-file-name.pdf does not exist\./)


### PR DESCRIPTION
Presently the spec only tests for correct handling of errors. Do not really have idea what to test in case of success. The problem is: if I stub out the exec function there is nothing to test, otherwise the system will launch Preview (which I assume is _not_ what we want). 

Other issues with specs: should  the PreviewAppPdfOpener spec be run only on systems that support that program? What's the idiomatic way of solving this problem? A check in the spec itself?
