### PR TITLE
Add Okular Viewer support for linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Current wish list, in a semi-prioritized order.
 - [ ] BibTeX autocompletion support.
 - [x] Open PDF automatically.
   - [x] Configurable.
-  - [x] Support for other distributions, besides OS X.
+  - [x] Support for other distributions (linux via Okular and OSX via Skim).
   - [x] Support for custom PDF viewer.
 - [ ] Support for compilers other than latexmk.
   - [x] Partially supported via the "Builder" concept, but no alternative

--- a/lib/config-schema.js
+++ b/lib/config-schema.js
@@ -97,6 +97,13 @@ export default {
     default: "C:\\Program Files (x86)\\SumatraPDF\\SumatraPDF.exe",
   },
 
+  okularPath: {
+    title: "Okular viewer Path",
+    description: "Full application path to Okular (*nix).",
+    type: "string",
+    default: "/usr/bin/okular",
+  },
+
   viewerPath: {
     title: "Custom PDF viewer Path",
     description: heredoc(`Full application path to your PDF viewer. Overrides Skim and SumatraPDF options.`),

--- a/lib/latex.js
+++ b/lib/latex.js
@@ -113,7 +113,6 @@ export default class Latex {
           return require("./openers/skim-opener");
         }
 
-        // TODO: This should probably not be here
         return require("./openers/preview-opener");
 
       case "win32":

--- a/lib/latex.js
+++ b/lib/latex.js
@@ -90,6 +90,7 @@ export default class Latex {
     atom.config.onDidChange("latex.alwaysOpenResultInAtom", callback);
     atom.config.onDidChange("latex.skimPath", callback);
     atom.config.onDidChange("latex.sumatraPath", callback);
+    atom.config.onDidChange("latex.okularPath", callback);
   }
 
   observeBuilderConfig() {
@@ -112,11 +113,19 @@ export default class Latex {
           return require("./openers/skim-opener");
         }
 
+        // TODO: This should probably not be here
         return require("./openers/preview-opener");
 
       case "win32":
         if (this.sumatraExecutableExists()) {
           return require("./openers/sumatra-opener");
+        }
+
+        break;
+
+      case "linux":
+        if (this.okularExecutableExists()) {
+          return require("./openers/okular-opener");
         }
     }
 
@@ -141,6 +150,10 @@ export default class Latex {
 
   sumatraExecutableExists() {
     return fs.existsSync(atom.config.get("latex.sumatraPath"));
+  }
+
+  okularExecutableExists() {
+    return fs.existsSync(atom.config.get("latex.okularPath"));
   }
 
   viewerExecutableExists() {

--- a/lib/openers/okular-opener.js
+++ b/lib/openers/okular-opener.js
@@ -1,0 +1,17 @@
+"use babel";
+
+import Opener from "../opener";
+import child_process from "child_process";
+
+export default class CustomOpener extends Opener {
+  // Used the custom pdf viewer method
+  open(filePath, texPath, lineNumber, callback) {
+    const command = `okular --unique "${filePath}#src:${lineNumber} ${texPath}"`;
+
+    child_process.exec(command, (error) => {
+      if (callback) {
+        callback((error) ? error.code : 0);
+      }
+    });
+  }
+}

--- a/lib/openers/okular-opener.js
+++ b/lib/openers/okular-opener.js
@@ -6,7 +6,7 @@ import child_process from "child_process";
 export default class CustomOpener extends Opener {
   // Used the custom pdf viewer method
   open(filePath, texPath, lineNumber, callback) {
-    const command = `okular --unique "${filePath}#src:${lineNumber} ${texPath}"`;
+    const command = `"${atom.config.get("latex.okularPath")}\" --unique "${filePath}#src:${lineNumber} ${texPath}"`;
 
     child_process.exec(command, (error) => {
       if (callback) {


### PR DESCRIPTION
Checks for `linux` platform, also allows the user to input a custom path to the viewer