### PR TITLE
Migrate away from pure JavaScript Standard Style

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,7 +9,7 @@
     "latex": true
   },
   "rules": {
-    "babel/array-bracket-spacing": 2,
+    "babel/array-bracket-spacing": [2, "always"],
     "babel/arrow-parens": [2, "as-needed"],
     "babel/generator-star-spacing": 2,
     "babel/new-cap": 2,

--- a/.eslintrc
+++ b/.eslintrc
@@ -10,7 +10,7 @@
   },
   "rules": {
     "babel/array-bracket-spacing": 2,
-    "babel/arrow-parens": 0,
+    "babel/arrow-parens": [2, "as-needed"],
     "babel/generator-star-spacing": 2,
     "babel/new-cap": 2,
     "babel/no-await-in-loop": 2,

--- a/.eslintrc
+++ b/.eslintrc
@@ -15,7 +15,7 @@
     "babel/new-cap": 2,
     "babel/no-await-in-loop": 2,
     "babel/object-curly-spacing": 2,
-    "babel/object-shorthand": 0,
+    "babel/object-shorthand": 2,
 
     "arrow-parens": 0,
     "no-return-assign": 0

--- a/.eslintrc
+++ b/.eslintrc
@@ -18,6 +18,5 @@
     "babel/object-shorthand": 2,
 
     "arrow-parens": 0,
-    "no-return-assign": 0
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -18,5 +18,6 @@
     "babel/object-shorthand": 2,
 
     "arrow-parens": 0,
+    "max-len": [2, {"code": 80, "ignoreTrailingComments": true}]
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,23 @@
+{
+  "extends": "standard",
+  "parser": "babel-eslint",
+  "plugins": [
+    "babel"
+  ],
+  "globals": {
+    "atom": true,
+    "latex": true
+  },
+  "rules": {
+    "babel/array-bracket-spacing": 2,
+    "babel/arrow-parens": 0,
+    "babel/generator-star-spacing": 2,
+    "babel/new-cap": 2,
+    "babel/no-await-in-loop": 2,
+    "babel/object-curly-spacing": 2,
+    "babel/object-shorthand": 0,
+
+    "arrow-parens": 0,
+    "no-return-assign": 0
+  }
+}

--- a/.eslintrc
+++ b/.eslintrc
@@ -14,7 +14,7 @@
     "babel/generator-star-spacing": 2,
     "babel/new-cap": 2,
     "babel/no-await-in-loop": 2,
-    "babel/object-curly-spacing": 2,
+    "babel/object-curly-spacing": [2, "always"],
     "babel/object-shorthand": 2,
 
     "arrow-parens": 0,

--- a/lib/builder-registry.js
+++ b/lib/builder-registry.js
@@ -6,7 +6,7 @@ import path from 'path'
 export default class BuilderRegistry {
   getBuilder (filePath) {
     const builders = this.getAllBuilders()
-    const candidates = builders.filter((builder) => builder.canProcess(filePath))
+    const candidates = builders.filter(builder => builder.canProcess(filePath))
     switch (candidates.length) {
       case 0: return null
       case 1: return candidates[0]
@@ -18,13 +18,13 @@ export default class BuilderRegistry {
   getAllBuilders () {
     const moduleDir = path.join(__dirname, 'builders')
     const entries = fs.readdirSync(moduleDir)
-    const builders = entries.map((entry) => require(path.join(moduleDir, entry)))
+    const builders = entries.map(entry => require(path.join(moduleDir, entry)))
 
     return builders
   }
 
   resolveAmbigiousBuilders (builders) {
-    const names = builders.map((builder) => builder.name)
+    const names = builders.map(builder => builder.name)
     const indexOfLatexmk = names.indexOf('LatexmkBuilder')
     const indexOfTexify = names.indexOf('TexifyBuilder')
     if (names.length === 2 && indexOfLatexmk >= 0 && indexOfTexify >= 0) {

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -34,7 +34,7 @@ export default class Builder {
       env[this.envPathKey] = childPath
     }
 
-    return {env}
+    return { env }
   }
 
   constructPath () {

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -49,7 +49,7 @@ export default class Builder {
       return `${match[1]}${processPath}${match[3]}`
     }
 
-    return [texPath, processPath]
+    return [ texPath, processPath ]
       .filter(str => str && str.length > 0)
       .join(path.delimiter)
   }

--- a/lib/builders/latexmk.js
+++ b/lib/builders/latexmk.js
@@ -23,9 +23,9 @@ export default class LatexmkBuilder extends Builder {
     options.maxBuffer = 52428800 // Set process' max buffer size to 50 MB.
     options.env.max_print_line = 1000 // Max log file line length.
 
-    return new Promise((resolve) => {
+    return new Promise(resolve => {
       // TODO: Add support for killing the process.
-      child_process.exec(command, options, (error) => {
+      child_process.exec(command, options, error => {
         resolve((error) ? error.code : 0)
       })
     })

--- a/lib/builders/texify.js
+++ b/lib/builders/texify.js
@@ -22,9 +22,9 @@ export default class TexifyBuilder extends Builder {
     options.cwd = path.dirname(filePath) // Run process with sensible CWD.
     options.maxBuffer = 52428800 // Set process' max buffer size to 50 MB.
 
-    return new Promise((resolve) => {
+    return new Promise(resolve => {
       // TODO: Add support for killing the process.
-      child_process.exec(command, options, (error) => {
+      child_process.exec(command, options, error => {
         resolve((error) ? error.code : 0)
       })
     })

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -17,7 +17,7 @@ export default class Composer {
   }
 
   async build () {
-    const {editor, filePath} = this.getEditorDetails()
+    const { editor, filePath } = this.getEditorDetails()
 
     if (!filePath) {
       latex.log.warning('File needs to be saved to disk before it can be TeXified.')
@@ -72,7 +72,7 @@ export default class Composer {
   }
 
   sync () {
-    const {filePath, lineNumber} = this.getEditorDetails()
+    const { filePath, lineNumber } = this.getEditorDetails()
     if (!filePath || !this.isTexFile(filePath)) {
       return
     }
@@ -90,7 +90,7 @@ export default class Composer {
   }
 
   async clean () {
-    const {filePath} = this.getEditorDetails()
+    const { filePath } = this.getEditorDetails()
     if (!filePath || !this.isTexFile(filePath)) {
       return Promise.reject()
     }
@@ -111,7 +111,7 @@ export default class Composer {
       const candidatePath = path.join(rootPath, rootFile + extension)
       return new Promise(async resolve => {
         fs.remove(candidatePath, error => {
-          resolve({filePath: candidatePath, error})
+          resolve({ filePath: candidatePath, error })
         })
       })
     }))
@@ -176,7 +176,7 @@ export default class Composer {
 
     const opener = latex.getOpener()
     if (opener) {
-      const {filePath, lineNumber} = this.getEditorDetails()
+      const { filePath, lineNumber } = this.getEditorDetails()
       opener.open(result.outputFilePath, filePath, lineNumber)
     }
   }
@@ -273,7 +273,7 @@ export default class Composer {
       lineNumber = editor.getCursorBufferPosition().row + 1
     }
 
-    return {editor, filePath, lineNumber}
+    return { editor, filePath, lineNumber }
   }
 
   getAllEditors () {

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -20,7 +20,9 @@ export default class Composer {
     const { editor, filePath } = this.getEditorDetails()
 
     if (!filePath) {
-      latex.log.warning('File needs to be saved to disk before it can be TeXified.')
+      latex.log.warning(
+        'File needs to be saved to disk before it can be ' +
+        'TeXified.')
       return Promise.reject(false)
     }
 
@@ -79,7 +81,9 @@ export default class Composer {
 
     const outputFilePath = this.resolveOutputFilePath(filePath)
     if (!outputFilePath) {
-      latex.log.warning('Could not resolve path to output file associated with the current file.')
+      latex.log.warning(
+        'Could not resolve path to output file associated with the current ' +
+        'file.')
       return
     }
 
@@ -123,13 +127,15 @@ export default class Composer {
 
   moveResult (result, filePath) {
     const originalOutputFilePath = result.outputFilePath
-    result.outputFilePath = this.alterParentPath(filePath, originalOutputFilePath)
+    result.outputFilePath = this.alterParentPath(
+      filePath, originalOutputFilePath)
     if (fs.existsSync(originalOutputFilePath)) {
       fs.removeSync(result.outputFilePath)
       fs.moveSync(originalOutputFilePath, result.outputFilePath)
     }
 
-    const originalSyncFilePath = originalOutputFilePath.replace(/\.pdf$/, '.synctex.gz')
+    const originalSyncFilePath = originalOutputFilePath.replace(
+      /\.pdf$/, '.synctex.gz')
     if (fs.existsSync(originalSyncFilePath)) {
       const syncFilePath = this.alterParentPath(filePath, originalSyncFilePath)
       fs.removeSync(syncFilePath)
@@ -212,7 +218,10 @@ export default class Composer {
   }
 
   showErrorMarkers (result) {
-    if (this.errorMarkers && this.errorMarkers.length > 0) { this.destroyErrorMarkers() }
+    if (this.errorMarkers && this.errorMarkers.length > 0) {
+      this.destroyErrorMarkers()
+    }
+
     const editors = this.getAllEditors()
     this.errorMarkers = []
     const ErrorMarker = require('./error-marker')

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -111,7 +111,7 @@ export default class Composer {
       const candidatePath = path.join(rootPath, rootFile + extension)
       return new Promise(async resolve => {
         fs.remove(candidatePath, error => {
-          resolve({filePath: candidatePath, error: error})
+          resolve({filePath: candidatePath, error})
         })
       })
     }))
@@ -273,11 +273,7 @@ export default class Composer {
       lineNumber = editor.getCursorBufferPosition().row + 1
     }
 
-    return {
-      editor: editor,
-      filePath: filePath,
-      lineNumber: lineNumber
-    }
+    return {editor, filePath, lineNumber}
   }
 
   getAllEditors () {

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -107,10 +107,10 @@ export default class Composer {
     rootFile = rootFile.substring(0, rootFile.lastIndexOf('.'))
 
     const cleanExtensions = atom.config.get('latex.cleanExtensions')
-    return Promise.all(cleanExtensions.map(async (extension) => {
+    return Promise.all(cleanExtensions.map(async extension => {
       const candidatePath = path.join(rootPath, rootFile + extension)
-      return new Promise(async (resolve) => {
-        fs.remove(candidatePath, (error) => {
+      return new Promise(async resolve => {
+        fs.remove(candidatePath, error => {
           resolve({filePath: candidatePath, error: error})
         })
       })

--- a/lib/error-marker.js
+++ b/lib/error-marker.js
@@ -20,7 +20,8 @@ export default class ErrorMarker {
 
   markRow (row, colour) {
     const column = this.editor.buffer.lineLengthForRow(row)
-    const marker = this.editor.markBufferRange([ [ row, 0 ], [ row, column ] ], { invalidate: 'touch' })
+    const marker = this.editor.markBufferRange(
+      [ [ row, 0 ], [ row, column ] ], { invalidate: 'touch' })
     this.editor.decorateMarker(marker, { type: 'line-number', class: colour })
     this.markers.push(marker)
   }

--- a/lib/error-marker.js
+++ b/lib/error-marker.js
@@ -20,8 +20,8 @@ export default class ErrorMarker {
 
   markRow (row, colour) {
     const column = this.editor.buffer.lineLengthForRow(row)
-    const marker = this.editor.markBufferRange([[row, 0], [row, column]], {invalidate: 'touch'})
-    this.editor.decorateMarker(marker, {type: 'line-number', class: colour})
+    const marker = this.editor.markBufferRange([[row, 0], [row, column]], { invalidate: 'touch' })
+    this.editor.decorateMarker(marker, { type: 'line-number', class: colour })
     this.markers.push(marker)
   }
 

--- a/lib/error-marker.js
+++ b/lib/error-marker.js
@@ -20,7 +20,7 @@ export default class ErrorMarker {
 
   markRow (row, colour) {
     const column = this.editor.buffer.lineLengthForRow(row)
-    const marker = this.editor.markBufferRange([[row, 0], [row, column]], { invalidate: 'touch' })
+    const marker = this.editor.markBufferRange([ [ row, 0 ], [ row, column ] ], { invalidate: 'touch' })
     this.editor.decorateMarker(marker, { type: 'line-number', class: colour })
     this.markers.push(marker)
   }

--- a/lib/latex.js
+++ b/lib/latex.js
@@ -2,7 +2,7 @@
 
 import fs from 'fs-plus'
 import _ from 'lodash'
-import {heredoc} from './werkzeug'
+import { heredoc } from './werkzeug'
 
 function defineDefaultProperty (target, property) {
   const shadowProperty = `__${property}`

--- a/lib/latex.js
+++ b/lib/latex.js
@@ -62,10 +62,10 @@ export default class Latex {
       error: (statusCode, result, builder) => {
         this.logger.error(statusCode, result, builder)
       },
-      warning: (message) => {
+      warning: message => {
         this.logger.warning(message)
       },
-      info: (message) => {
+      info: message => {
         this.logger.info(message)
       }
     }

--- a/lib/latex.js
+++ b/lib/latex.js
@@ -9,14 +9,14 @@ function defineDefaultProperty (target, property) {
   const defaultGetter = `getDefault${_.capitalize(property)}`
 
   Object.defineProperty(target, property, {
-    get: function () {
+    get () {
       if (!target[shadowProperty]) {
         target[shadowProperty] = target[defaultGetter].apply(target)
       }
       return target[shadowProperty]
     },
 
-    set: function (value) { target[shadowProperty] = value }
+    set (value) { target[shadowProperty] = value }
   })
 }
 

--- a/lib/loggers/console-logger.js
+++ b/lib/loggers/console-logger.js
@@ -1,7 +1,7 @@
 'use babel'
 
 import Logger from '../logger'
-import {heredoc} from '../werkzeug'
+import { heredoc } from '../werkzeug'
 
 export default class ConsoleLogger extends Logger {
   error (statusCode, result, builder) {

--- a/lib/loggers/console-logger.js
+++ b/lib/loggers/console-logger.js
@@ -25,11 +25,15 @@ export default class ConsoleLogger extends Logger {
         if (result && result.errors) {
           console.group(`TeXification failed with status code ${statusCode}`)
           for (const error of result.errors) {
-            console.log(`%c${error.filePath}:${error.lineNumber}: ${error.message}`, 'color: red')
+            console.log(
+              `%c${error.filePath}:${error.lineNumber}: ${error.message}`,
+              'color: red')
           }
           console.groupEnd()
         } else {
-          console.log(`%cTeXification failed with status code ${statusCode}`, 'color: red')
+          console.log(
+            `%cTeXification failed with status code ${statusCode}`,
+            'color: red')
         }
     }
     console.groupEnd()

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,6 +1,6 @@
 'use babel'
 
-import {CompositeDisposable} from 'atom'
+import { CompositeDisposable } from 'atom'
 
 export default {
   activate () {

--- a/lib/master-tex-finder.js
+++ b/lib/master-tex-finder.js
@@ -25,7 +25,7 @@ export default class MasterTexFinder {
     return fs.listSync(this.projectPath, [ '.tex' ])
   }
 
-  // Returns true iff path is a master file (contains the documentclass declaration)
+  // Returns true iff path is a master file (contains \documentclass).
   isMasterFile (filePath) {
     if (!fs.existsSync(filePath)) { return false }
 
@@ -42,8 +42,8 @@ export default class MasterTexFinder {
     return path.resolve(this.projectPath, magic.root)
   }
 
-  // Returns the list of tex files in the directory where this.filePath lives that
-  // contain a documentclass declaration.
+  // Returns the list of tex files in the directory where this.filePath lives
+  // that contain a documentclass declaration.
   searchForMasterFile () {
     const files = this.getTexFilesList()
     if (!files) { return null }
@@ -60,11 +60,12 @@ export default class MasterTexFinder {
 
   // Returns the a latex master file.
   //
-  // If this.filePath contains a magic comment uses that comment to determine the master file.
+  // If this.filePath contains a magic comment uses that comment to determine
+  //   the master file.
   // Else if master file search is disabled, returns this.filePath.
   // Else if the this.filePath is itself a master file, returns this.filePath.
-  // Otherwise it searches the directory where this.filePath is contained for files having a
-  //   'documentclass' declaration.
+  // Otherwise it searches the directory where this.filePath is contained for
+  //   files having a 'documentclass' declaration.
   getMasterTexPath () {
     const masterPath = this.getMagicCommentMasterFile()
     if (masterPath) { return masterPath }
@@ -74,5 +75,7 @@ export default class MasterTexFinder {
     return this.searchForMasterFile()
   }
 
-  isMasterFileSearchEnabled () { return atom.config.get('latex.useMasterFileSearch') }
+  isMasterFileSearchEnabled () {
+    return atom.config.get('latex.useMasterFileSearch')
+  }
 }

--- a/lib/master-tex-finder.js
+++ b/lib/master-tex-finder.js
@@ -29,7 +29,7 @@ export default class MasterTexFinder {
   isMasterFile (filePath) {
     if (!fs.existsSync(filePath)) { return false }
 
-    const rawFile = fs.readFileSync(filePath, {encoding: 'utf-8'})
+    const rawFile = fs.readFileSync(filePath, { encoding: 'utf-8' })
     return masterFilePattern.test(rawFile)
   }
 

--- a/lib/master-tex-finder.js
+++ b/lib/master-tex-finder.js
@@ -22,7 +22,7 @@ export default class MasterTexFinder {
 
   // Returns the list of tex files in the project directory
   getTexFilesList () {
-    return fs.listSync(this.projectPath, ['.tex'])
+    return fs.listSync(this.projectPath, [ '.tex' ])
   }
 
   // Returns true iff path is a master file (contains the documentclass declaration)

--- a/lib/openers/atompdf-opener.js
+++ b/lib/openers/atompdf-opener.js
@@ -22,7 +22,7 @@ export default class AtomPdfOpener extends Opener {
     }
 
     // TODO: Make this configurable?
-    atom.workspace.open(filePath, {'split': 'right'}).then(forwardSync)
+    atom.workspace.open(filePath, { 'split': 'right' }).then(forwardSync)
 
     // TODO: Check for actual success?
     if (callback) {

--- a/lib/openers/custom-opener.js
+++ b/lib/openers/custom-opener.js
@@ -8,7 +8,7 @@ export default class CustomOpener extends Opener {
   open (filePath, texPath, lineNumber, callback) {
     const command = `"${atom.config.get('latex.viewerPath')}" "${filePath}"`
 
-    child_process.exec(command, (error) => {
+    child_process.exec(command, error => {
       if (callback) {
         callback((error) ? error.code : 0)
       }

--- a/lib/openers/okular-opener.js
+++ b/lib/openers/okular-opener.js
@@ -7,7 +7,7 @@ export default class OkularOpener extends Opener {
   open (filePath, texPath, lineNumber, callback) {
     const command = `"${atom.config.get('latex.okularPath')}" --unique "${filePath}#src:${lineNumber} ${texPath}"`
 
-    child_process.exec(command, (error) => {
+    child_process.exec(command, error => {
       if (callback) {
         callback((error) ? error.code : 0)
       }

--- a/lib/openers/okular-opener.js
+++ b/lib/openers/okular-opener.js
@@ -5,7 +5,8 @@ import child_process from 'child_process'
 
 export default class OkularOpener extends Opener {
   open (filePath, texPath, lineNumber, callback) {
-    const command = `"${atom.config.get('latex.okularPath')}" --unique "${filePath}#src:${lineNumber} ${texPath}"`
+    const command = `"${atom.config.get('latex.okularPath')}" --unique ` +
+      `"${filePath}#src:${lineNumber} ${texPath}"`
 
     child_process.exec(command, error => {
       if (callback) {

--- a/lib/openers/preview-opener.js
+++ b/lib/openers/preview-opener.js
@@ -15,7 +15,7 @@ export default class PreviewOpener extends Opener {
       command = command.replace(/\-g\s/, '')
     }
 
-    child_process.exec(command, (error) => {
+    child_process.exec(command, error => {
       if (callback) {
         callback((error) ? error.code : 0)
       }

--- a/lib/openers/skim-opener.js
+++ b/lib/openers/skim-opener.js
@@ -27,7 +27,7 @@ export default class SkimOpener extends Opener {
       "
       `)
 
-    child_process.exec(command, (error) => {
+    child_process.exec(command, error => {
       if (callback) {
         callback((error) ? error.code : 0)
       }

--- a/lib/openers/skim-opener.js
+++ b/lib/openers/skim-opener.js
@@ -1,7 +1,7 @@
 'use babel'
 
 import child_process from 'child_process'
-import {heredoc} from '../werkzeug'
+import { heredoc } from '../werkzeug'
 import Opener from '../opener'
 
 export default class SkimOpener extends Opener {

--- a/lib/openers/sumatra-opener.js
+++ b/lib/openers/sumatra-opener.js
@@ -14,7 +14,7 @@ export default class SumatraOpener extends Opener {
       `"${lineNumber}"`,
       `"${filePath}"`,
       '-inverse-search',
-      ['\"\\\"', `${atomPath}`, '\\\"'].join(''),
+      [ '\"\\\"', `${atomPath}`, '\\\"' ].join(''),
       '\\\"%f:%l\\\"'
     ]
 

--- a/lib/openers/sumatra-opener.js
+++ b/lib/openers/sumatra-opener.js
@@ -20,7 +20,7 @@ export default class SumatraOpener extends Opener {
 
     const command = `${sumatraPath} ${args.join(' ')}`
 
-    child_process.exec(command, (error) => {
+    child_process.exec(command, error => {
       if (callback) {
         callback((error) ? error.code : 0)
       }

--- a/lib/parsers/log-parser.js
+++ b/lib/parsers/log-parser.js
@@ -61,7 +61,7 @@ export default class LogParser {
       throw new Error(`No such file: ${this.filePath}`)
     }
 
-    const rawFile = fs.readFileSync(this.filePath, {encoding: 'utf-8'})
+    const rawFile = fs.readFileSync(this.filePath, { encoding: 'utf-8' })
     const lines = rawFile.replace(/(\r\n)|\r/g, '\n').split('\n')
     return lines
   }

--- a/lib/parsers/log-parser.js
+++ b/lib/parsers/log-parser.js
@@ -44,7 +44,7 @@ export default class LogParser {
       match = line.match(errorPattern)
       if (match) {
         result.errors.push({
-          logPosition: [index, 0],
+          logPosition: [ index, 0 ],
           filePath: match[1],
           lineNumber: parseInt(match[2], 10),
           message: match[3]

--- a/lib/parsers/log-parser.js
+++ b/lib/parsers/log-parser.js
@@ -11,10 +11,10 @@ const outputPattern = new RegExp('' +
 )
 
 const errorPattern = new RegExp('' +
-  '^(?:\\.\\/)?(.*):' +     // File path ignoring the possible ./ at the start.
-  '(\\d+):' +              // Line number.
+  '^(?:\\.\\/)?(.*):' +         // File path ignoring the possible ./ at the start.
+  '(\\d+):' +                   // Line number.
   '(?:\\sLaTeX\\sError:\\s)?' + // Marker.
-  '(.*)\\.$'               // Error message.
+  '(.*)\\.$'                    // Error message.
 )
 
 export default class LogParser {

--- a/lib/parsers/magic-parser.js
+++ b/lib/parsers/magic-parser.js
@@ -42,7 +42,7 @@ export default class MagicParser {
   getLines () {
     if (!fs.existsSync(this.filePath)) { return [] }
 
-    const rawFile = fs.readFileSync(this.filePath, {encoding: 'utf-8'})
+    const rawFile = fs.readFileSync(this.filePath, { encoding: 'utf-8' })
     const lines = rawFile.replace(/(\r\n)|\r/g, '\n').split('\n')
     return lines
   }

--- a/lib/status-bar/error-indicator.js
+++ b/lib/status-bar/error-indicator.js
@@ -30,7 +30,7 @@ export default class ErrorIndicator {
 
     atom.workspace.open(this.model.logFilePath).then(editor => {
       const position = this.getFirstErrorPosition()
-      editor.scrollToBufferPosition(position, {center: true})
+      editor.scrollToBufferPosition(position, { center: true })
     })
   }
 

--- a/lib/status-bar/error-indicator.js
+++ b/lib/status-bar/error-indicator.js
@@ -36,6 +36,6 @@ export default class ErrorIndicator {
 
   getFirstErrorPosition () {
     const position = _.first(_.pluck(this.model.errors, 'logPosition'))
-    return position || [0, 0]
+    return position || [ 0, 0 ]
   }
 }

--- a/lib/werkzeug.js
+++ b/lib/werkzeug.js
@@ -5,7 +5,8 @@ import _ from 'lodash'
 export function heredoc (input) {
   if (input === null) { return null }
 
-  const lines = _.dropWhile(input.split(/\r\n|\n|\r/), line => line.length === 0)
+  const allLines = input.split(/\r\n|\n|\r/)
+  const lines = _.dropWhile(allLines, line => line.length === 0)
   const indentLength = _.takeWhile(lines[0], char => char === ' ').length
   const truncatedLines = lines.map(line => line.slice(indentLength))
 

--- a/package.json
+++ b/package.json
@@ -20,26 +20,10 @@
     "wrench": "^1.5.8"
   },
   "devDependencies": {
-    "babel-eslint": "^4.1.3",
-    "snazzy": "^3.0.0",
-    "standard": "^5.3.1"
-  },
-  "standard": {
-    "parser": "babel-eslint",
-    "globals": [
-      "atom",
-      "latex",
-      "afterEach",
-      "beforeEach",
-      "describe",
-      "expect",
-      "it",
-      "jasmine",
-      "runs",
-      "spyOn",
-      "waitsFor",
-      "waitsForPromise"
-    ]
+    "babel-eslint": "^6.0.0",
+    "eslint": "^2.5.3",
+    "eslint-config-standard": "^5.1.0",
+    "eslint-plugin-babel": "^3.0.0"
   },
   "engines": {
     "atom": ">=1.0.0 <2.0.0"

--- a/script/lint
+++ b/script/lint
@@ -3,7 +3,7 @@
 cd "${BASH_SOURCE%/*}" || exit
 
 echo "Linting package..."
-$(npm bin)/standard --verbose "../lib/**/*.js" | $(npm bin)/snazzy
+$(npm bin)/eslint ../lib
 
 echo "Linting package specs..."
-$(npm bin)/standard --verbose "../spec/**/*.js" | $(npm bin)/snazzy
+$(npm bin)/eslint ../spec

--- a/spec/.eslintrc
+++ b/spec/.eslintrc
@@ -1,0 +1,8 @@
+{
+  "env": {
+    "jasmine": true
+  },
+  "globals": {
+    "waitsForPromise": true
+  }
+}

--- a/spec/.eslintrc
+++ b/spec/.eslintrc
@@ -4,5 +4,12 @@
   },
   "globals": {
     "waitsForPromise": true
+  },
+  "rules": {
+    "max-len": [2, {
+      "code": 80,
+      "ignoreTrailingComments": true,
+      "ignorePattern": "^\\s*describe|it\\("
+    }]
   }
 }

--- a/spec/build-registry-spec.js
+++ b/spec/build-registry-spec.js
@@ -3,7 +3,7 @@
 import helpers from './spec-helpers'
 import path from 'path'
 import BuilderRegistry from '../lib/builder-registry'
-import {NullBuilder} from './stubs'
+import { NullBuilder } from './stubs'
 
 describe('BuilderRegistry', () => {
   let registry, fixturesPath, filePath

--- a/spec/builder-spec.js
+++ b/spec/builder-spec.js
@@ -24,7 +24,8 @@ describe('Builder', () => {
 
     it('uses platform default when `latex.texPath` is not configured', () => {
       const defaultTexPath = '/foo/bar'
-      const expectedPath = [ defaultTexPath, process.env.PATH ].join(path.delimiter)
+      const expectedPath = [ defaultTexPath, process.env.PATH ]
+        .join(path.delimiter)
       helpers.spyOnConfig('latex.texPath', '')
       spyOn(builder, 'defaultTexPath').andReturn(defaultTexPath)
 
@@ -107,7 +108,8 @@ describe('Builder', () => {
 
   describe('getLatexEngineFromMagic', () => {
     it('detects program magic and outputs correct engine', () => {
-      const filePath = path.join(fixturesPath, 'magic-comments', 'latex-engine.tex')
+      const filePath = path.join(
+        fixturesPath, 'magic-comments', 'latex-engine.tex')
       expect(builder.getLatexEngineFromMagic(filePath)).toEqual('pdflatex')
     })
   })

--- a/spec/builder-spec.js
+++ b/spec/builder-spec.js
@@ -24,7 +24,7 @@ describe('Builder', () => {
 
     it('uses platform default when `latex.texPath` is not configured', () => {
       const defaultTexPath = '/foo/bar'
-      const expectedPath = [defaultTexPath, process.env.PATH].join(path.delimiter)
+      const expectedPath = [ defaultTexPath, process.env.PATH ].join(path.delimiter)
       helpers.spyOnConfig('latex.texPath', '')
       spyOn(builder, 'defaultTexPath').andReturn(defaultTexPath)
 
@@ -65,7 +65,7 @@ describe('Builder', () => {
 
     it('prepends process.env.PATH with texPath', () => {
       const texPath = '/foo'
-      const expectedPath = [texPath, process.env.PATH].join(path.delimiter)
+      const expectedPath = [ texPath, process.env.PATH ].join(path.delimiter)
       helpers.spyOnConfig('latex.texPath', texPath)
 
       const constructedPath = builder.constructPath()
@@ -78,7 +78,7 @@ describe('Builder', () => {
     let logParser
 
     beforeEach(() => {
-      logParser = jasmine.createSpyObj('MockLogParser', ['parse'])
+      logParser = jasmine.createSpyObj('MockLogParser', [ 'parse' ])
       spyOn(builder, 'getLogParser').andReturn(logParser)
     })
 

--- a/spec/builders/latexmk-spec.js
+++ b/spec/builders/latexmk-spec.js
@@ -88,7 +88,7 @@ describe('LatexmkBuilder', () => {
     })
 
     it('fails to execute latexmk when given invalid arguments', () => {
-      spyOn(builder, 'constructArgs').andReturn(['-invalid-argument'])
+      spyOn(builder, 'constructArgs').andReturn([ '-invalid-argument' ])
 
       waitsForPromise(() => {
         return builder.run(filePath).then(code => exitCode = code)
@@ -105,7 +105,7 @@ describe('LatexmkBuilder', () => {
 
       // Need to remove the 'force' flag to trigger the desired failure.
       const removed = args.splice(1, 1)
-      expect(removed).toEqual(['-f'])
+      expect(removed).toEqual([ '-f' ])
 
       spyOn(builder, 'constructArgs').andReturn(args)
 

--- a/spec/builders/latexmk-spec.js
+++ b/spec/builders/latexmk-spec.js
@@ -67,7 +67,7 @@ describe('LatexmkBuilder', () => {
 
     it('successfully executes latexmk when given a valid TeX file', () => {
       waitsForPromise(() => {
-        return builder.run(filePath).then(code => exitCode = code)
+        return builder.run(filePath).then(code => { exitCode = code })
       })
 
       runs(() => {
@@ -79,7 +79,7 @@ describe('LatexmkBuilder', () => {
       filePath = path.join(fixturesPath, 'filename with spaces.tex')
 
       waitsForPromise(() => {
-        return builder.run(filePath).then(code => exitCode = code)
+        return builder.run(filePath).then(code => { exitCode = code })
       })
 
       runs(() => {
@@ -91,7 +91,7 @@ describe('LatexmkBuilder', () => {
       spyOn(builder, 'constructArgs').andReturn([ '-invalid-argument' ])
 
       waitsForPromise(() => {
-        return builder.run(filePath).then(code => exitCode = code)
+        return builder.run(filePath).then(code => { exitCode = code })
       })
 
       runs(() => {
@@ -110,7 +110,7 @@ describe('LatexmkBuilder', () => {
       spyOn(builder, 'constructArgs').andReturn(args)
 
       waitsForPromise(() => {
-        return builder.run(filePath).then(code => exitCode = code)
+        return builder.run(filePath).then(code => { exitCode = code })
       })
 
       runs(() => {

--- a/spec/builders/latexmk-spec.js
+++ b/spec/builders/latexmk-spec.js
@@ -49,7 +49,8 @@ describe('LatexmkBuilder', () => {
 
     it('adds a custom engine string according to package config', () => {
       helpers.spyOnConfig('latex.customEngine', 'pdflatex %O %S')
-      expect(builder.constructArgs(filePath)).toContain('-pdflatex="pdflatex %O %S"')
+      expect(builder.constructArgs(filePath)).toContain(
+        '-pdflatex="pdflatex %O %S"')
     })
 
     it('adds -ps or -dvi and removes -pdf arguments according to package config', () => {

--- a/spec/composer-spec.js
+++ b/spec/composer-spec.js
@@ -18,11 +18,11 @@ describe('Composer', () => {
     let editor, builder
 
     function initializeSpies (filePath, statusCode = 0) {
-      editor = jasmine.createSpyObj('MockEditor', ['save', 'isModified'])
+      editor = jasmine.createSpyObj('MockEditor', [ 'save', 'isModified' ])
       spyOn(composer, 'resolveRootFilePath').andReturn(filePath)
       spyOn(composer, 'getEditorDetails').andReturn({ editor, filePath })
 
-      builder = jasmine.createSpyObj('MockBuilder', ['run', 'constructArgs', 'parseLogFile'])
+      builder = jasmine.createSpyObj('MockBuilder', [ 'run', 'constructArgs', 'parseLogFile' ])
       builder.run.andCallFake(() => {
         switch (statusCode) {
           case 0: { return Promise.resolve(statusCode) }
@@ -154,7 +154,7 @@ describe('Composer', () => {
   })
 
   describe('clean', () => {
-    const extensions = ['.bar', '.baz', '.quux']
+    const extensions = [ '.bar', '.baz', '.quux' ]
 
     function fakeFilePaths (filePath) {
       const filePathSansExtension = filePath.substring(0, filePath.lastIndexOf('.'))

--- a/spec/composer-spec.js
+++ b/spec/composer-spec.js
@@ -20,7 +20,7 @@ describe('Composer', () => {
     function initializeSpies (filePath, statusCode = 0) {
       editor = jasmine.createSpyObj('MockEditor', ['save', 'isModified'])
       spyOn(composer, 'resolveRootFilePath').andReturn(filePath)
-      spyOn(composer, 'getEditorDetails').andReturn({editor, filePath})
+      spyOn(composer, 'getEditorDetails').andReturn({ editor, filePath })
 
       builder = jasmine.createSpyObj('MockBuilder', ['run', 'constructArgs', 'parseLogFile'])
       builder.run.andCallFake(() => {
@@ -162,7 +162,7 @@ describe('Composer', () => {
     }
 
     function initializeSpies (filePath) {
-      spyOn(composer, 'getEditorDetails').andReturn({filePath})
+      spyOn(composer, 'getEditorDetails').andReturn({ filePath })
       spyOn(composer, 'resolveRootFilePath').andReturn(filePath)
     }
 

--- a/spec/composer-spec.js
+++ b/spec/composer-spec.js
@@ -43,7 +43,7 @@ describe('Composer', () => {
 
       let result = 'aaaaaaaaaaaa'
       waitsForPromise(() => {
-        return composer.build().catch(r => result = r)
+        return composer.build().catch(r => { result = r })
       })
 
       runs(() => {
@@ -59,7 +59,7 @@ describe('Composer', () => {
 
       let result
       waitsForPromise(() => {
-        return composer.build().catch(r => result = r)
+        return composer.build().catch(r => { result = r })
       })
 
       runs(() => {

--- a/spec/composer-spec.js
+++ b/spec/composer-spec.js
@@ -22,7 +22,8 @@ describe('Composer', () => {
       spyOn(composer, 'resolveRootFilePath').andReturn(filePath)
       spyOn(composer, 'getEditorDetails').andReturn({ editor, filePath })
 
-      builder = jasmine.createSpyObj('MockBuilder', [ 'run', 'constructArgs', 'parseLogFile' ])
+      builder = jasmine.createSpyObj(
+        'MockBuilder', [ 'run', 'constructArgs', 'parseLogFile' ])
       builder.run.andCallFake(() => {
         switch (statusCode) {
           case 0: { return Promise.resolve(statusCode) }
@@ -157,7 +158,8 @@ describe('Composer', () => {
     const extensions = [ '.bar', '.baz', '.quux' ]
 
     function fakeFilePaths (filePath) {
-      const filePathSansExtension = filePath.substring(0, filePath.lastIndexOf('.'))
+      const filePathSansExtension = filePath.substring(
+        0, filePath.lastIndexOf('.'))
       return extensions.map(ext => filePathSansExtension + ext)
     }
 
@@ -241,10 +243,12 @@ describe('Composer', () => {
     it('returns a builder instance as configured for regular .tex files', () => {
       const filePath = 'foo.tex'
 
-      expect(composer.getBuilder(filePath).constructor.name).toEqual('LatexmkBuilder')
+      let builderName = composer.getBuilder(filePath).constructor.name
+      expect(builderName).toEqual('LatexmkBuilder')
 
       atom.config.set('latex.builder', 'texify')
-      expect(composer.getBuilder(filePath).constructor.name).toEqual('TexifyBuilder')
+      builderName = composer.getBuilder(filePath).constructor.name
+      expect(builderName).toEqual('TexifyBuilder')
     })
 
     it('returns null when passed an unhandled file type', () => {

--- a/spec/composer-spec.js
+++ b/spec/composer-spec.js
@@ -20,10 +20,7 @@ describe('Composer', () => {
     function initializeSpies (filePath, statusCode = 0) {
       editor = jasmine.createSpyObj('MockEditor', ['save', 'isModified'])
       spyOn(composer, 'resolveRootFilePath').andReturn(filePath)
-      spyOn(composer, 'getEditorDetails').andReturn({
-        editor: editor,
-        filePath: filePath
-      })
+      spyOn(composer, 'getEditorDetails').andReturn({editor, filePath})
 
       builder = jasmine.createSpyObj('MockBuilder', ['run', 'constructArgs', 'parseLogFile'])
       builder.run.andCallFake(() => {

--- a/spec/latex-spec.js
+++ b/spec/latex-spec.js
@@ -47,7 +47,8 @@ describe('Latex', () => {
     let logger
 
     beforeEach(() => {
-      logger = jasmine.createSpyObj('MockLogger', [ 'error', 'warning', 'info' ])
+      logger = jasmine.createSpyObj(
+        'MockLogger', [ 'error', 'warning', 'info' ])
       latex.setLogger(logger)
       latex.createLogProxy()
     })

--- a/spec/latex-spec.js
+++ b/spec/latex-spec.js
@@ -54,8 +54,8 @@ describe('Latex', () => {
 
     it('correctly proxies error to error', () => {
       const statusCode = 0
-      const result = { foo: 'bar' }
-      const builder = { run () { return '' } }
+      const result = {foo: 'bar'}
+      const builder = {run () { return '' }}
       latex.log.error(statusCode, result, builder)
 
       expect(logger.error).toHaveBeenCalledWith(statusCode, result, builder)

--- a/spec/latex-spec.js
+++ b/spec/latex-spec.js
@@ -2,7 +2,7 @@
 
 import './spec-helpers'
 import Latex from '../lib/latex'
-import {NullOpener} from './stubs'
+import { NullOpener } from './stubs'
 
 describe('Latex', () => {
   let latex, globalLatex
@@ -54,8 +54,8 @@ describe('Latex', () => {
 
     it('correctly proxies error to error', () => {
       const statusCode = 0
-      const result = {foo: 'bar'}
-      const builder = {run () { return '' }}
+      const result = { foo: 'bar' }
+      const builder = { run () { return '' } }
       latex.log.error(statusCode, result, builder)
 
       expect(logger.error).toHaveBeenCalledWith(statusCode, result, builder)

--- a/spec/latex-spec.js
+++ b/spec/latex-spec.js
@@ -47,7 +47,7 @@ describe('Latex', () => {
     let logger
 
     beforeEach(() => {
-      logger = jasmine.createSpyObj('MockLogger', ['error', 'warning', 'info'])
+      logger = jasmine.createSpyObj('MockLogger', [ 'error', 'warning', 'info' ])
       latex.setLogger(logger)
       latex.createLogProxy()
     })

--- a/spec/master-tex-finder-spec.js
+++ b/spec/master-tex-finder-spec.js
@@ -18,8 +18,9 @@ describe('MasterTexFinder', () => {
     it('returns the master tex file for the current project', () => {
       const inc2Path = path.join(fixturesPath, 'inc2.tex')
       const finder = new MasterTexFinder(inc2Path)
+      const masterTexPath = path.join(fixturesPath, 'master.tex')
 
-      expect(finder.getMasterTexPath()).toBe(path.join(fixturesPath, 'master.tex'))
+      expect(finder.getMasterTexPath()).toBe(masterTexPath)
     })
 
     it('immediately return the given file, if itself is a root-file', () => {
@@ -32,7 +33,8 @@ describe('MasterTexFinder', () => {
     })
 
     it('returns the original file if more than one file is a master file', () => {
-      const multiMasterFixturePath = path.join(rootPath, 'master-tex-finder', 'multiple-masters')
+      const multiMasterFixturePath = path.join(
+        rootPath, 'master-tex-finder', 'multiple-masters')
       const inc1Path = path.join(multiMasterFixturePath, 'inc1.tex')
       const finder = new MasterTexFinder(inc1Path)
 
@@ -42,10 +44,11 @@ describe('MasterTexFinder', () => {
     it('immediately returns the file specified by the magic comment when present', () => {
       const inc1Path = path.join(fixturesPath, 'inc1.tex')
       const finder = new MasterTexFinder(inc1Path)
+      const masterTexPath = path.join(fixturesPath, 'master.tex')
 
       spyOn(finder, 'getTexFilesList').andCallThrough()
 
-      expect(finder.getMasterTexPath()).toBe(path.join(fixturesPath, 'master.tex'))
+      expect(finder.getMasterTexPath()).toBe(masterTexPath)
       expect(finder.getTexFilesList).not.toHaveBeenCalled()
     })
 
@@ -75,7 +78,8 @@ describe('MasterTexFinder', () => {
 
   describe('getTexFilesList', () => {
     it('returns the list of tex files in the project directory', () => {
-      const expectedFileList = [ 'inc1.tex', 'inc2.tex', 'inc3.tex', 'master.tex' ]
+      const expectedFileList = [
+        'inc1.tex', 'inc2.tex', 'inc3.tex', 'master.tex' ]
         .map(name => path.join(fixturesPath, name))
       const inc2Path = path.join(fixturesPath, 'inc2.tex')
       const finder = new MasterTexFinder(inc2Path)

--- a/spec/master-tex-finder-spec.js
+++ b/spec/master-tex-finder-spec.js
@@ -75,7 +75,7 @@ describe('MasterTexFinder', () => {
 
   describe('getTexFilesList', () => {
     it('returns the list of tex files in the project directory', () => {
-      const expectedFileList = ['inc1.tex', 'inc2.tex', 'inc3.tex', 'master.tex']
+      const expectedFileList = [ 'inc1.tex', 'inc2.tex', 'inc3.tex', 'master.tex' ]
         .map(name => path.join(fixturesPath, name))
       const inc2Path = path.join(fixturesPath, 'inc2.tex')
       const finder = new MasterTexFinder(inc2Path)

--- a/spec/parsers/log-parser-spec.js
+++ b/spec/parsers/log-parser-spec.js
@@ -46,7 +46,7 @@ describe('LogParser', () => {
       const error = result.errors[0]
 
       expect(error).toEqual({
-        logPosition: [196, 0],
+        logPosition: [ 196, 0 ],
         filePath: 'errors.tex',
         lineNumber: 10,
         message: '\\begin{gather*} on input line 8 ended by \\end{gather}'

--- a/spec/parsers/magic-parser-spec.js
+++ b/spec/parsers/magic-parser-spec.js
@@ -20,7 +20,8 @@ describe('MagicParser', () => {
     })
 
     it('returns path to root file when file contains magic root comment', () => {
-      const filePath = path.join(fixturesPath, 'magic-comments', 'root-comment.tex')
+      const filePath = path.join(
+        fixturesPath, 'magic-comments', 'root-comment.tex')
       const parser = new MagicParser(filePath)
       const result = parser.parse()
 
@@ -30,7 +31,8 @@ describe('MagicParser', () => {
     })
 
     it('returns path to root file when file contains magic root comment when magic comment is not on the first line', () => {
-      const filePath = path.join(fixturesPath, 'magic-comments', 'not-first-line.tex')
+      const filePath = path.join(
+        fixturesPath, 'magic-comments', 'not-first-line.tex')
       const parser = new MagicParser(filePath)
       const result = parser.parse()
 
@@ -40,14 +42,17 @@ describe('MagicParser', () => {
     })
 
     it('handles magic comments without optional whitespace', () => {
-      const filePath = path.join(fixturesPath, 'magic-comments', 'no-whitespace.tex')
+      const filePath = path.join(
+        fixturesPath, 'magic-comments', 'no-whitespace.tex')
       const parser = new MagicParser(filePath)
       const result = parser.parse()
 
       expect(result).not.toEqual({})
     })
+
     it('detects multiple object information when multiple magice comments are defined', () => {
-      const filePath = path.join(fixturesPath, 'magic-comments', 'multiple-magic-comments.tex')
+      const filePath = path.join(fixturesPath,
+        'magic-comments', 'multiple-magic-comments.tex')
       const parser = new MagicParser(filePath)
       const result = parser.parse()
 

--- a/spec/spec-bootstrap.js
+++ b/spec/spec-bootstrap.js
@@ -1,7 +1,7 @@
 'use babel'
 
 import Latex from '../lib/latex'
-import {NullLogger} from './stubs'
+import { NullLogger } from './stubs'
 
 global.latex = new Latex()
 latex.setLogger(new NullLogger())

--- a/spec/spec-helpers.js
+++ b/spec/spec-helpers.js
@@ -12,7 +12,7 @@ export default {
     const tempPath = fs.realpathSync(temp.mkdirSync('latex'))
     let fixturesPath = atom.project.getPaths()[0]
     wrench.copyDirSyncRecursive(fixturesPath, tempPath, { forceDelete: true })
-    atom.project.setPaths([tempPath])
+    atom.project.setPaths([ tempPath ])
     fixturesPath = tempPath
 
     return fixturesPath

--- a/spec/spec-helpers.js
+++ b/spec/spec-helpers.js
@@ -11,7 +11,7 @@ export default {
   cloneFixtures () {
     const tempPath = fs.realpathSync(temp.mkdirSync('latex'))
     let fixturesPath = atom.project.getPaths()[0]
-    wrench.copyDirSyncRecursive(fixturesPath, tempPath, {forceDelete: true})
+    wrench.copyDirSyncRecursive(fixturesPath, tempPath, { forceDelete: true })
     atom.project.setPaths([tempPath])
     fixturesPath = tempPath
 
@@ -19,7 +19,7 @@ export default {
   },
 
   overridePlatform (name) {
-    Object.defineProperty(process, 'platform', {__proto__: null, value: name})
+    Object.defineProperty(process, 'platform', { __proto__: null, value: name })
   },
 
   spyOnConfig (key, value) {


### PR DESCRIPTION
There are issues (e.g. arrow function parens) that can only be properly solved by using eslint plugins that cannot be used with pure Standard. Hence the move away from the `standard` package to `eslint-config-standard` together with `eslint-plugin-babel`.

Additional benefit is that globals can now be sensibly be scoped to folders again since we can use .eslintrc files and we can specify the `jasmine` env, etc :sparkles: