### PR TITLE
Open log file when clicking error indicator

### DIFF
--- a/lib/composer.js
+++ b/lib/composer.js
@@ -175,7 +175,7 @@ export default class Composer {
   }
 
   showError(statusCode, result, builder) {
-    this.showErrorIndicator();
+    this.showErrorIndicator(result);
     latex.log.error(statusCode, result, builder);
   }
 
@@ -190,12 +190,13 @@ export default class Composer {
     return this.indicator;
   }
 
-  showErrorIndicator() {
+  showErrorIndicator(result) {
     if (!this.statusBar) { return null; }
     if (this.errorIndicator) { return this.errorIndicator; }
 
     const ErrorIndicatorView = require("./views/error-indicator-view");
     this.errorIndicator = new ErrorIndicatorView();
+    this.errorIndicator.initialize(result);
     this.statusBar.addRightTile({item: this.errorIndicator, priority: 9001});
 
     return this.errorIndicator;

--- a/lib/parsers/log-parser.js
+++ b/lib/parsers/log-parser.js
@@ -1,5 +1,6 @@
 "use babel";
 
+import _ from "lodash";
 import fs from "fs-plus";
 import path from "path";
 
@@ -31,25 +32,26 @@ export default class LogParser {
     };
 
     const lines = this.getLines();
-    for (const line of lines) {
+    _.forEach(lines, (line, index) => {
       // Simplest Thing That Works™ and KISS®
       let match = line.match(outputPattern);
       if (match) {
         const filePath = match[1].replace(/\"/g, ""); // TODO: Fix with improved regex.
         result.outputFilePath = path.resolve(this.projectPath, filePath);
-        continue;
+        return;
       }
 
       match = line.match(errorPattern);
       if (match) {
         result.errors.push({
+          logPosition: [index, 0],
           filePath: match[1],
           lineNumber: parseInt(match[2], 10),
           message: match[3],
         });
-        continue;
+        return;
       }
-    }
+    });
 
     return result;
   }

--- a/lib/parsers/log-parser.js
+++ b/lib/parsers/log-parser.js
@@ -24,6 +24,7 @@ export default class LogParser {
 
   parse() {
     const result = {
+      logFilePath: this.filePath,
       outputFilePath: null,
       errors: [],
       warnings: [],

--- a/lib/views/error-indicator-view.js
+++ b/lib/views/error-indicator-view.js
@@ -31,11 +31,6 @@ class ErrorIndicatorView extends HTMLElement {
     });
   }
 
-  openDevConsole() {
-    atom.openDevTools();
-    atom.executeJavaScriptInDevTools("InspectorFrontendAPI.showConsole()");
-  }
-
   getFirstErrorPosition() {
     const position = _.first(_.pluck(this.model.errors, "logPosition"));
     return position || [0, 0];

--- a/lib/views/error-indicator-view.js
+++ b/lib/views/error-indicator-view.js
@@ -1,5 +1,7 @@
 "use babel";
 
+import _ from "lodash";
+
 class ErrorIndicatorView extends HTMLElement {
   model = null;
 
@@ -22,12 +24,21 @@ class ErrorIndicatorView extends HTMLElement {
 
   openLogFile() {
     if (!this.model) { return; }
-    atom.workspace.open(this.model.logFilePath);
+
+    atom.workspace.open(this.model.logFilePath).then(editor => {
+      const position = this.getFirstErrorPosition();
+      editor.scrollToBufferPosition(position, {center: true});
+    });
   }
 
   openDevConsole() {
     atom.openDevTools();
     atom.executeJavaScriptInDevTools("InspectorFrontendAPI.showConsole()");
+  }
+
+  getFirstErrorPosition() {
+    const position = _.first(_.pluck(this.model.errors, "logPosition"));
+    return position || [0, 0];
   }
 }
 

--- a/lib/views/error-indicator-view.js
+++ b/lib/views/error-indicator-view.js
@@ -1,13 +1,28 @@
 "use babel";
 
 class ErrorIndicatorView extends HTMLElement {
+  model = null;
+
   createdCallback() {
     this.classList.add("inline-block");
 
     const messageElement = document.createElement("a");
     this.appendChild(messageElement);
     messageElement.innerText = "LaTeX compilation error";
-    messageElement.addEventListener("click", () => { this.openDevConsole(); });
+    messageElement.addEventListener("click", () => { this.openLogFile(); });
+  }
+
+  initialize(model) {
+    this.setModel(model);
+  }
+
+  setModel(model) {
+    this.model = model;
+  }
+
+  openLogFile() {
+    if (!this.model) { return; }
+    atom.workspace.open(this.model.logFilePath);
   }
 
   openDevConsole() {

--- a/spec/parsers/log-parser-spec.js
+++ b/spec/parsers/log-parser-spec.js
@@ -37,6 +37,7 @@ describe("LogParser", function() {
       const error = result.errors[0];
 
       expect(error).toEqual({
+        logPosition: [196, 0],
         filePath: "./errors.tex",
         lineNumber: 10,
         message: "\\begin{gather*} on input line 8 ended by \\end{gather}",


### PR DESCRIPTION
See https://github.com/thomasjo/atom-latex/issues/82.

- [x] Open log file when clicking indicator.
- [x] Scroll to first error after opening log file.

/cc @nscaife @myfavouritekk