### PR TITLE
Added inverse-search functionality for sumatra-opener

### DIFF
--- a/lib/config-schema.js
+++ b/lib/config-schema.js
@@ -9,11 +9,6 @@ export default {
     default: false
   },
 
-  atomPath: {
-    description: 'Set the Path to Atom Executable (used for inverse search from SumatraPDF).',
-    type: 'string',
-  },
-
   builder: {
     description: 'Select LaTeX builder. MiKTeX distribution is required for texify.',
     type: 'string',

--- a/lib/config-schema.js
+++ b/lib/config-schema.js
@@ -9,6 +9,11 @@ export default {
     default: false
   },
 
+  atomPath: {
+    description: 'Set the Path to Atom Executable (used for inverse search from SumatraPDF).',
+    type: 'string',
+  },
+
   builder: {
     description: 'Select LaTeX builder. MiKTeX distribution is required for texify.',
     type: 'string',

--- a/lib/openers/sumatra-opener.js
+++ b/lib/openers/sumatra-opener.js
@@ -6,7 +6,7 @@ import Opener from '../opener'
 export default class SumatraOpener extends Opener {
   open (filePath, texPath, lineNumber, callback) {
     const sumatraPath = `"${atom.config.get('latex.sumatraPath')}"`
-    const atomPath = `"${atom.config.get('latex.atomPath')}"`
+    const atomPath = `"${process.argv[0]}"`
     const args = [
       '-reuse-instance',
       '-forward-search',

--- a/lib/openers/sumatra-opener.js
+++ b/lib/openers/sumatra-opener.js
@@ -6,12 +6,16 @@ import Opener from '../opener'
 export default class SumatraOpener extends Opener {
   open (filePath, texPath, lineNumber, callback) {
     const sumatraPath = `"${atom.config.get('latex.sumatraPath')}"`
+    const atomPath = `"${atom.config.get('latex.atomPath')}"`
     const args = [
       '-reuse-instance',
       '-forward-search',
       `"${texPath}"`,
       `"${lineNumber}"`,
-      `"${filePath}"`
+      `"${filePath}"`,
+      '-inverse-search',
+      ['\"\\\"', `${atomPath}`, '\\\"'].join(''),
+      '\\\"%f:%l\\\"'
     ]
 
     const command = `${sumatraPath} ${args.join(' ')}`


### PR DESCRIPTION
* Simply adds `-inverse-search` flag to the SumatraPDF command that `sumatra-opener.js` generates
* Inverse search means double clicking inside the generated SumatraPDF document generates a command to open the source document in Atom at the source line that produced it
* __Tested on Windows only__ -- based the command line statement found at the bottom of [this discussion](https://discuss.atom.io/t/inverse-search-with-sumatrapdf/20076/2)
* Had to add a setting for the path to the Atom executable in order to complete the arguments to the `-inverse-search` flag