### PR TITLE
For lineNumber use getCursorBufferPosition()

### DIFF
--- a/lib/composer.coffee
+++ b/lib/composer.coffee
@@ -148,7 +148,7 @@ class Composer
 
     editorDetails =
       filePath: editor.getPath()
-      lineNumber: editor.getCursorScreenPosition().row + 1
+      lineNumber: editor.getCursorBufferPosition().row + 1
 
   alterParentPath: (targetPath, originalPath) ->
     targetDir = path.dirname(targetPath)


### PR DESCRIPTION
I have problems when I use softwrap for editing a tex file, this change seems to fix the problem, at least on OSX with Skim.

When using getCursorScreenPosition() with softwrap the line number includes wrapped lines and the location in the document is incorrect. Instead use getCursorBufferPosition() which does not count wrapped lines.
For Explanation See https://atom.io/docs/api/v0.187.0/TextEditor#buffer-vs-screen-coordinates