### PR TITLE
Add support for ps and dvi file formats for latexmk builder

### DIFF
--- a/lib/builders/latexmk.js
+++ b/lib/builders/latexmk.js
@@ -41,6 +41,7 @@ export default class LatexmkBuilder extends Builder {
     const engineFromMagic = this.getLatexEngineFromMagic(filePath)
     const customEngine = atom.config.get('latex.customEngine')
     const engine = atom.config.get('latex.engine')
+    const outputFormat = atom.config.get('latex.outputFormat')
 
     if (enableShellEscape) {
       args.push('-shell-escape')
@@ -57,6 +58,13 @@ export default class LatexmkBuilder extends Builder {
     let outdir = this.getOutputDirectory(filePath)
     if (outdir) {
       args.push(`-outdir="${outdir}"`)
+    }
+
+    if (outputFormat) {
+      if (!(outputFormat=='pdf')) {
+        args.splice(args.indexOf('-pdf'), 1)
+        args.push(`-${outputFormat}`)
+      }
     }
 
     args.push(`"${filePath}"`)

--- a/lib/builders/latexmk.js
+++ b/lib/builders/latexmk.js
@@ -61,7 +61,7 @@ export default class LatexmkBuilder extends Builder {
     }
 
     if (outputFormat) {
-      if (!(outputFormat=='pdf')) {
+      if (outputFormat !== 'pdf') {
         args.splice(args.indexOf('-pdf'), 1)
         args.push(`-${outputFormat}`)
       }

--- a/lib/builders/latexmk.js
+++ b/lib/builders/latexmk.js
@@ -28,11 +28,13 @@ export default class LatexmkBuilder extends Builder {
   }
 
   constructArgs (filePath) {
+    const outputFormat = atom.config.get('latex.outputFormat') || 'pdf'
+
     const args = [
       '-interaction=nonstopmode',
       '-f',
       '-cd',
-      '-pdf',
+      `-${outputFormat}`,
       '-synctex=1',
       '-file-line-error'
     ]
@@ -41,7 +43,6 @@ export default class LatexmkBuilder extends Builder {
     const engineFromMagic = this.getLatexEngineFromMagic(filePath)
     const customEngine = atom.config.get('latex.customEngine')
     const engine = atom.config.get('latex.engine')
-    const outputFormat = atom.config.get('latex.outputFormat')
 
     if (enableShellEscape) {
       args.push('-shell-escape')
@@ -58,13 +59,6 @@ export default class LatexmkBuilder extends Builder {
     let outdir = this.getOutputDirectory(filePath)
     if (outdir) {
       args.push(`-outdir="${outdir}"`)
-    }
-
-    if (outputFormat) {
-      if (outputFormat !== 'pdf') {
-        args.splice(args.indexOf('-pdf'), 1)
-        args.push(`-${outputFormat}`)
-      }
     }
 
     args.push(`"${filePath}"`)

--- a/lib/config-schema.js
+++ b/lib/config-schema.js
@@ -44,6 +44,13 @@ export default {
     default: ''
   },
 
+  outputFormat: {
+    description: 'Output file format. DVI and PS currently only supported for latexmk.',
+    type: 'string',
+    enum: ['pdf', 'dvi', 'ps'],
+    default: 'pdf'
+  },
+
   enableShellEscape: {
     type: 'boolean',
     default: false

--- a/spec/builders/latexmk-spec.js
+++ b/spec/builders/latexmk-spec.js
@@ -51,6 +51,15 @@ describe('LatexmkBuilder', () => {
       helpers.spyOnConfig('latex.customEngine', 'pdflatex %O %S')
       expect(builder.constructArgs(filePath)).toContain('-pdflatex="pdflatex %O %S"')
     })
+
+    it('adds -ps or -dvi and removes -pdf arguments according to package config', () => {
+      helpers.spyOnConfig('latex.outputFormat', 'ps')
+      expect(builder.constructArgs(filePath)).toContain('-ps')
+      expect(builder.constructArgs(filePath)).not.toContain('-pdf')
+      helpers.spyOnConfig('latex.outputFormat', 'dvi')
+      expect(builder.constructArgs(filePath)).toContain('-dvi')
+      expect(builder.constructArgs(filePath)).not.toContain('-pdf')
+    })
   })
 
   describe('run', () => {


### PR DESCRIPTION
Hi, I have added an option to create ps or dvi files instead of the default pdf when using the latexmk builder. Currently, this only works for latexmk, since I do not have access to texify.