### PR TITLE
texify builder: fix engine support

### DIFF
--- a/lib/builders/texify.js
+++ b/lib/builders/texify.js
@@ -36,17 +36,20 @@ export default class TexifyBuilder extends Builder {
     ];
 
     const enableShellEscape = atom.config.get("latex.enableShellEscape");
+    const customEngine = atom.config.get("latex.customEngine");
+    const engine = atom.config.get("latex.engine");
+
     if (enableShellEscape) {
       args.push("--tex-option=--enable-write18");
     }
 
-    const customEngine = atom.config.get("latex.customEngine");
-    const engine = atom.config.get("latex.engine");
-    if (customEngine || engine !== "pdflatex") {
-      atom.notifications.addWarning(
-        "Engine customization is not supported by texify, " +
-        "so this functionality is disabled when using the texify builder."
-      );
+    if (engine) {
+      if (engine === "xelatex") {
+          args.push("--engine=xetex");
+      }
+      if (engine === "lualatex") {
+          args.push("--engine=luatex");
+      }
     }
 
     let outdir = this.getOutputDirectory(filePath);

--- a/lib/builders/texify.js
+++ b/lib/builders/texify.js
@@ -30,7 +30,8 @@ export default class TexifyBuilder extends Builder {
     const args = [
       "--batch",
       "--pdf",
-      "--tex-option=--synctex=1",
+      "--tex-option=\"--synctex=1\"",
+      "--tex-option=\"--interaction=nonstopmode\"",
       // Set logfile max line length.
       "--tex-option=--max-print-line=1000",
     ];


### PR DESCRIPTION
I've made a small fix to make `texify` builder support the engine selection.