### PR TITLE
Tweak #152

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -9,12 +9,26 @@ export default {
       'latex:clean': () => this.composer.clean(),
       'latex:sync': () => this.composer.sync()
     })
+
+    this.workspace = atom.workspace.observeTextEditors(function(editor) {
+      editor.onDidSave(function(event) {
+        if (atom.config.get('latex.buildOnSave')) {
+          var workspaceElement = atom.views.getView(atom.workspace)
+          atom.commands.dispatch(workspaceElement, 'latex:build')
+        }
+      })
+    })
   },
 
   deactivate () {
     if (this.commands) {
       this.commands.dispose()
       delete this.commands
+    }
+
+    if (this.workspace) {
+      this.workspace.dispose()
+      delete this.workspace
     }
 
     if (this.composer) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -16,8 +16,7 @@ export default {
     this.disposables.add(atom.workspace.observeTextEditors(editor => {
       this.disposables.add(editor.onDidSave(() => {
         if (atom.config.get('latex.buildOnSave')) {
-          const workspaceElement = atom.views.getView(atom.workspace)
-          atom.commands.dispatch(workspaceElement, 'latex:build')
+          this.composer.build()
         }
       }))
     }))

--- a/lib/main.js
+++ b/lib/main.js
@@ -14,12 +14,12 @@ export default {
     }))
 
     this.disposables.add(atom.workspace.observeTextEditors(editor => {
-      editor.onDidSave(() => {
+      this.disposables.add(editor.onDidSave(() => {
         if (atom.config.get('latex.buildOnSave')) {
           const workspaceElement = atom.views.getView(atom.workspace)
           atom.commands.dispatch(workspaceElement, 'latex:build')
         }
-      })
+      }))
     }))
   },
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,34 +1,32 @@
 'use babel'
 
+import { CompositeDisposable } from 'atom'
+
 export default {
   activate () {
     this.bootstrap()
+    this.disposables = new CompositeDisposable()
 
-    this.commands = atom.commands.add('atom-workspace', {
+    this.disposables.add(atom.commands.add('atom-workspace', {
       'latex:build': () => this.composer.build(),
       'latex:clean': () => this.composer.clean(),
       'latex:sync': () => this.composer.sync()
-    })
+    }))
 
-    this.workspace = atom.workspace.observeTextEditors(editor => {
+    this.disposables.add(atom.workspace.observeTextEditors(editor => {
       editor.onDidSave(() => {
         if (atom.config.get('latex.buildOnSave')) {
           const workspaceElement = atom.views.getView(atom.workspace)
           atom.commands.dispatch(workspaceElement, 'latex:build')
         }
       })
-    })
+    }))
   },
 
   deactivate () {
-    if (this.commands) {
-      this.commands.dispose()
-      delete this.commands
-    }
-
-    if (this.workspace) {
-      this.workspace.dispose()
-      delete this.workspace
+    if (this.disposables) {
+      this.disposables.dispose()
+      delete this.disposables
     }
 
     if (this.composer) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -15,7 +15,9 @@ export default {
 
     this.disposables.add(atom.workspace.observeTextEditors(editor => {
       this.disposables.add(editor.onDidSave(() => {
-        if (atom.config.get('latex.buildOnSave')) {
+        // Let's play it safe; only trigger builds for the active editor.
+        const activeEditor = atom.workspace.getActiveTextEditor()
+        if (editor === activeEditor && atom.config.get('latex.buildOnSave')) {
           this.composer.build()
         }
       }))

--- a/lib/main.js
+++ b/lib/main.js
@@ -10,10 +10,10 @@ export default {
       'latex:sync': () => this.composer.sync()
     })
 
-    this.workspace = atom.workspace.observeTextEditors(function(editor) {
-      editor.onDidSave(function(event) {
+    this.workspace = atom.workspace.observeTextEditors(editor => {
+      editor.onDidSave(() => {
         if (atom.config.get('latex.buildOnSave')) {
-          var workspaceElement = atom.views.getView(atom.workspace)
+          const workspaceElement = atom.views.getView(atom.workspace)
           atom.commands.dispatch(workspaceElement, 'latex:build')
         }
       })

--- a/package.json
+++ b/package.json
@@ -148,56 +148,63 @@
       "default": true,
       "order": 9
     },
+    "buildOnSave": {
+      "title": "Build on Save",
+      "description": "Automatically run builds when files are saved.",
+      "type": "boolean",
+      "default": false,
+      "order": 10
+    },
     "openResultAfterBuild": {
       "title": "Open Result after Successful Build",
       "type": "boolean",
       "default": true,
-      "order": 10
+      "order": 11
     },
     "openResultInBackground": {
       "title": "Open Result in Background",
       "type": "boolean",
       "default": true,
-      "order": 11
+      "order": 12
     },
     "alwaysOpenResultInAtom": {
       "title": "Always Open Result in Atom",
       "description": "Always open result in Atom. Depends on the pdf-view package being installed.",
       "type": "boolean",
       "default": false,
-      "order": 12
+      "order": 13
     },
     "skimPath": {
       "description": "Full application path to Skim (OS X).",
       "type": "string",
       "default": "/Applications/Skim.app",
-      "order": 13
+      "order": 14
     },
     "sumatraPath": {
       "title": "SumatraPDF Path",
       "description": "Full application path to SumatraPDF (Windows).",
       "type": "string",
       "default": "C:\\Program Files (x86)\\SumatraPDF\\SumatraPDF.exe",
-      "order": 14
+      "order": 15
     },
     "okularPath": {
       "description": "Full application path to Okular (*nix).",
       "type": "string",
       "default": "/usr/bin/okular",
-      "order": 15
+      "order": 16
     },
     "viewerPath": {
       "title": "Custom PDF Viewer Path",
       "description": "Full application path to your PDF viewer. Overrides Skim and SumatraPDF options.",
       "type": "string",
       "default": "",
-      "order": 16
+      "order": 17
     },
     "useMasterFileSearch": {
       "description": "Enables naive search for master/root file when building distributed documents. Note that this does not affect the equivalent *Magic Comments* functionality.",
       "type": "boolean",
       "default": true,
-      "order": 17
+      "order": 18
     }
   }
 }


### PR DESCRIPTION
This PR is meant to augment #152, to fix edge case bugs, but also to improve the existing disposable setup in `main.js`. /cc @ravinrabbid

## TODO
- [x] Merge #152 with `master`; resolve conflicts with the config schema overhaul.
- [x] Invoke `Composer::build` directly instead of dispatching a `latex:build` command.
- [x] Only trigger builds for the active editor. Avoids potential issues caused by e.g. "Save All" in
  conjunction with multi-file documents, and similar scenarios.
- [x] Improve the overall disposable story in `main.js`;
  - [x] Capture all disposables in `main.js` in a single `CompositeDisposable`.
  - [x] Capture and dispose of all `editor.onDidSave` handlers.

---
Closes #152 
Resolves #150 