### PR TITLE
Command to wrap long lines

### DIFF
--- a/keymaps/latex.cson
+++ b/keymaps/latex.cson
@@ -1,3 +1,4 @@
 'atom-text-editor':
   'ctrl-alt-b': 'latex:build'
   'ctrl-alt-s': 'latex:sync'
+  'ctrl-alt-w': 'latex:wrap'

--- a/lib/latex.coffee
+++ b/lib/latex.coffee
@@ -68,13 +68,14 @@ module.exports =
         extension = path.extname(filePath)
         console.info "File does not seem to be a TeX file; unsupported extension '#{extension}'"
       return false
-    # we work with cursors here. This might not be the best way of doing this,
-    # but it works.
-    lineCount = editor.getLineCount()
-    lastLineLength = editor.lineTextForBufferRow(lineCount - 1).length
-    editor.backwardsScanInBufferRange /^(.){120,}$/g, [[0,1], [lineCount - 1, lastLineLength - 1]], (match) ->
-      w = wrap 120
-      match.replace w(match.matchText)
+    preferredLineLength = atom.config.get('editor.preferredLineLength')
+    editor.transact () ->
+      lineCount = editor.getLineCount()
+      lastLineLength = editor.lineTextForBufferRow(lineCount - 1).length
+      regexp = RegExp("^(.){" + preferredLineLength + ",}$", "g")
+      editor.backwardsScanInBufferRange regexp, [[0,1], [lineCount - 1, lastLineLength - 1]], (match) ->
+        w = wrap preferredLineLength
+        match.replace w(match.matchText)
 
   # TODO: Improve overall code quality within this function.
   clean: ->

--- a/lib/latex.coffee
+++ b/lib/latex.coffee
@@ -71,6 +71,7 @@ module.exports =
       return false
     # we work with cursors here. This might not be the best way of doing this,
     # but it works.
+    # TODO: hard coding 120 here is not optimal. We should read this value from the configuration
     lineCount = editor.getLineCount()
     lastLineLength = editor.lineTextForBufferRow(lineCount - 1).length
     editor.backwardsScanInBufferRange /^(.){120,}$/g, [[0,1], [lineCount - 1, lastLineLength - 1]], (match) ->

--- a/lib/latex.coffee
+++ b/lib/latex.coffee
@@ -46,7 +46,6 @@ module.exports =
     proc = builder.run args, (statusCode) =>
       @destroyProgressIndicator()
       result = builder.parseLogFile(rootFilePath)
-<<<<<<< HEAD
 
       unless result.outputFilePath?
         error = @constructError(statusCode, builder)
@@ -135,21 +134,6 @@ module.exports =
     editorDetails =
       filePath: editor.getPath()
       lineNumber: editor.getCursorScreenPosition().row + 1
-=======
-      switch statusCode
-        when 0
-          @moveResult(result, rootFilePath) if @shouldMoveResult()
-          @showResult(result)
-        else
-          if result.errors.length
-            @showError(result, statusCode)
-          else
-            @showWarning(result)
-            @moveResult(result, rootFilePath) if @shouldMoveResult()
-            @showResult(result)
-
-    return
->>>>>>> FETCH_HEAD
 
   getBuilder: ->
     new LatexmkBuilder()
@@ -200,44 +184,10 @@ module.exports =
       {filePath, lineNumber} = @getEditorDetails()
       opener.open(result.outputFilePath, filePath, lineNumber)
 
-  showError: (result, statusCode) ->
+  showError: (error) ->
     # TODO: Introduce proper error and warning handling.
-    unless atom.inSpecMode()
-      atom.openDevTools()
-      atom.executeJavaScriptInDevTools('InspectorFrontendAPI.showConsole()')
-      console.group('LaTeX')
-
-      switch statusCode
-        when 127
-          console.error \
-            """
-            TeXification failed! Builder executable not found.
-
-              latex.texPath
-                as configured: #{atom.config.get('latex.texPath')}
-                when resolved: #{builder.constructPath()}
-
-            Make sure latex.texPath is configured correctly; either adjust it \
-            via the settings view, or directly in your config.cson file.
-            """
-        else
-          console.group("TeXification failed with status code #{statusCode}")
-          console.error("#{error.filePath}:#{error.lineNumber}:  #{error.message}") for error in result.errors
-          console.groupEnd()
-
-      console.groupEnd()
-
+    console.error error unless atom.inSpecMode()
     @showErrorIndicator()
-
-  showWarning: (result) ->
-    unless atom.inSpecMode()
-      atom.openDevTools()
-      atom.executeJavaScriptInDevTools('InspectorFrontendAPI.showConsole()')
-      console.group('LaTeX')
-      console.group('TeXification ended with warnings')
-      # TODO: Display warnings.
-      console.groupEnd()
-      console.groupEnd()
 
   showProgressIndicator: ->
     return @indicator if @indicator?

--- a/lib/latex.coffee
+++ b/lib/latex.coffee
@@ -71,7 +71,6 @@ module.exports =
       return false
     # we work with cursors here. This might not be the best way of doing this,
     # but it works.
-    # TODO: hard coding 120 here is not optimal. We should read this value from the configuration
     lineCount = editor.getLineCount()
     lastLineLength = editor.lineTextForBufferRow(lineCount - 1).length
     editor.backwardsScanInBufferRange /^(.){120,}$/g, [[0,1], [lineCount - 1, lastLineLength - 1]], (match) ->

--- a/lib/latex.coffee
+++ b/lib/latex.coffee
@@ -133,7 +133,8 @@ module.exports =
       if atom.packages.resolvePackagePath('pdf-view')?
         OpenerImpl = require './openers/atompdf-opener'
       else
-        console.info 'No PDF opener found.  For cross-platform viewing, install the pdf-view package.' unless atom.inSpecMode()
+        console.info 'No PDF opener found. For cross-platform viewing,
+          install the pdf-view package.' unless atom.inSpecMode()
         return
     return new OpenerImpl()
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "space-pen": "^5.1.1",
     "temp": "~0.8.0",
     "underscore-plus": "~1.5.1",
-    "wrench": "~1.5.8"
+    "wrench": "~1.5.8",
+    "wordwrap": "~0.0.2"
   }
 }


### PR DESCRIPTION
I often collaborate on TeX-Files. My colleagues usually write long lines of text, which has several disadvantages (sync between source and PDF is less accurate and it is just ugly).

I usually wrap the lines, but I do not want to do that manually. So I just added a command that searches for all lines longer than atom.config.get('editor.preferredLineLength') and wrap them by inserting a new line. Since a new line usually does not have any semantic properties in LaTeX (other then a whitespace), this should usually work.