### PR TITLE
Tweak TexifyBuilder

### DIFF
--- a/lib/builders/texify.js
+++ b/lib/builders/texify.js
@@ -48,7 +48,7 @@ export default class TexifyBuilder extends Builder {
 
     let outdir = this.getOutputDirectory(filePath);
     if (outdir) {
-      atom.notifcations.addInfo(heredoc(`
+      atom.notifications.addInfo(heredoc(`
         Output directory functionality is poorly supported by texify,
         so this functionality is disabled for the foreseeable future.`));
     }

--- a/lib/builders/texify.js
+++ b/lib/builders/texify.js
@@ -3,6 +3,7 @@
 import child_process from "child_process";
 import path from "path";
 import Builder from "../builder";
+import {heredoc} from "../werkzeug";
 
 export default class TexifyBuilder extends Builder {
   constructor() {
@@ -31,27 +32,25 @@ export default class TexifyBuilder extends Builder {
       "--batch",
       "--pdf",
       "--tex-option=--synctex=1",
-      "--tex-option=--max-print-line=1000" // Max log file line length
+      "--tex-option=--max-print-line=1000", // Max log file line length
     ];
 
     const enableShellEscape = atom.config.get("latex.enableShellEscape");
-    const customEngine = atom.config.get("latex.customEngine");
-    const engine = atom.config.get("latex.engine");
-
     if (enableShellEscape) {
       args.push("--tex-option=--enable-write18");
     }
 
-    if (customEngine) {
-      args.push(`--engine=\"${customEngine}\"`);
-    }
-    else if (engine && engine !== "pdflatex") {
-      args.push(`--engine=${engine}`);
+    const customEngine = atom.config.get("latex.customEngine");
+    const engine = atom.config.get("latex.engine");
+    if (customEngine || engine !== "pdflatex") {
+      atom.notifications.addInfo("Engine customization is not supported by texify.");
     }
 
     let outdir = this.getOutputDirectory(filePath);
     if (outdir) {
-      args.push(`--tex-option=\"-output-directory=${outdir}\"`);
+      atom.notifcations.addInfo(heredoc(`
+        Output directory functionality is poorly supported by texify,
+        so this functionality is disabled for the foreseeable future.`));
     }
 
     args.push(`\"${filePath}\"`);

--- a/lib/builders/texify.js
+++ b/lib/builders/texify.js
@@ -39,7 +39,7 @@ export default class TexifyBuilder extends Builder {
     const engine = atom.config.get("latex.engine");
 
     if (enableShellEscape) {
-      args.push("--tex-option=--shell-escape");
+      args.push("--tex-option=--enable-write18");
     }
 
     if (customEngine) {

--- a/lib/builders/texify.js
+++ b/lib/builders/texify.js
@@ -3,7 +3,6 @@
 import child_process from "child_process";
 import path from "path";
 import Builder from "../builder";
-import {heredoc} from "../werkzeug";
 
 export default class TexifyBuilder extends Builder {
   constructor() {
@@ -43,14 +42,19 @@ export default class TexifyBuilder extends Builder {
     const customEngine = atom.config.get("latex.customEngine");
     const engine = atom.config.get("latex.engine");
     if (customEngine || engine !== "pdflatex") {
-      atom.notifications.addWarning("Engine customization is not supported by texify.");
+      atom.notifications.addWarning(
+        "Engine customization is not supported by texify, " +
+        "so this functionality is disabled when using the texify builder."
+      );
     }
 
     let outdir = this.getOutputDirectory(filePath);
     if (outdir) {
-      atom.notifications.addWarning(heredoc(`
-        Output directory functionality is poorly supported by texify,
-        so this functionality is disabled for the foreseeable future.`));
+      atom.notifications.addWarning(
+        "Output directory functionality is poorly supported by texify, " +
+        "so this functionality is disabled (for the foreseeable future) " +
+        "when using the texify builder."
+      );
     }
 
     args.push(`\"${filePath}\"`);

--- a/lib/builders/texify.js
+++ b/lib/builders/texify.js
@@ -43,12 +43,12 @@ export default class TexifyBuilder extends Builder {
     const customEngine = atom.config.get("latex.customEngine");
     const engine = atom.config.get("latex.engine");
     if (customEngine || engine !== "pdflatex") {
-      atom.notifications.addInfo("Engine customization is not supported by texify.");
+      atom.notifications.addWarning("Engine customization is not supported by texify.");
     }
 
     let outdir = this.getOutputDirectory(filePath);
     if (outdir) {
-      atom.notifications.addInfo(heredoc(`
+      atom.notifications.addWarning(heredoc(`
         Output directory functionality is poorly supported by texify,
         so this functionality is disabled for the foreseeable future.`));
     }

--- a/lib/builders/texify.js
+++ b/lib/builders/texify.js
@@ -17,7 +17,6 @@ export default class TexifyBuilder extends Builder {
 
     options.cwd = path.dirname(filePath); // Run process with sensible CWD.
     options.maxBuffer = 52428800; // Set process' max buffer size to 50 MB.
-    options.env.max_print_line = 1000; // Max log file line length.
 
     return new Promise((resolve) => {
       // TODO: Add support for killing the process.
@@ -29,9 +28,10 @@ export default class TexifyBuilder extends Builder {
 
   constructArgs(filePath) {
     const args = [
-        // "-c", // can't clean if we want to parse log file
-        "-b",
-        "--pdf",
+      "--batch",
+      "--pdf",
+      "--tex-option=--synctex=1",
+      "--tex-option=--max-print-line=1000" // Max log file line length
     ];
 
     const enableShellEscape = atom.config.get("latex.enableShellEscape");


### PR DESCRIPTION
Currently `TexifyBuilder` has some incorrect feature flags, as well as functionality that is not (properly) supported by `texify` such as engine customizations and `--output-directory`.

The problematic functionality is removed and instead replaced with notifications to let the user know they are using unsupported functionality. I wish there was a better way, but configuration is still a static concept in Atom, so for the time being this way of handling unsupported config combinations will suffice.