### PR TITLE
Clean uses now custom build directory

### DIFF
--- a/lib/composer.js
+++ b/lib/composer.js
@@ -83,7 +83,6 @@ export default class Composer {
     }
   }
 
-  // NOTE: Does not support `latex.outputDirectory` setting!
   async clean () {
     const {filePath} = this.getEditorDetails()
     if (!filePath || !this.isTexFile(filePath)) {
@@ -91,7 +90,13 @@ export default class Composer {
     }
 
     const rootFilePath = this.resolveRootFilePath(filePath)
-    const rootPath = path.dirname(rootFilePath)
+    let rootPath = path.dirname(rootFilePath)
+    
+    let outdir = atom.config.get('latex.outputDirectory')
+    if (outdir) {
+      rootPath = path.join(rootPath, outdir)
+    }
+    
     let rootFile = path.basename(rootFilePath)
     rootFile = rootFile.substring(0, rootFile.lastIndexOf('.'))
 


### PR DESCRIPTION
The clean command now take the custom build directory into account.