### PR TITLE
Wrap custom opener file path in quotation marks to support spaces.

### DIFF
--- a/lib/openers/custom-opener.js
+++ b/lib/openers/custom-opener.js
@@ -6,7 +6,7 @@ import child_process from "child_process";
 export default class CustomOpener extends Opener {
   // Custom PDF viewer cannot support texPath and lineNumber
   open(filePath, texPath, lineNumber, callback) {
-    const command = `\"${atom.config.get("latex.viewerPath")}\" ${filePath}`;
+    const command = `\"${atom.config.get("latex.viewerPath")}\" \"${filePath}\"`;
 
     child_process.exec(command, (error) => {
       if (callback) {


### PR DESCRIPTION
If ${filePath} contains spaces most PDF viewers, e.g. evince, will not treat it as a single argument. Wrapping the path in quotation marks fixes that issue.