### PR TITLE
Remove "LaTeX Error" from error message regex.

### DIFF
--- a/lib/parsers/log-parser.js
+++ b/lib/parsers/log-parser.js
@@ -13,7 +13,6 @@ const outputPattern = new RegExp('' +
 const errorPattern = new RegExp('' +
   '^(.*):' +               // File path.
   '(\\d+):' +              // Line number.
-  '\\sLaTeX\\sError:\\s' + // Marker.
   '(.*)\\.$'               // Error message.
 )
 


### PR DESCRIPTION
[This pull request is mostly for discussion purposes, and you're obviously welcome to merge if it turns out to be a good idea.]

Many error-related output messages from pdflatex do not include this marker. By removing it, the console logger correctly displays a number of additional error messages.

Please be aware that I have not had the opportunity to test this in different environment and with different compilers. It very well may be a change that you've considered but rejected for specific reasons.

My environment:
* Atom 1.2.4
* atom-latex 0.28.2
* Mac OS X 10.11.1
* pdflatex 3.14159265-2.6-1.40.16 (TeX Live 2015)
* latexmk 4.43a

Thank you so much for you work on this; it's a joy to use!