### PR TITLE
Reintroduce (proper) delayed package activation

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -2,19 +2,12 @@
 
 export default {
   activate () {
+    this.bootstrap()
+
     this.commands = atom.commands.add('atom-workspace', {
-      'latex:build': () => {
-        this.bootstrap()
-        this.composer.build()
-      },
-      'latex:sync': () => {
-        this.bootstrap()
-        this.composer.sync()
-      },
-      'latex:clean': () => {
-        this.bootstrap()
-        this.composer.clean()
-      }
+      'latex:build': () => this.composer.build(),
+      'latex:clean': () => this.composer.clean(),
+      'latex:sync': () => this.composer.sync()
     })
   },
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,16 @@
   "engines": {
     "atom": ">=1.0.0 <2.0.0"
   },
+  "activationCommands": {
+    "atom-workspace": [
+      "latex:build",
+      "latex:clean",
+      "latex:sync"
+    ]
+  },
+  "activationHooks": [
+    "language-latex:grammar-used"
+  ],
   "consumedServices": {
     "status-bar": {
       "versions": {


### PR DESCRIPTION
Since the config schema is now stored in package.json, we can reintroduce delayed package activation without compromising the user experience.

From a development perspective this simplifies the code, and also reduces the level of Magic™ :sparkles: 