### PR TITLE
Generalize the builder concept

### DIFF
--- a/lib/builder-registry.js
+++ b/lib/builder-registry.js
@@ -3,41 +3,37 @@
 import fs from 'fs-plus'
 import path from 'path'
 
-let builders = []
-
-function getAllBuilders () {
-  if (builders.length === 0) {
-    const moduleDir = path.join(__dirname, 'builders')
-    const entries = fs.readdirSync(moduleDir)
-    builders = entries.map((entry) => require(path.join(moduleDir, entry)))
-  }
-
-  return builders
-}
-
-function resolveAmbigiousBuilders (builders) {
-  const names = builders.map((builder) => builder.name)
-  const indexOfLatexmk = names.indexOf('LatexmkBuilder')
-  const indexOfTexify = names.indexOf('TexifyBuilder')
-  if (builders.length === 2 && indexOfLatexmk >= 0 && indexOfTexify >= 0) {
-    switch (atom.config.get('latex.builder')) {
-      case 'latexmk': return builders[indexOfLatexmk]
-      case 'texify': return builders[indexOfTexify]
-    }
-  }
-
-  throw Error('Unable to resolve ambigous builder registration')
-}
-
 export default class BuilderRegistry {
-  static getBuilder (filePath) {
-    const builders = getAllBuilders()
+  getBuilder (filePath) {
+    const builders = this.getAllBuilders()
     const candidates = builders.filter((builder) => builder.canProcess(filePath))
     switch (candidates.length) {
       case 0: return null
       case 1: return candidates[0]
     }
 
-    return resolveAmbigiousBuilders(candidates)
+    return this.resolveAmbigiousBuilders(candidates)
+  }
+
+  getAllBuilders () {
+    const moduleDir = path.join(__dirname, 'builders')
+    const entries = fs.readdirSync(moduleDir)
+    const builders = entries.map((entry) => require(path.join(moduleDir, entry)))
+
+    return builders
+  }
+
+  resolveAmbigiousBuilders (builders) {
+    const names = builders.map((builder) => builder.name)
+    const indexOfLatexmk = names.indexOf('LatexmkBuilder')
+    const indexOfTexify = names.indexOf('TexifyBuilder')
+    if (names.length === 2 && indexOfLatexmk >= 0 && indexOfTexify >= 0) {
+      switch (atom.config.get('latex.builder')) {
+        case 'latexmk': return builders[indexOfLatexmk]
+        case 'texify': return builders[indexOfTexify]
+      }
+    }
+
+    throw Error('Unable to resolve ambigous builder registration')
   }
 }

--- a/lib/builder-registry.js
+++ b/lib/builder-registry.js
@@ -1,0 +1,43 @@
+'use babel'
+
+import fs from 'fs-plus'
+import path from 'path'
+
+let builders = []
+
+function getAllBuilders () {
+  if (builders.length === 0) {
+    const moduleDir = path.join(__dirname, 'builders')
+    const entries = fs.readdirSync(moduleDir)
+    builders = entries.map((entry) => require(path.join(moduleDir, entry)))
+  }
+
+  return builders
+}
+
+function resolveAmbigiousBuilders (builders) {
+  const names = builders.map((builder) => builder.name)
+  const indexOfLatexmk = names.indexOf('LatexmkBuilder')
+  const indexOfTexify = names.indexOf('TexifyBuilder')
+  if (builders.length === 2 && indexOfLatexmk >= 0 && indexOfTexify >= 0) {
+    switch (atom.config.get('latex.builder')) {
+      case 'latexmk': return builders[indexOfLatexmk]
+      case 'texify': return builders[indexOfTexify]
+    }
+  }
+
+  throw Error('Unable to resolve ambigous builder registration')
+}
+
+export default class BuilderRegistry {
+  static getBuilder (filePath) {
+    const builders = getAllBuilders()
+    const candidates = builders.filter((builder) => builder.canProcess(filePath))
+    switch (candidates.length) {
+      case 0: return null
+      case 1: return candidates[0]
+    }
+
+    return resolveAmbigiousBuilders(candidates)
+  }
+}

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -18,6 +18,20 @@ function getAllBuilders () {
   return builders
 }
 
+function resolveAmbigiousBuilders (builders) {
+  const names = builders.map((builder) => builder.name)
+  const indexOfLatexmk = names.indexOf('LatexmkBuilder')
+  const indexOfTexify = names.indexOf('TexifyBuilder')
+  if (builders.length === 2 && indexOfLatexmk >= 0 && indexOfTexify >= 0) {
+    switch (atom.config.get('latex.builder')) {
+      case 'latexmk': return builders[indexOfLatexmk]
+      case 'texify': return builders[indexOfTexify]
+    }
+  }
+
+  throw Error('Unable to resolve ambigous builder registration')
+}
+
 export default class Builder {
   constructor () {
     this.envPathKey = this.getEnvironmentPathKey(process.platform)
@@ -28,8 +42,14 @@ export default class Builder {
   constructArgs (/* filePath */) {}
 
   static getBuilder (filePath) {
-    const candidates = getAllBuilders()
-    return candidates.filter((candidate) => candidate.canProcess(filePath))
+    const builders = getAllBuilders()
+    const candidates = builders.filter((builder) => builder.canProcess(filePath))
+    switch (candidates.length) {
+      case 0: return null
+      case 1: return candidates[0]
+    }
+
+    return resolveAmbigiousBuilders(candidates)
   }
 
   parseLogFile (texFilePath) {

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -6,13 +6,31 @@ import path from 'path'
 import LogParser from './parsers/log-parser'
 import MagicParser from './parsers/magic-parser'
 
+let builders = []
+
+function getAllBuilders () {
+  if (builders.length === 0) {
+    const moduleDir = path.join(__dirname, 'builders')
+    const entries = fs.readdirSync(moduleDir)
+    builders = entries.map((entry) => require(path.join(moduleDir, entry)))
+  }
+
+  return builders
+}
+
 export default class Builder {
   constructor () {
     this.envPathKey = this.getEnvironmentPathKey(process.platform)
   }
 
+  static canProcess (/* filePath */) {}
   run (/* filePath */) {}
   constructArgs (/* filePath */) {}
+
+  static getBuilder (filePath) {
+    const candidates = getAllBuilders()
+    return candidates.filter((candidate) => candidate.canProcess(filePath))
+  }
 
   parseLogFile (texFilePath) {
     const logFilePath = this.resolveLogFilePath(texFilePath)

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -6,32 +6,6 @@ import path from 'path'
 import LogParser from './parsers/log-parser'
 import MagicParser from './parsers/magic-parser'
 
-let builders = []
-
-function getAllBuilders () {
-  if (builders.length === 0) {
-    const moduleDir = path.join(__dirname, 'builders')
-    const entries = fs.readdirSync(moduleDir)
-    builders = entries.map((entry) => require(path.join(moduleDir, entry)))
-  }
-
-  return builders
-}
-
-function resolveAmbigiousBuilders (builders) {
-  const names = builders.map((builder) => builder.name)
-  const indexOfLatexmk = names.indexOf('LatexmkBuilder')
-  const indexOfTexify = names.indexOf('TexifyBuilder')
-  if (builders.length === 2 && indexOfLatexmk >= 0 && indexOfTexify >= 0) {
-    switch (atom.config.get('latex.builder')) {
-      case 'latexmk': return builders[indexOfLatexmk]
-      case 'texify': return builders[indexOfTexify]
-    }
-  }
-
-  throw Error('Unable to resolve ambigous builder registration')
-}
-
 export default class Builder {
   constructor () {
     this.envPathKey = this.getEnvironmentPathKey(process.platform)
@@ -40,17 +14,6 @@ export default class Builder {
   static canProcess (/* filePath */) {}
   run (/* filePath */) {}
   constructArgs (/* filePath */) {}
-
-  static getBuilder (filePath) {
-    const builders = getAllBuilders()
-    const candidates = builders.filter((builder) => builder.canProcess(filePath))
-    switch (candidates.length) {
-      case 0: return null
-      case 1: return candidates[0]
-    }
-
-    return resolveAmbigiousBuilders(candidates)
-  }
 
   parseLogFile (texFilePath) {
     const logFilePath = this.resolveLogFilePath(texFilePath)

--- a/lib/builders/latexmk.js
+++ b/lib/builders/latexmk.js
@@ -10,6 +10,10 @@ export default class LatexmkBuilder extends Builder {
     this.executable = 'latexmk'
   }
 
+  static canProcess (filePath) {
+    return path.extname(filePath) === '.tex'
+  }
+
   run (filePath) {
     const args = this.constructArgs(filePath)
     const command = `${this.executable} ${args.join(' ')}`

--- a/lib/builders/texify.js
+++ b/lib/builders/texify.js
@@ -10,6 +10,10 @@ export default class TexifyBuilder extends Builder {
     this.executable = 'texify'
   }
 
+  static canProcess (filePath) {
+    return path.extname(filePath) === '.tex'
+  }
+
   run (filePath) {
     const args = this.constructArgs(filePath)
     const command = `${this.executable} ${args.join(' ')}`

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -6,6 +6,10 @@ import path from 'path'
 import BuilderRegistry from './builder-registry'
 
 export default class Composer {
+  constructor () {
+    this.builderRegistry = new BuilderRegistry()
+  }
+
   destroy () {
     this.destroyProgressIndicator()
     this.destroyErrorIndicator()
@@ -206,6 +210,7 @@ export default class Composer {
       priority: 9001
     })
   }
+
   showErrorMarkers (result) {
     if (this.errorMarkers && this.errorMarkers.length > 0) { this.destroyErrorMarkers() }
     const editors = this.getAllEditors()
@@ -256,7 +261,7 @@ export default class Composer {
   }
 
   getBuilder (filePath) {
-    const BuilderImpl = BuilderRegistry.getBuilder(filePath)
+    const BuilderImpl = this.builderRegistry.getBuilder(filePath)
     return (BuilderImpl != null) ? new BuilderImpl() : null
   }
 

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -3,7 +3,7 @@
 import _ from 'lodash'
 import fs from 'fs-plus'
 import path from 'path'
-import {heredoc} from './werkzeug'
+import BuilderRegistry from './builder-registry'
 
 export default class Composer {
   destroy () {
@@ -20,9 +20,9 @@ export default class Composer {
       return Promise.reject(false)
     }
 
-    if (!this.isTexFile(filePath)) {
-      latex.log.warning(heredoc(`File does not seem to be a TeX file
-        unsupported extension '${path.extname(filePath)}'.`))
+    const builder = this.getBuilder(filePath)
+    if (builder == null) {
+      latex.log.warning(`No registered LaTeX builder can process ${filePath}.`)
       return Promise.reject(false)
     }
 
@@ -30,7 +30,6 @@ export default class Composer {
       editor.save() // TODO: Make this configurable?
     }
 
-    const builder = latex.getBuilder()
     const rootFilePath = this.resolveRootFilePath(filePath)
 
     this.destroyErrorMarkers()
@@ -254,6 +253,11 @@ export default class Composer {
   isTexFile (filePath) {
     // TODO: Improve will suffice for the time being.
     return !filePath || filePath.search(/\.(tex|lhs)$/) > 0
+  }
+
+  getBuilder (filePath) {
+    const BuilderImpl = BuilderRegistry.getBuilder(filePath)
+    return (BuilderImpl != null) ? new BuilderImpl() : null
   }
 
   getEditorDetails () {

--- a/lib/latex.js
+++ b/lib/latex.js
@@ -24,30 +24,17 @@ export default class Latex {
   constructor () {
     this.createLogProxy()
 
-    defineDefaultProperty(this, 'builder')
     defineDefaultProperty(this, 'logger')
     defineDefaultProperty(this, 'opener')
 
     this.observeOpenerConfig()
-    this.observeBuilderConfig()
   }
 
-  getBuilder () { return this.builder }
   getLogger () { return this.logger }
   getOpener () { return this.opener }
 
   setLogger (logger) {
     this.logger = logger
-  }
-
-  getDefaultBuilder () {
-    let BuilderClass = null
-    if (this.useLatexmk()) {
-      BuilderClass = require('./builders/latexmk')
-    } else {
-      BuilderClass = require('./builders/texify')
-    }
-    return new BuilderClass()
   }
 
   getDefaultLogger () {
@@ -90,11 +77,6 @@ export default class Latex {
     atom.config.onDidChange('latex.skimPath', callback)
     atom.config.onDidChange('latex.sumatraPath', callback)
     atom.config.onDidChange('latex.okularPath', callback)
-  }
-
-  observeBuilderConfig () {
-    const callback = () => { this['__builder'] = this.getDefaultBuilder() }
-    atom.config.onDidChange('latex.builder', callback)
   }
 
   resolveOpenerImplementation (platform) {
@@ -156,9 +138,5 @@ export default class Latex {
 
   viewerExecutableExists () {
     return fs.existsSync(atom.config.get('latex.viewerPath'))
-  }
-
-  useLatexmk () {
-    return atom.config.get('latex.builder') === 'latexmk'
   }
 }

--- a/spec/build-registry-spec.js
+++ b/spec/build-registry-spec.js
@@ -5,34 +5,35 @@ import path from 'path'
 import BuilderRegistry from '../lib/builder-registry'
 
 describe('BuilderRegistry', () => {
-  let fixturesPath, filePath
+  let registry, fixturesPath, filePath
 
   beforeEach(() => {
+    registry = new BuilderRegistry()
     fixturesPath = helpers.cloneFixtures()
     filePath = path.join(fixturesPath, 'file.tex')
   })
 
-  describe('::getBuilder', () => {
+  describe('getBuilder', () => {
     beforeEach(() => {
       helpers.spyOnConfig('latex.builder', 'latexmk')
     })
 
     it('returns null when no builders are associated with the given file', () => {
       const filePath = path.join('foo', 'quux.txt')
-      expect(BuilderRegistry.getBuilder(filePath)).toBeNull()
+      expect(registry.getBuilder(filePath)).toBeNull()
     })
 
     it('returns the configured builder when given a regular .tex file', () => {
       const filePath = path.join('foo', 'bar.tex')
-      expect(BuilderRegistry.getBuilder(filePath).name).toEqual('LatexmkBuilder')
+      expect(registry.getBuilder(filePath).name).toEqual('LatexmkBuilder')
 
       helpers.spyOnConfig('latex.builder', 'texify')
-      expect(BuilderRegistry.getBuilder(filePath).name).toEqual('TexifyBuilder')
+      expect(registry.getBuilder(filePath).name).toEqual('TexifyBuilder')
     })
 
     it('throws an error when unable to resolve ambigious builder registration', () => {
       helpers.spyOnConfig('latex.builder', 'foo')
-      expect(() => { BuilderRegistry.getBuilder(filePath) }).toThrow()
+      expect(() => { registry.getBuilder(filePath) }).toThrow()
     })
   })
 })

--- a/spec/build-registry-spec.js
+++ b/spec/build-registry-spec.js
@@ -30,7 +30,7 @@ describe('BuilderRegistry', () => {
       expect(BuilderRegistry.getBuilder(filePath).name).toEqual('TexifyBuilder')
     })
 
-    it('throws an error when unable to resolve ambigous builder registration', () => {
+    it('throws an error when unable to resolve ambigious builder registration', () => {
       helpers.spyOnConfig('latex.builder', 'foo')
       expect(() => { BuilderRegistry.getBuilder(filePath) }).toThrow()
     })

--- a/spec/build-registry-spec.js
+++ b/spec/build-registry-spec.js
@@ -1,0 +1,38 @@
+'use babel'
+
+import helpers from './spec-helpers'
+import path from 'path'
+import BuilderRegistry from '../lib/builder-registry'
+
+describe('BuilderRegistry', () => {
+  let fixturesPath, filePath
+
+  beforeEach(() => {
+    fixturesPath = helpers.cloneFixtures()
+    filePath = path.join(fixturesPath, 'file.tex')
+  })
+
+  describe('::getBuilder', () => {
+    beforeEach(() => {
+      helpers.spyOnConfig('latex.builder', 'latexmk')
+    })
+
+    it('returns null when no builders are associated with the given file', () => {
+      const filePath = path.join('foo', 'quux.txt')
+      expect(BuilderRegistry.getBuilder(filePath)).toBeNull()
+    })
+
+    it('returns the configured builder when given a regular .tex file', () => {
+      const filePath = path.join('foo', 'bar.tex')
+      expect(BuilderRegistry.getBuilder(filePath).name).toEqual('LatexmkBuilder')
+
+      helpers.spyOnConfig('latex.builder', 'texify')
+      expect(BuilderRegistry.getBuilder(filePath).name).toEqual('TexifyBuilder')
+    })
+
+    it('throws an error when unable to resolve ambigous builder registration', () => {
+      helpers.spyOnConfig('latex.builder', 'foo')
+      expect(() => { BuilderRegistry.getBuilder(filePath) }).toThrow()
+    })
+  })
+})

--- a/spec/builder-spec.js
+++ b/spec/builder-spec.js
@@ -113,14 +113,26 @@ describe('Builder', () => {
   })
 
   describe('::getBuilder', () => {
-    it('returns an empty list when no builders are associated with the given file', () => {
-      const filePath = path.join('foo', 'quux.txt')
-      expect(Builder.getBuilder(filePath)).toEqual([])
+    beforeEach(() => {
+      helpers.spyOnConfig('latex.builder', 'latexmk')
     })
 
-    it('returns a non-empty list when there are builders associated with the given file', () => {
+    it('returns null when no builders are associated with the given file', () => {
+      const filePath = path.join('foo', 'quux.txt')
+      expect(Builder.getBuilder(filePath)).toBeNull()
+    })
+
+    it('returns the configured builder when given a regular .tex file', () => {
       const filePath = path.join('foo', 'bar.tex')
-      expect(Builder.getBuilder(filePath)).not.toEqual([])
+      expect(Builder.getBuilder(filePath).name).toEqual('LatexmkBuilder')
+
+      helpers.spyOnConfig('latex.builder', 'texify')
+      expect(Builder.getBuilder(filePath).name).toEqual('TexifyBuilder')
+    })
+
+    it('throws an error when unable to resolve ambigous builder registration', () => {
+      helpers.spyOnConfig('latex.builder', 'foo')
+      expect(() => { Builder.getBuilder(filePath) }).toThrow()
     })
   })
 })

--- a/spec/builder-spec.js
+++ b/spec/builder-spec.js
@@ -111,4 +111,16 @@ describe('Builder', () => {
       expect(builder.getLatexEngineFromMagic(filePath)).toEqual('pdflatex')
     })
   })
+
+  describe('::getBuilder', () => {
+    it('returns an empty list when no builders are associated with the given file', () => {
+      const filePath = path.join('foo', 'quux.txt')
+      expect(Builder.getBuilder(filePath)).toEqual([])
+    })
+
+    it('returns a non-empty list when there are builders associated with the given file', () => {
+      const filePath = path.join('foo', 'bar.tex')
+      expect(Builder.getBuilder(filePath)).not.toEqual([])
+    })
+  })
 })

--- a/spec/builder-spec.js
+++ b/spec/builder-spec.js
@@ -111,28 +111,4 @@ describe('Builder', () => {
       expect(builder.getLatexEngineFromMagic(filePath)).toEqual('pdflatex')
     })
   })
-
-  describe('::getBuilder', () => {
-    beforeEach(() => {
-      helpers.spyOnConfig('latex.builder', 'latexmk')
-    })
-
-    it('returns null when no builders are associated with the given file', () => {
-      const filePath = path.join('foo', 'quux.txt')
-      expect(Builder.getBuilder(filePath)).toBeNull()
-    })
-
-    it('returns the configured builder when given a regular .tex file', () => {
-      const filePath = path.join('foo', 'bar.tex')
-      expect(Builder.getBuilder(filePath).name).toEqual('LatexmkBuilder')
-
-      helpers.spyOnConfig('latex.builder', 'texify')
-      expect(Builder.getBuilder(filePath).name).toEqual('TexifyBuilder')
-    })
-
-    it('throws an error when unable to resolve ambigous builder registration', () => {
-      helpers.spyOnConfig('latex.builder', 'foo')
-      expect(() => { Builder.getBuilder(filePath) }).toThrow()
-    })
-  })
 })

--- a/spec/composer-spec.js
+++ b/spec/composer-spec.js
@@ -10,6 +10,7 @@ describe('Composer', () => {
   let composer
 
   beforeEach(() => {
+    atom.config.set('latex.builder', 'latexmk')
     composer = new Composer()
   })
 
@@ -32,7 +33,7 @@ describe('Composer', () => {
 
         return Promise.reject(statusCode)
       })
-      spyOn(latex, 'getBuilder').andReturn(builder)
+      spyOn(composer, 'getBuilder').andReturn(builder)
     }
 
     beforeEach(() => {
@@ -57,6 +58,7 @@ describe('Composer', () => {
 
     it('does nothing for unsupported file extensions', () => {
       initializeSpies('foo.bar')
+      composer.getBuilder.andReturn(null)
 
       let result
       waitsForPromise(() => {
@@ -231,6 +233,26 @@ describe('Composer', () => {
       helpers.spyOnConfig('latex.moveResultToSourceDirectory', true)
 
       expect(composer.shouldMoveResult()).toBe(true)
+    })
+  })
+
+  describe('getBuilder', () => {
+    beforeEach(() => {
+      atom.config.set('latex.builder', 'latexmk')
+    })
+
+    it('returns a builder instance as configured for regular .tex files', () => {
+      const filePath = 'foo.tex'
+
+      expect(composer.getBuilder(filePath).constructor.name).toEqual('LatexmkBuilder')
+
+      atom.config.set('latex.builder', 'texify')
+      expect(composer.getBuilder(filePath).constructor.name).toEqual('TexifyBuilder')
+    })
+
+    it('returns null when passed an unhandled file type', () => {
+      const filePath = 'quux.txt'
+      expect(composer.getBuilder(filePath)).toBeNull()
     })
   })
 })

--- a/spec/latex-spec.js
+++ b/spec/latex-spec.js
@@ -21,23 +21,8 @@ describe('Latex', () => {
     it('initializes all properties', () => {
       spyOn(latex, 'resolveOpenerImplementation').andReturn(NullOpener)
 
-      expect(latex.builder).toBeDefined()
       expect(latex.logger).toBeDefined()
       expect(latex.opener).toBeDefined()
-    })
-  })
-
-  describe('getDefaultBuilder', () => {
-    it('returns an instance of LatexmkBuilder by default', () => {
-      spyOn(latex, 'useLatexmk').andReturn(true)
-      const defaultBuilder = latex.getDefaultBuilder()
-      expect(defaultBuilder.constructor.name).toBe('LatexmkBuilder')
-    })
-
-    it('returns an instance of TexifyBuilder when chosen', () => {
-      spyOn(latex, 'useLatexmk').andReturn(false)
-      const defaultBuilder = latex.getDefaultBuilder()
-      expect(defaultBuilder.constructor.name).toBe('TexifyBuilder')
     })
   })
 


### PR DESCRIPTION
This is an attempt to generalize the builder concept which will make it easy to implement file type specific builders, which is currently needed in #144.

/cc @m0nhawk

---
#### Current tasks
  - [x] Add simple builder registry by simply loading all modules in the builders
    directory.
  - [x] Add `BuilderRegistry::getBuilder` method for querying registered builders
    for ones that can process the current file. Querying is done via abstract
    `Builder.prototype.canProcess` method.
  - [x] Resolve duplicate builder registration for `.tex` files. For regular `.tex` files we return both
    `LatexmkBuilder` and `TexifyBuilder`, but we need to choose one based on configuration.
    Whether this should be done in the `BuilderRegistry::getBuilder` method or in the `Composer` needs
    to be experimented with.
  - [x] Remove `Latex.getBuilder` and `Latex.builder`, and migrate to new codepath.