### PR TITLE
Add option for always opening result in Atom

### DIFF
--- a/lib/config-schema.js
+++ b/lib/config-schema.js
@@ -3,6 +3,11 @@
 import {heredoc} from "./werkzeug";
 
 export default {
+  alwaysOpenResultInAtom: {
+    type: "boolean",
+    default: false,
+  },
+
   cleanExtensions: {
     type: "array",
     items: {type: "string"},

--- a/lib/latex.js
+++ b/lib/latex.js
@@ -27,6 +27,8 @@ export default class Latex {
     defineDefaultProperty(this, "builder");
     defineDefaultProperty(this, "logger");
     defineDefaultProperty(this, "opener");
+
+    this.observeOpenerConfig();
   }
 
   getBuilder() { return this.builder; }
@@ -70,30 +72,44 @@ export default class Latex {
     };
   }
 
+  observeOpenerConfig() {
+    const callback = () => { this["__opener"] = this.getDefaultOpener(); };
+    atom.config.onDidChange("latex.alwaysOpenResultInAtom", callback);
+    atom.config.onDidChange("latex.skimPath", callback);
+    atom.config.onDidChange("latex.sumatraPath", callback);
+  }
+
   resolveOpenerImplementation(platform) {
-    let OpenerImpl;
+    if (this.hasPdfViewerPackage() && this.shouldOpenResultInAtom()) {
+      return require("./openers/atompdf-opener");
+    }
 
     switch (platform) {
       case "darwin":
         if (fs.existsSync(atom.config.get("latex.skimPath"))) {
-          OpenerImpl = require("./openers/skim-opener");
-          break;
+          return require("./openers/skim-opener");
         }
 
-        OpenerImpl = require("./openers/preview-opener");
-        break;
+        return require("./openers/preview-opener");
 
       case "win32":
         if (fs.existsSync(atom.config.get("latex.sumatraPath"))) {
-          OpenerImpl = require("./openers/sumatra-opener");
-          break;
+          return require("./openers/sumatra-opener");
         }
     }
 
-    if (!OpenerImpl && atom.packages.resolvePackagePath("pdf-view")) {
-      OpenerImpl = require("./openers/atompdf-opener");
+    if (this.hasPdfViewerPackage()) {
+      return require("./openers/atompdf-opener");
     }
 
-    return OpenerImpl;
+    return null;
+  }
+
+  hasPdfViewerPackage() {
+    return !!atom.packages.resolvePackagePath("pdf-view");
+  }
+
+  shouldOpenResultInAtom() {
+    return atom.config.get("latex.alwaysOpenResultInAtom");
   }
 }

--- a/lib/latex.js
+++ b/lib/latex.js
@@ -86,14 +86,14 @@ export default class Latex {
 
     switch (platform) {
       case "darwin":
-        if (fs.existsSync(atom.config.get("latex.skimPath"))) {
+        if (this.skimExecutableExists()) {
           return require("./openers/skim-opener");
         }
 
         return require("./openers/preview-opener");
 
       case "win32":
-        if (fs.existsSync(atom.config.get("latex.sumatraPath"))) {
+        if (this.sumatraExecutableExists()) {
           return require("./openers/sumatra-opener");
         }
     }
@@ -111,5 +111,13 @@ export default class Latex {
 
   shouldOpenResultInAtom() {
     return atom.config.get("latex.alwaysOpenResultInAtom");
+  }
+
+  skimExecutableExists() {
+    return fs.existsSync(atom.config.get("latex.skimPath"));
+  }
+
+  sumatraExecutableExists() {
+    return fs.existsSync(atom.config.get("latex.sumatraPath"));
   }
 }

--- a/spec/latex-spec.js
+++ b/spec/latex-spec.js
@@ -135,13 +135,15 @@ describe("Latex", function() {
     });
 
     it("does not support GNU/Linux", function() {
+      spyOn(latex, "hasPdfViewerPackage").andReturn(false);
       const opener = latex.resolveOpenerImplementation("linux");
-      expect(opener).toBeUndefined();
+      expect(opener).toBeNull();
     });
 
     it("does not support unknown operating systems", function() {
+      spyOn(latex, "hasPdfViewerPackage").andReturn(false);
       const opener = latex.resolveOpenerImplementation("foo");
-      expect(opener).toBeUndefined();
+      expect(opener).toBeNull();
     });
   });
 });

--- a/spec/latex-spec.js
+++ b/spec/latex-spec.js
@@ -126,6 +126,23 @@ describe("Latex", function() {
       expect(latex.skimExecutableExists).not.toHaveBeenCalled();
     });
 
+    it("responds to changes in configuration", function() {
+      spyOn(latex, "hasPdfViewerPackage").andReturn(true);
+      spyOn(latex, "shouldOpenResultInAtom").andReturn(false);
+      spyOn(latex, "skimExecutableExists").andReturn(true);
+
+      let opener = latex.resolveOpenerImplementation("darwin");
+      expect(opener.name).toBe("SkimOpener");
+
+      latex.shouldOpenResultInAtom.andReturn(true);
+      opener = latex.resolveOpenerImplementation("darwin");
+      expect(opener.name).toBe("AtomPdfOpener");
+
+      latex.shouldOpenResultInAtom.andReturn(false);
+      opener = latex.resolveOpenerImplementation("darwin");
+      expect(opener.name).toBe("SkimOpener");
+    });
+
     it("does not support GNU/Linux", function() {
       spyOn(latex, "hasPdfViewerPackage").andReturn(false);
       const opener = latex.resolveOpenerImplementation("linux");

--- a/spec/latex-spec.js
+++ b/spec/latex-spec.js
@@ -123,15 +123,21 @@ describe("Latex", function() {
     });
 
     it("returns AtomPdfOpener as a fallback, if the pdf-view package is installed", function() {
-      const resolvePackagePath = atom.packages.resolvePackagePath;
-      atom.packages.resolvePackagePath.andCallFake(name => {
-        if (name === "pdf-view") { return true; }
-        return resolvePackagePath(name);
-      });
-
+      spyOn(latex, "hasPdfViewerPackage").andReturn(true);
       const opener = latex.resolveOpenerImplementation("foo");
 
       expect(opener.name).toBe("AtomPdfOpener");
+    });
+
+    it("always returns AtomPdfOpener if alwaysOpenResultInAtom is enabled and pdf-view is installed", function() {
+      spyOn(latex, "hasPdfViewerPackage").andReturn(true);
+      spyOn(latex, "shouldOpenResultInAtom").andReturn(true);
+      spyOn(fs, "existsSync").andCallThrough();
+
+      const opener = latex.resolveOpenerImplementation("darwin");
+
+      expect(opener.name).toBe("AtomPdfOpener");
+      expect(fs.existsSync).not.toHaveBeenCalled();
     });
 
     it("does not support GNU/Linux", function() {


### PR DESCRIPTION
Inspired by https://github.com/daskelly/atom-latex/commit/bc1c7ef21239e97374e96146174cd7eb5b779099.

Only supports the `AtomPdfOpener` right now, but at some point it might be necessary to expand that. Also not entirely sure whether to call the option `alwaysOpenResultInAtom` or `preferOpeningResultInAtom` or some such variation thereof. Might be necessary to add a description to the option as well, stating the option will only be used if the `pdf-view` package is actually installed.

- [x] Implement option `latex.alwaysOpenResultInAtom`.
- [x] Add specs.

/cc @daskelly