### PR TITLE
Add forward sync support to Atom PDF opener

### DIFF
--- a/lib/openers/atompdf-opener.js
+++ b/lib/openers/atompdf-opener.js
@@ -6,7 +6,7 @@ export default class AtomPdfOpener extends Opener {
   open (filePath, texPath, lineNumber, callback) {
     // Opens PDF in a new pane -- requires pdf-view module
 
-    function forwardSync(pdfView) {
+    function forwardSync (pdfView) {
       if (pdfView != null && pdfView.forwardSync != null) {
         pdfView.forwardSync(texPath, lineNumber)
       }
@@ -21,11 +21,8 @@ export default class AtomPdfOpener extends Opener {
       }
     }
 
-    const activePane = atom.workspace.getActivePane()
     // TODO: Make this configurable?
-    atom.workspace.open(filePath, {'split': 'right'}).done(function (pdfView) {
-      forwardSync(pdfView)
-    })
+    atom.workspace.open(filePath, {'split': 'right'}).done(forwardSync)
 
     // TODO: Check for actual success?
     if (callback) {

--- a/lib/openers/atompdf-opener.js
+++ b/lib/openers/atompdf-opener.js
@@ -5,18 +5,27 @@ import Opener from '../opener'
 export default class AtomPdfOpener extends Opener {
   open (filePath, texPath, lineNumber, callback) {
     // Opens PDF in a new pane -- requires pdf-view module
-    const openPanes = atom.workspace.getPaneItems()
-    for (const openPane of openPanes) {
-      // File is already open in another pane
-      if (openPane.filePath === filePath) { return }
+
+    function forwardSync(pdfView) {
+      if (pdfView != null && pdfView.forwardSync != null) {
+        pdfView.forwardSync(texPath, lineNumber)
+      }
     }
 
-    const pane = atom.workspace.getActivePane()
+    const openPaneItems = atom.workspace.getPaneItems()
+    for (const openPaneItem of openPaneItems) {
+      // File is already open in another pane
+      if (openPaneItem.filePath === filePath) {
+        forwardSync(openPaneItem)
+        return
+      }
+    }
+
+    const activePane = atom.workspace.getActivePane()
     // TODO: Make this configurable?
-    // FIXME: Migrate to Pane::splitRight.
-    const newPane = pane.split('horizontal', 'after')
-    // FIXME: Use public API instead.
-    atom.workspace.openURIInPane(filePath, newPane)
+    atom.workspace.open(filePath, {'split': 'right'}).done(function (pdfView) {
+      forwardSync(pdfView)
+    })
 
     // TODO: Check for actual success?
     if (callback) {


### PR DESCRIPTION
I recently got a [PR](https://github.com/izuzak/atom-pdf-view/pull/111) merged into atom-pdf package which allows forward syncing. This patch provides the second part of the functionality that allows a user to forward sync to the Atom PDF viewer.

I don't write JS frequently so let me know if I should change anything :smiley: