### PR TITLE
Add support for cross-platform and Windows PDF viewers

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Current wish list, in a semi-prioritized order.
 - [ ] BibTeX autocompletion support.
 - [x] Open PDF automatically.
  - [x] Configurable.
- - [ ] Support for other distributions, besides OS X.
+ - [x] Support for other distributions, besides OS X.
 - [ ] Support for compilers other than latexmk.
  - [ ] Add support for non-PDF typesetting (e.g. dvi).
 - [ ] Project management.

--- a/lib/latex.coffee
+++ b/lib/latex.coffee
@@ -79,20 +79,18 @@ module.exports =
 
   getOpener: ->
     # TODO: Move this to a resolver module? Will get more complex...
-    if atom.config.get('latex.useAtomPdfViewer')
+    OpenerImpl = switch process.platform
+      when 'darwin'
+        if fs.existsSync(atom.config.get('latex.skimPath'))
+          require './openers/skim-opener'
+        else
+          require './openers/preview-opener'
+      when 'win32'
+        if fs.existsSync(atom.config.get('latex.sumatraPath'))
+          require './openers/sumatra-opener'
+    unless OpenerImpl?
       OpenerImpl = require './openers/atompdf-opener'
-    else
-      OpenerImpl = switch process.platform
-        when 'darwin'
-          if fs.existsSync(atom.config.get('latex.skimPath'))
-            require './openers/skim-opener'
-          else
-            require './openers/preview-opener'
-        when 'win32'
-          if fs.existsSync(atom.config.get('latex.sumatraPath'))
-            require './openers/sumatra-opener'
-    return new OpenerImpl() if OpenerImpl?
-    console.info 'Opening PDF files is not yet supported on your platform.' unless atom.inSpecMode()
+    return new OpenerImpl()
 
   moveResult: (result, filePath) ->
     sourceDir = path.dirname(filePath)

--- a/lib/latex.coffee
+++ b/lib/latex.coffee
@@ -88,7 +88,9 @@ module.exports =
             require './openers/skim-opener'
           else
             require './openers/preview-opener'
-
+        when 'win32'
+          if fs.existsSync(atom.config.get('latex.sumatraPath'))
+            require './openers/sumatra-opener'
     return new OpenerImpl() if OpenerImpl?
     console.info 'Opening PDF files is not yet supported on your platform.' unless atom.inSpecMode()
 

--- a/lib/latex.coffee
+++ b/lib/latex.coffee
@@ -89,7 +89,11 @@ module.exports =
         if fs.existsSync(atom.config.get('latex.sumatraPath'))
           require './openers/sumatra-opener'
     unless OpenerImpl?
-      OpenerImpl = require './openers/atompdf-opener'
+      if atom.packages.resolvePackagePath('pdf-view')?
+        OpenerImpl = require './openers/atompdf-opener'
+      else
+        console.info 'No PDF opener found.  For cross-platform viewing, install the pdf-view package.' unless atom.inSpecMode()
+        return
     return new OpenerImpl()
 
   moveResult: (result, filePath) ->

--- a/lib/latex.coffee
+++ b/lib/latex.coffee
@@ -79,12 +79,15 @@ module.exports =
 
   getOpener: ->
     # TODO: Move this to a resolver module? Will get more complex...
-    OpenerImpl = switch process.platform
-      when 'darwin'
-        if fs.existsSync(atom.config.get('latex.skimPath'))
-          require './openers/skim-opener'
-        else
-          require './openers/preview-opener'
+    if atom.config.get('latex.useAtomPdfViewer')
+      OpenerImpl = require './openers/atompdf-opener'
+    else
+      OpenerImpl = switch process.platform
+        when 'darwin'
+          if fs.existsSync(atom.config.get('latex.skimPath'))
+            require './openers/skim-opener'
+          else
+            require './openers/preview-opener'
 
     return new OpenerImpl() if OpenerImpl?
     console.info 'Opening PDF files is not yet supported on your platform.' unless atom.inSpecMode()

--- a/lib/openers/atompdf-opener.coffee
+++ b/lib/openers/atompdf-opener.coffee
@@ -1,0 +1,14 @@
+Opener = require '../opener'
+
+module.exports =
+class AtomPdfOpener extends Opener
+  open: (filePath, texPath, lineNumber, callback) ->
+    # Opens PDF in a new pane -- requires pdf-view module
+    openPanes = atom.workspace.getPaneItems()
+    for pane in openPanes
+      if pane.filePath == filePath
+        # File is already open in another pane
+        return
+    pane = atom.workspace.getActivePane()
+    newPane = pane.split('horizontal', 'after')
+    atom.workspace.openURIInPane(filePath, newPane)

--- a/lib/openers/sumatra-opener.coffee
+++ b/lib/openers/sumatra-opener.coffee
@@ -1,0 +1,14 @@
+child_process = require 'child_process'
+Opener = require '../opener'
+
+module.exports =
+class SumatraOpener extends Opener
+  open: (filePath, texPath, lineNumber, callback) ->
+    sumatraPath = atom.config.get('latex.sumatraPath')
+    args = [
+      '-forward-search'
+      texPath
+      lineNumber
+      filePath
+    ]
+    child_process.execFile(sumatraPath, args)

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   },
   "dependencies": {
     "fs-plus": "~2.3.0",
-    "pdf-view": "~0.14.0",
     "temp": "~0.8.0",
     "underscore-plus": "~1.5.1",
     "wrench": "~1.5.8"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "fs-plus": "~2.3.0",
+    "pdf-view": "~0.14.0",
     "temp": "~0.8.0",
     "underscore-plus": "~1.5.1",
     "wrench": "~1.5.8"


### PR DESCRIPTION
These commits add support for (and dependency on) the [pdf-view](https://atom.io/packages/pdf-view) module to allow previewing directly in Atom. If no other opener is found/configured, the built-in preview is used as a fallback.

I've also added basic support for opening SumatraPDF on Windows.  Unfortunately Acrobat puts a write lock on PDF files, preventing the LaTeX build from succeeding while the PDF is open.  Sumatra will auto-refresh the PDF view on update.