### PR TITLE
Update keymaps/latex.cson to fix deprecation warning

### DIFF
--- a/keymaps/latex.cson
+++ b/keymaps/latex.cson
@@ -1,3 +1,3 @@
-'.editor':
+'atom-text-editor':
   'ctrl-alt-b': 'latex:build'
   'ctrl-alt-s': 'latex:sync'


### PR DESCRIPTION
Use the 'atom-text-editor' tag instead of the '.editor' class

Fix the deprecation warning on Atom 0.174.0 and API 1.0