### PR TITLE
Jobname support

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -12,11 +12,11 @@ export default class Builder {
   }
 
   static canProcess (/* filePath */) {}
-  run (/* filePath */) {}
-  constructArgs (/* filePath */) {}
+  run (/* filePath, jobname */) {}
+  constructArgs (/* filePath, jobname */) {}
 
-  parseLogFile (texFilePath) {
-    const logFilePath = this.resolveLogFilePath(texFilePath)
+  parseLogFile (texFilePath, jobname) {
+    const logFilePath = this.resolveLogFilePath(texFilePath, jobname)
     if (!fs.existsSync(logFilePath)) { return null }
 
     const parser = this.getLogParser(logFilePath)
@@ -70,10 +70,10 @@ export default class Builder {
     ].join(':')
   }
 
-  resolveLogFilePath (texFilePath) {
+  resolveLogFilePath (texFilePath, jobname) {
     const outputDirectory = atom.config.get('latex.outputDirectory') || ''
     const currentDirectory = path.dirname(texFilePath)
-    const fileName = path.basename(texFilePath).replace(/\.\w+$/, '.log')
+    const fileName = jobname ? `${jobname}.log` : path.basename(texFilePath).replace(/\.\w+$/, '.log')
 
     return path.join(currentDirectory, outputDirectory, fileName)
   }
@@ -101,4 +101,14 @@ export default class Builder {
 
     return null
   }
+
+  getJobNamesFromMagic (filePath) {
+    const magic = new MagicParser(filePath).parse()
+    if (magic && magic.jobnames) {
+      return magic.jobnames.split(/\s+/)
+    }
+
+    return [null]
+  }
+
 }

--- a/lib/builders/latexmk.js
+++ b/lib/builders/latexmk.js
@@ -14,8 +14,8 @@ export default class LatexmkBuilder extends Builder {
     return path.extname(filePath) === '.tex'
   }
 
-  run (filePath) {
-    const args = this.constructArgs(filePath)
+  run (filePath, jobname) {
+    const args = this.constructArgs(filePath, jobname)
     const command = `${this.executable} ${args.join(' ')}`
     const options = this.constructChildProcessOptions()
 
@@ -31,7 +31,7 @@ export default class LatexmkBuilder extends Builder {
     })
   }
 
-  constructArgs (filePath) {
+  constructArgs (filePath, jobname) {
     const outputFormat = atom.config.get('latex.outputFormat') || 'pdf'
 
     const args = [
@@ -48,6 +48,9 @@ export default class LatexmkBuilder extends Builder {
     const customEngine = atom.config.get('latex.customEngine')
     const engine = atom.config.get('latex.engine')
 
+    if (jobname) {
+      args.push(`-jobname=${jobname}`)
+    }
     if (enableShellEscape) {
       args.push('-shell-escape')
     }

--- a/lib/builders/texify.js
+++ b/lib/builders/texify.js
@@ -14,8 +14,8 @@ export default class TexifyBuilder extends Builder {
     return path.extname(filePath) === '.tex'
   }
 
-  run (filePath) {
-    const args = this.constructArgs(filePath)
+  run (filePath, jobname) {
+    const args = this.constructArgs(filePath, jobname)
     const command = `${this.executable} ${args.join(' ')}`
     const options = this.constructChildProcessOptions()
 
@@ -30,7 +30,7 @@ export default class TexifyBuilder extends Builder {
     })
   }
 
-  constructArgs (filePath) {
+  constructArgs (filePath, jobname) {
     const args = [
       '--batch',
       '--pdf',
@@ -45,6 +45,9 @@ export default class TexifyBuilder extends Builder {
     const customEngine = atom.config.get('latex.customEngine')
     const engine = atom.config.get('latex.engine')
 
+    if (jobname) {
+      args.push(`--tex-option="--job-name=${jobname}"`)
+    }
     if (enableShellEscape) {
       args.push('--tex-option=--enable-write18')
     }

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -41,7 +41,8 @@ export default class Composer {
     this.showProgressIndicator()
 
     return new Promise(async (resolve, reject) => {
-      let statusCode, result, jobnames = builder.getJobNamesFromMagic(rootFilePath)
+      let statusCode, result
+      let jobnames = builder.getJobNamesFromMagic(rootFilePath)
 
       const showBuildError = () => {
         this.showError(statusCode, result, builder)
@@ -49,7 +50,7 @@ export default class Composer {
       }
 
       try {
-        for (jobname of jobnames) {
+        for (let jobname of jobnames) {
           statusCode = await builder.run(rootFilePath, jobname)
           result = builder.parseLogFile(rootFilePath, jobname)
           if (statusCode > 0 || !result || !result.outputFilePath) {

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -41,7 +41,7 @@ export default class Composer {
     this.showProgressIndicator()
 
     return new Promise(async (resolve, reject) => {
-      let statusCode, result
+      let statusCode, result, jobnames = builder.getJobNamesFromMagic(rootFilePath)
 
       const showBuildError = () => {
         this.showError(statusCode, result, builder)
@@ -49,19 +49,21 @@ export default class Composer {
       }
 
       try {
-        statusCode = await builder.run(rootFilePath)
-        result = builder.parseLogFile(rootFilePath)
-        if (statusCode > 0 || !result || !result.outputFilePath) {
-          showBuildError(statusCode, result, builder)
-          return
-        }
+        for (jobname of jobnames) {
+          statusCode = await builder.run(rootFilePath, jobname)
+          result = builder.parseLogFile(rootFilePath, jobname)
+          if (statusCode > 0 || !result || !result.outputFilePath) {
+            showBuildError(statusCode, result, builder)
+            return
+          }
 
-        if (this.shouldMoveResult()) {
-          this.moveResult(result, rootFilePath)
-        }
+          if (this.shouldMoveResult()) {
+            this.moveResult(result, rootFilePath)
+          }
 
-        this.showResult(result)
-        resolve(statusCode)
+          this.showResult(result)
+          resolve(statusCode)
+        }
       } catch (error) {
         console.error(error.message)
         reject(error.message)

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -50,7 +50,7 @@ export default class Composer {
       }
 
       try {
-        for (let jobname of jobnames) {
+        for (const jobname of jobnames) {
           statusCode = await builder.run(rootFilePath, jobname)
           result = builder.parseLogFile(rootFilePath, jobname)
           if (statusCode > 0 || !result || !result.outputFilePath) {

--- a/spec/builder-spec.js
+++ b/spec/builder-spec.js
@@ -106,4 +106,11 @@ describe('Builder', () => {
       expect(builder.getLatexEngineFromMagic(filePath)).toEqual('pdflatex')
     })
   })
+
+  describe('getJobNamesFromMagic', () => {
+    it('detects program magic and outputs jobnames', () => {
+      const filePath = path.join(fixturesPath, 'magic-comments', 'latex-jobnames.tex')
+      expect(builder.getJobNamesFromMagic(filePath)).toEqual(['foo', 'bar'])
+    })
+  })
 })

--- a/spec/builder-spec.js
+++ b/spec/builder-spec.js
@@ -80,13 +80,13 @@ describe('Builder', () => {
     it('resolves the associated log file path by invoking @resolveLogFilePath', () => {
       spyOn(builder, 'resolveLogFilePath').andReturn('foo.log')
 
-      builder.parseLogFile(filePath)
-      expect(builder.resolveLogFilePath).toHaveBeenCalledWith(filePath)
+      builder.parseLogFile(filePath, null)
+      expect(builder.resolveLogFilePath).toHaveBeenCalledWith(filePath, null)
     })
 
     it('returns null if passed a file path that does not exist', () => {
       filePath = '/foo/bar/quux.tex'
-      const result = builder.parseLogFile(filePath)
+      const result = builder.parseLogFile(filePath, null)
 
       expect(result).toBeNull()
       expect(logParser.parse).not.toHaveBeenCalled()

--- a/spec/composer-spec.js
+++ b/spec/composer-spec.js
@@ -25,7 +25,8 @@ describe('Composer', () => {
         filePath: filePath
       })
 
-      builder = jasmine.createSpyObj('MockBuilder', ['run', 'constructArgs', 'parseLogFile'])
+      builder = jasmine.createSpyObj('MockBuilder', ['run', 'constructArgs', 'parseLogFile', 'getJobNamesFromMagic'])
+      builder.getJobNamesFromMagic.andReturn([null])
       builder.run.andCallFake(() => {
         switch (statusCode) {
           case 0: { return Promise.resolve(statusCode) }

--- a/spec/fixtures/magic-comments/latex-jobnames.tex
+++ b/spec/fixtures/magic-comments/latex-jobnames.tex
@@ -1,0 +1,7 @@
+% !TEX jobnames = foo bar
+\documentclass{article}
+
+\begin{document}
+  \section{\LaTeX}
+  Lorem ipsum dolor sit amet...
+\end{document}


### PR DESCRIPTION
Add support for jobnames TeX Magic.  ``# !TEX jobnames = foo bar`` causes two builds. First with "foo" and second with "bar."

