### PR TITLE
Add engine customization

### DIFF
--- a/lib/builders/latexmk.coffee
+++ b/lib/builders/latexmk.coffee
@@ -25,16 +25,20 @@ class LatexmkBuilder extends Builder
       '-f'
       '-cd'
       '-pdf'
-    ]
-
-    pdfOpts = [
       '-synctex=1'
       '-file-line-error'
     ]
 
     enableShellEscape = atom.config.get('latex.enableShellEscape')
-    pdfOpts.push('-shell-escape') if enableShellEscape?
-    args.push("-pdflatex=\"pdflatex #{pdfOpts.join(' ')} %O %S\"")
+    customEngine = atom.config.get('latex.customEngine')
+    engine = atom.config.get('latex.engine')
+
+    args.push('-shell-escape') if enableShellEscape?
+
+    if customEngine
+      args.push("-pdflatex=\"#{customEngine}\"")
+    else if engine? and engine isnt 'pdflatex'
+      args.push("-#{engine}")
 
     if outdir = atom.config.get('latex.outputDirectory')
       dir = path.dirname(filePath)

--- a/lib/config-schema.coffee
+++ b/lib/config-schema.coffee
@@ -27,3 +27,12 @@ module.exports =
     description: "The full path to your TeX distribution's bin directory."
     type: 'string'
     default: ''
+  engine:
+    description: 'Select standard LaTeX engine'
+    type: 'string'
+    default: 'pdflatex'
+    enum: ['pdflatex', 'lualatex', 'xelatex']
+  customEngine:
+    description: 'Enter command for custom LaTeX engine. Overrides Engine.'
+    type: 'string'
+    default: ''

--- a/spec/builders/latexmk-spec.coffee
+++ b/spec/builders/latexmk-spec.coffee
@@ -17,22 +17,27 @@ describe "LatexmkBuilder", ->
         '-f'
         '-cd'
         '-pdf'
-        '-pdflatex="pdflatex -synctex=1 -file-line-error %O %S"'
+        '-synctex=1'
+        '-file-line-error'
         "\"#{@filePath}\""
       ]
       args = builder.constructArgs(@filePath)
       expect(args).toEqual(expectedArgs)
 
     it "adds -shell-escape flag when package config value is set", ->
-      expectedArg = '-pdflatex="pdflatex -synctex=1 -file-line-error
-        -shell-escape %O %S"'
       helpers.spyOnConfig('latex.enableShellEscape', true)
-      arg = builder.constructArgs(@filePath)?.splice(-2, 1)[0]
-      expect(arg).toEqual(expectedArg)
+      expect(builder.constructArgs(@filePath)).toContain "-shell-escape"
 
     it "adds -outdir=<path> argument according to package config", ->
       outdir = 'bar'
       expectedArg = "-outdir=\"#{outdir}\""
       helpers.spyOnConfig('latex.outputDirectory', outdir)
-      arg = builder.constructArgs(@filePath)?.splice(-2, 1)[0]
-      expect(arg).toEqual(expectedArg)
+      expect(builder.constructArgs(@filePath)).toContain expectedArg
+
+    it "adds engine argument according to package config", ->
+      helpers.spyOnConfig('latex.engine', 'lualatex')
+      expect(builder.constructArgs(@filePath)).toContain "-lualatex"
+
+    it "adds a custom engine string according to package config", ->
+      helpers.spyOnConfig('latex.customEngine', 'pdflatex %O %S')
+      expect(builder.constructArgs(@filePath)).toContain '-pdflatex="pdflatex %O %S"'


### PR DESCRIPTION
Allow selection of standard engines and custom engine command line
Move -synctex, -file-line-error and -shell-escape flags to main latexmk flags
