### PR TITLE
Add a Skim.app opener

### DIFF
--- a/lib/openers/skim-opener.coffee
+++ b/lib/openers/skim-opener.coffee
@@ -1,0 +1,11 @@
+child_process = require 'child_process'
+Opener = require '../opener'
+
+module.exports =
+class SkimOpener extends Opener
+  open: (filePath, callback) ->
+    command = "open -g -a Skim.app #{filePath}"
+    command = command.replace(/\-g\s/, '') unless @shouldOpenInBackground()
+    child_process.exec command, (error, stdout, stderr) ->
+      exitCode = error?.code ? 0
+      callback(exitCode) if callback?

--- a/spec/openers/skim-opener-spec.coffee
+++ b/spec/openers/skim-opener-spec.coffee
@@ -1,0 +1,11 @@
+PreviewOpener = require '../../lib/openers/skim-opener'
+
+describe "SkimOpener", ->
+  describe "open", ->
+    it "invokes the callback with an exit code equal to `1` because the file is not found", ->
+      exitCode = null
+      opener = new SkimOpener()
+      opener.open 'dummy-file-name.pdf', (code) -> exitCode = code
+
+      waitsFor -> exitCode > 0
+      runs -> expect(exitCode).toEqual(1)


### PR DESCRIPTION
Only adds the actual opener, with no code to make it accessible to the user. This would probably be done using some kind of option, but I'm not sure what the best implementation of PDF viewer selection options would be.

This is kind of in preparation of introducing SyncTeX capabilities, since Preview.app doesn't support this(?). Skim.app does, through a utility included in its application contents, but using that utility requires that the caller knows the full path to Skim (standard is `/Applications/Skim.app`) which may be something to have in mind when designing a PDF viewer option.

Briefly SyncTeX with Skim would be calling `/Applications/Skim.app/Contents/SharedSupport/displayline -r [-g] <line> <pdf-file> <tex-file>` for forward syncing as [the Sublime package does](https://github.com/SublimeText/LaTeXTools/blob/master/jumpToPDF.py#L62-66), and doing `atom <tex-file>:<line>` in the other direction (assuming atom/atom#1743 gets fixed), so it's not that difficult assuming the path to Skim.app is known and appropriate hooks are available in Atom itself.
