### PR TITLE
Improve TeX path resolution

### DIFF
--- a/lib/builder.coffee
+++ b/lib/builder.coffee
@@ -30,7 +30,11 @@ class Builder
   defaultTexPath: ->
     switch process.platform
       when 'win32'
-        'C:\\texlive\\2014\\bin\\win32'
+        [
+          'C:\\texlive\\2014\\bin\\win32'
+          'C:\\Program Files\\MiKTeX 2.9\\miktex\\bin\\x64'
+          'C:\\Program Files (x86)\\MiKTeX 2.9\\miktex\\bin'
+        ].join(';')
       else
         '/usr/texbin'
 

--- a/lib/builder.coffee
+++ b/lib/builder.coffee
@@ -20,14 +20,19 @@ class Builder
   constructPath: ->
     texPath = atom.config.get('latex.texPath')?.trim()
     texPath = @defaultTexPath() unless texPath?.length
-    texPath = texPath.replace('$PATH', process.env[@envPathKey])
+    processPath = process.env[@envPathKey]
+
+    if match = texPath.match /^(.*)(\$PATH)(.*)$/
+      texPath = "#{match[1]}#{processPath}#{match[3]}"
+    else
+      texPath = [texPath, processPath].join(path.delimiter)
 
   defaultTexPath: ->
     switch process.platform
       when 'win32'
-        '$PATH;C:\\texlive\\2014\\bin\\win32'
+        'C:\\texlive\\2014\\bin\\win32'
       else
-        '$PATH:/usr/texbin'
+        '/usr/texbin'
 
   resolveLogFilePath: (texFilePath) ->
     outputDirectory = atom.config.get('latex.outputDirectory') ? ''

--- a/lib/config-schema.coffee
+++ b/lib/config-schema.coffee
@@ -66,6 +66,7 @@ module.exports =
 
   texPath:
     title: 'TeX Path'
-    description: "The full path to your TeX distribution's bin directory."
+    description: "The full path to your TeX distribution's bin directory.
+      Supports $PATH substitution."
     type: 'string'
     default: ''

--- a/spec/builder-spec.coffee
+++ b/spec/builder-spec.coffee
@@ -2,7 +2,7 @@ helpers = require './spec-helpers'
 path = require 'path'
 Builder = require '../lib/builder'
 
-fdescribe "Builder", ->
+describe "Builder", ->
   [builder] = []
 
   beforeEach ->

--- a/spec/builder-spec.coffee
+++ b/spec/builder-spec.coffee
@@ -1,23 +1,52 @@
 helpers = require './spec-helpers'
+path = require 'path'
 Builder = require '../lib/builder'
 
-describe "Builder", ->
+fdescribe "Builder", ->
   [builder] = []
 
   beforeEach ->
     builder = new Builder()
 
   describe "constructPath", ->
-    beforeEach ->
-      helpers.spyOnConfig('latex.texPath', '$PATH:/usr/texbin')
-
     it "reads `latex.texPath` as configured", ->
+      spyOn(atom.config, 'get').andReturn()
       builder.constructPath()
 
       expect(atom.config.get).toHaveBeenCalledWith('latex.texPath')
 
-    it "replaces $PATH with process.env.PATH", ->
-      expectedPath = "#{process.env.PATH}:/usr/texbin"
+    it "uses platform default when `latex.texPath` is not configured", ->
+      helpers.spyOnConfig('latex.texPath', '')
+      spyOn(builder, 'defaultTexPath').andReturn(defaultTexPath = '/foo/bar')
+      expectedPath = [defaultTexPath, process.env.PATH].join(path.delimiter)
+      constructedPath = builder.constructPath()
+
+      expect(constructedPath).toEqual(expectedPath)
+
+    it "replaces surrounded $PATH with process.env.PATH", ->
+      helpers.spyOnConfig('latex.texPath', texPath = '/foo:$PATH:/bar')
+      expectedPath = texPath.replace('$PATH', process.env.PATH)
+      constructedPath = builder.constructPath()
+
+      expect(constructedPath).toEqual(expectedPath)
+
+    it "replaces leading $PATH with process.env.PATH", ->
+      helpers.spyOnConfig('latex.texPath', texPath = '$PATH:/bar')
+      expectedPath = texPath.replace('$PATH', process.env.PATH)
+      constructedPath = builder.constructPath()
+
+      expect(constructedPath).toEqual(expectedPath)
+
+    it "replaces trailing $PATH with process.env.PATH", ->
+      helpers.spyOnConfig('latex.texPath', texPath = '/foo:$PATH')
+      expectedPath = texPath.replace('$PATH', process.env.PATH)
+      constructedPath = builder.constructPath()
+
+      expect(constructedPath).toEqual(expectedPath)
+
+    it "prepends process.env.PATH with texPath", ->
+      helpers.spyOnConfig('latex.texPath', texPath = '/foo')
+      expectedPath = [texPath, process.env.PATH].join(path.delimiter)
       constructedPath = builder.constructPath()
 
       expect(constructedPath).toEqual(expectedPath)


### PR DESCRIPTION
Changes the old default behavior of only using the inherited system/process $PATH environment variable if the configured (or platform default) TeX path contained the substitution marker `$PATH`. Now it instead appends the aforementioned $PATH to the configured path. $PATH substitution is still supported for those who want or need it. However, it is no longer possible to prevent inheritance, but I don't think that will cause any adverse problems.

Would be great if folks could test this out and see if it causes any regressions. I'm especially interested in feedback from those of you who use MiKTeX. You should hopefully no longer need to specify Perl paths in `latex.texPath`.

/cc @nscaife @igor25