### PR TITLE
Add feature to clean LaTeX project directory

### DIFF
--- a/menus/latex.cson
+++ b/menus/latex.cson
@@ -5,6 +5,7 @@
       'label': 'LaTeX'
       'submenu': [
         { 'label': 'Build', 'command': 'latex:build' }
+        { 'label': 'Clean', 'command': 'latex:clean' }
       ]
     ]
   }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "repository": "https://github.com/thomasjo/atom-latex",
   "license": "MIT",
   "activationEvents": [
-    "latex:build"
+    "latex:build",
+    "latex:clean"
   ],
   "engines": {
     "atom": ">0.170.0"


### PR DESCRIPTION
In my LaTeX workflow, it is often useful to *clean* the project directory, removing files created as a byproduct of the make process.  I've added a `Clean` item to the LaTeX menu which will take the root file and remove files with temporary extensions.  It's configurable in `latex.cleanExtensions` if non-defaults are desired.  I didn't add a keybinding, since deletion is potentially dangerous.

This was useful for me while troubleshooting #46, where I needed to do a full clean to get the document to compile and generate a new log file.