### PR TITLE
Knitr support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,16 +3,9 @@ branches:
     - master
 
 skip_tags: true
-clone_depth: 10
+clone_depth: 1
 
-version: "{build}"
-
-os: Visual Studio 2015
-platform: x64
-
-build: off
-test: off
-deploy: off
+image: Visual Studio 2015
 
 install:
   - ps: Install-Product node 5
@@ -27,7 +20,10 @@ environment:
     - ATOM_CHANNEL: beta
 
 cache:
-  - '%USERPROFILE%\R\library'
+  - '%R_LIBS_USER%'
 
 build_script:
   - sh ./script/cibuild
+
+test: off
+deploy: off

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,7 +19,6 @@ install:
 
 environment:
   global:
-    R_LIBS_USER: "%USERPROFILE%\\R\\library"
     APM_TEST_PACKAGES: "language-latex pdf-view"
   matrix:
     - ATOM_CHANNEL: stable

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,17 +10,19 @@ version: "{build}"
 os: Visual Studio 2015
 platform: x64
 
+build: off
 test: off
 deploy: off
 
 install:
-  - ps: Install-Product node ""
-  - choco install R.project
+  - ps: Install-Product node "5"
+  - choco install R.project --params="/DIR='C:\R'"
+  - set PATH="C:\R\bin;%PATH%"
 
 environment:
-  R_LIBS_USER: "$HOME/R/library"
-  APM_TEST_PACKAGES: "language-latex pdf-view"
-
+  global:
+    R_LIBS_USER: "$HOME/R/library"
+    APM_TEST_PACKAGES: "language-latex pdf-view"
   matrix:
     - ATOM_CHANNEL: stable
     - ATOM_CHANNEL: beta

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,6 +18,7 @@ install:
   - ps: Install-Product node "5"
   - choco install R.project --params="/DIR='C:\R'"
   - set PATH="C:\R\bin;%PATH%"
+  - echo %PATH%
 
 environment:
   global:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,10 +18,11 @@ install:
   - ps: Install-Product node "5"
   - choco install R.Project --ia="/DIR=C:\R"
   - set PATH=C:\R\bin;%PATH%
+  - set R_LIBS_USER=C:\projects\atom-latex\R\library
 
 environment:
   global:
-    R_LIBS_USER: "$HOME/R/library"
+    # R_LIBS_USER: "$HOME/R/library"
     APM_TEST_PACKAGES: "language-latex pdf-view"
   matrix:
     - ATOM_CHANNEL: stable

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,8 +16,8 @@ deploy: off
 
 install:
   - ps: Install-Product node "5"
-  - choco install R.project --ia="/DIR='C:\projects\atom-latex\R'" -y
-  - dir "C:\projects\atom-latex\R"
+  - choco install R.Project --ia="/DIR=C:\R" -y
+  - dir "C:\R"
   - dir "C:\Program Files\R"
   - set PATH=C:\R\bin;%PATH%
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,8 +16,10 @@ deploy: off
 
 install:
   - ps: Install-Product node "5"
+  - choco install -help
   - choco install R.project --params="/DIR='C:\R'" --verbose
-  - dir C:\R
+  - dir "C:\Program Files"
+  - dir "C:\Program Files\R\"
   - set PATH=C:\R\bin;%PATH%
 
 environment:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,13 +16,10 @@ deploy: off
 
 install:
   - ps: Install-Product node "5"
-  - choco install R.Project --ia="/DIR=C:\R"
-  - set PATH=C:\R\bin;%PATH%
-  - set R_LIBS_USER=C:\\projects\\atom-latex\\R\\library
 
 environment:
   global:
-    # R_LIBS_USER: "$HOME/R/library"
+    R_LIBS_USER: %USERPROFILE%\R\library
     APM_TEST_PACKAGES: "language-latex pdf-view"
   matrix:
     - ATOM_CHANNEL: stable

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,7 +18,7 @@ install:
   - ps: Install-Product node "5"
   - choco install R.Project --ia="/DIR=C:\R"
   - set PATH=C:\R\bin;%PATH%
-  - set R_LIBS_USER=C:\projects\atom-latex\R\library
+  - set R_LIBS_USER=C:/projects/atom-latex/R/library
 
 environment:
   global:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,7 +16,8 @@ deploy: off
 
 install:
   - ps: Install-Product node "5"
-  - choco install R.project --params="/DIR='C:\R'"
+  - choco install R.project --params="/DIR='C:\R'" --verbose
+  - dir C:\R
   - set PATH=C:\R\bin;%PATH%
 
 environment:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,7 +19,8 @@ install:
 
 environment:
   global:
-    R_LIBS_USER: C:/R/library"
+    R_HOME: '%PROGRAMFILES%\R'
+    R_LIBS_USER: '%USERPROFILE%\R\library'
     APM_TEST_PACKAGES: "language-latex pdf-view"
   matrix:
     - ATOM_CHANNEL: stable

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,10 +16,9 @@ deploy: off
 
 install:
   - ps: Install-Product node "5"
-  - choco install -help
-  - choco install R.project --params="/DIR='C:\R'" --verbose
-  - dir "C:\Program Files"
-  - dir "C:\Program Files\R\"
+  - choco install R.project --ia="/DIR='C:\R'" -n --verbose
+  - dir "C:\R"
+  - dir "C:\Program Files\R"
   - set PATH=C:\R\bin;%PATH%
 
 environment:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,6 +18,7 @@ install:
   - choco install R.project
 
 environment:
+  R_LIBS_USER: "$HOME/R/library"
   APM_TEST_PACKAGES: "language-latex pdf-view"
 
   matrix:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,8 +16,8 @@ deploy: off
 
 install:
   - ps: Install-Product node "5"
-  - choco install R.project --ia="/DIR='C:\R'" --verbose
-  - dir "C:\R"
+  - choco install R.project --ia="/DIR='C:\projects\atom-latex\R'" -y
+  - dir "C:\projects\atom-latex\R"
   - dir "C:\Program Files\R"
   - set PATH=C:\R\bin;%PATH%
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,8 +17,7 @@ deploy: off
 install:
   - ps: Install-Product node "5"
   - choco install R.project --params="/DIR='C:\R'"
-  - set PATH="C:\R\bin;%PATH%"
-  - echo %PATH%
+  - set PATH=C:\R\bin;%PATH%
 
 environment:
   global:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,7 +15,7 @@ test: off
 deploy: off
 
 install:
-  - ps: Install-Product node "5"
+  - ps: Install-Product node 5
 
 environment:
   global:
@@ -25,6 +25,9 @@ environment:
   matrix:
     - ATOM_CHANNEL: stable
     - ATOM_CHANNEL: beta
+
+cache:
+  - '%USERPROFILE%\R\library'
 
 build_script:
   - sh ./script/cibuild

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,6 +19,7 @@ install:
 
 environment:
   global:
+    R_LIBS_USER: C:/R/library"
     APM_TEST_PACKAGES: "language-latex pdf-view"
   matrix:
     - ATOM_CHANNEL: stable

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,7 +16,7 @@ deploy: off
 
 install:
   - ps: Install-Product node "5"
-  - choco install R.project --ia="/DIR='C:\R'" -n --verbose
+  - choco install R.project --ia="/DIR='C:\R'" --verbose
   - dir "C:\R"
   - dir "C:\Program Files\R"
   - set PATH=C:\R\bin;%PATH%

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,7 +19,7 @@ install:
 
 environment:
   global:
-    R_LIBS_USER: %USERPROFILE%\R\library
+    R_LIBS_USER: "%USERPROFILE%\\R\\library"
     APM_TEST_PACKAGES: "language-latex pdf-view"
   matrix:
     - ATOM_CHANNEL: stable

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,9 +16,7 @@ deploy: off
 
 install:
   - ps: Install-Product node "5"
-  - choco install R.Project --ia="/DIR=C:\R" -y
-  - dir "C:\R"
-  - dir "C:\Program Files\R"
+  - choco install R.Project --ia="/DIR=C:\R"
   - set PATH=C:\R\bin;%PATH%
 
 environment:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,7 +18,7 @@ install:
   - ps: Install-Product node "5"
   - choco install R.Project --ia="/DIR=C:\R"
   - set PATH=C:\R\bin;%PATH%
-  - set R_LIBS_USER=C:/projects/atom-latex/R/library
+  - set R_LIBS_USER=C:\\projects\\atom-latex\\R\\library
 
 environment:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
+notifications:
+  email:
+    on_success: never
+    on_failure: change
+
 branches:
   only:
     - master
@@ -11,32 +16,27 @@ os:
   - linux
   - osx
 
+env:
+  global:
+    - R_LIBS_USER=$HOME/R/library
+    - APM_TEST_PACKAGES="language-latex pdf-view"
+  matrix:
+    - ATOM_CHANNEL=stable
+    - ATOM_CHANNEL=beta
+
 addons:
   apt:
     sources:
       - r-packages-precise
     packages:
-    - build-essential
-    - fakeroot
-    - git
-    - libgnome-keyring-dev
-    - r-recommended
-
-env:
-  global:
-    - APM_TEST_PACKAGES="language-latex pdf-view"
-    - R_LIBS_USER=$HOME/R/library
-  matrix:
-    - ATOM_CHANNEL=stable
-    - ATOM_CHANNEL=beta
+      - build-essential
+      - fakeroot
+      - git
+      - libgnome-keyring-dev
+      - r-recommended
 
 cache:
   directories:
     - $R_LIBS_USER
-
-notifications:
-  email:
-    on_success: never
-    on_failure: change
 
 script: ./script/cibuild

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,14 @@ os:
 
 addons:
   apt:
+    sources:
+      - r-packages-precise
     packages:
     - build-essential
+    - fakeroot
     - git
     - libgnome-keyring-dev
-    - fakeroot
+    - r-recommended
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,10 @@ env:
     - ATOM_CHANNEL=stable
     - ATOM_CHANNEL=beta
 
+cache:
+  directories:
+    - $R_LIBS_USER
+
 notifications:
   email:
     on_success: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ addons:
 env:
   global:
     - APM_TEST_PACKAGES="language-latex pdf-view"
-
+    - R_LIBS_USER=$HOME/R/library
   matrix:
     - ATOM_CHANNEL=stable
     - ATOM_CHANNEL=beta

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,15 @@
-notifications:
-  email:
-    on_success: never
-    on_failure: change
-
 branches:
   only:
     - master
 
 git:
-  depth: 10
-
-sudo: false
+  depth: 1
 
 os:
   - linux
   - osx
+
+sudo: false
 
 env:
   global:
@@ -29,10 +24,6 @@ addons:
     sources:
       - r-packages-precise
     packages:
-      - build-essential
-      - fakeroot
-      - git
-      - libgnome-keyring-dev
       - r-recommended
 
 cache:
@@ -40,3 +31,8 @@ cache:
     - ${R_LIBS_USER}
 
 script: ./script/cibuild
+
+notifications:
+  email:
+    on_success: never
+    on_failure: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ os:
 
 env:
   global:
-    - R_LIBS_USER=$HOME/R/library
     - APM_TEST_PACKAGES="language-latex pdf-view"
   matrix:
     - ATOM_CHANNEL=stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ os:
 
 env:
   global:
+    - R_LIBS_USER=${HOME}/R/library
     - APM_TEST_PACKAGES="language-latex pdf-view"
   matrix:
     - ATOM_CHANNEL=stable
@@ -36,6 +37,6 @@ addons:
 
 cache:
   directories:
-    - $R_LIBS_USER
+    - ${R_LIBS_USER}
 
 script: ./script/cibuild

--- a/lib/builders/knitr.js
+++ b/lib/builders/knitr.js
@@ -54,7 +54,6 @@ export default class KnitrBuilder extends Builder {
   }
 
   resolveOutputPath (sourcePath, stdout) {
-    // TODO: Make this more robust.
     const candidatePath = OUTPUT_PATH_PATTERN.exec(stdout)[1]
     if (path.isAbsolute(candidatePath)) {
       return candidatePath

--- a/lib/builders/knitr.js
+++ b/lib/builders/knitr.js
@@ -1,0 +1,40 @@
+'use babel'
+
+import childProcess from 'child_process'
+import path from 'path'
+import Builder from '../builder'
+
+export default class KnitrBuilder extends Builder {
+  constructor () {
+    super()
+    this.executable = 'Rscript'
+  }
+
+  static canProcess (filePath) {
+    return path.extname(filePath) === '.Rnw'
+  }
+
+  run (filePath) {
+    const args = this.constructArgs(filePath)
+    const command = `${this.executable} ${args.join(' ')}`
+    const options = this.constructChildProcessOptions()
+
+    return new Promise((resolve) => {
+      childProcess.exec(command, options, (error) => {
+        // TODO: Parse output to detect missing 'knitr' library.
+        // TODO: Parse output to get the path to the resulting .tex file.
+        // TODO: Execute default builder on resulting .tex file.
+        resolve((error) ? error.code : 0)
+      })
+    })
+  }
+
+  constructArgs (filePath) {
+    const args = [
+      '--default-packages=knitr',
+      `-e "knit('${filePath}')"`
+    ]
+
+    return args
+  }
+}

--- a/lib/builders/knitr.js
+++ b/lib/builders/knitr.js
@@ -3,9 +3,15 @@
 import childProcess from 'child_process'
 import path from 'path'
 import Builder from '../builder'
+import BuilderRegistry from '../builder-registry'
 
 export default class KnitrBuilder extends Builder {
   executable = 'Rscript'
+
+  constructor () {
+    super()
+    this.builderRegistry = new BuilderRegistry()
+  }
 
   static canProcess (filePath) {
     return path.extname(filePath) === '.Rnw'
@@ -17,11 +23,17 @@ export default class KnitrBuilder extends Builder {
     const options = this.constructChildProcessOptions()
 
     return new Promise((resolve) => {
-      childProcess.exec(command, options, (error) => {
-        // TODO: Parse output to detect missing 'knitr' library.
-        // TODO: Parse output to get the path to the resulting .tex file.
-        // TODO: Execute default builder on resulting .tex file.
-        resolve((error) ? error.code : 0)
+      childProcess.exec(command, options, (error, stdout, stderr) => {
+        if (error) {
+          // TODO: Parse output to detect missing 'knitr' library.
+          resolve(error.code)
+        }
+
+        // TODO: Make this more robust.
+        const texFilePath = /\[1\]\s+"(.*)"/.exec(stdout)[1]
+
+        const builder = this.getResultBuilder(texFilePath)
+        builder.run(texFilePath).then((code) => resolve(code))
       })
     })
   }
@@ -39,5 +51,11 @@ export default class KnitrBuilder extends Builder {
   resolveOutputPath (filePath) {
     // TODO: Add support for `latex.outputDirectory`.
     return filePath.replace(/\.Rnw$/, '.tex')
+  }
+
+  // TODO: Move into base class, or perhaps introduce some new build pipeline concept?
+  getResultBuilder (filePath) {
+    const BuilderImpl = this.builderRegistry.getBuilder(filePath)
+    return new BuilderImpl()
   }
 }

--- a/lib/builders/knitr.js
+++ b/lib/builders/knitr.js
@@ -20,14 +20,14 @@ export default class KnitrBuilder extends Builder {
   run (filePath) {
     const args = this.constructArgs(filePath)
     const command = `${this.executable} ${args.join(' ')}`
-    const options = this.constructChildProcessOptions()
+    const options = this.constructChildProcessOptions(filePath)
 
     return new Promise((resolve) => {
       childProcess.exec(command, options, (error, stdout, stderr) => {
         if (error) {
           // Parse error message to detect missing 'knitr' library.
           if (stderr.match(/there is no package called ‘knitr’/)) {
-            latex.log.error("Knitr package missing")
+            latex.log.error('Knitr package missing')
             return resolve(-1)
           }
 
@@ -35,7 +35,7 @@ export default class KnitrBuilder extends Builder {
         }
 
         // TODO: Make this more robust.
-        const texFilePath = /\[1\]\s+"(.*)"/.exec(stdout)[1]
+        const texFilePath = this.resolveOutputPath(filePath, stdout)
         const builder = this.getResultBuilder(texFilePath)
         return builder.run(texFilePath).then((code) => resolve(code))
       })
@@ -43,18 +43,22 @@ export default class KnitrBuilder extends Builder {
   }
 
   constructArgs (filePath) {
-    const outputFilePath = this.resolveOutputPath(filePath)
     const args = [
       '--default-packages=knitr',
-      `-e "knit('${filePath}', '${outputFilePath}')"`
+      `-e "knit('${filePath}')"`
     ]
 
     return args
   }
 
-  resolveOutputPath (filePath) {
-    // TODO: Add support for `latex.outputDirectory`.
-    return filePath.replace(/\.Rnw$/, '.tex')
+  resolveOutputPath (sourcePath, stdout) {
+    const candidatePath = /\[1\]\s+"(.*)"/.exec(stdout)[1]
+    if (path.isAbsolute(candidatePath)) {
+      return candidatePath
+    }
+
+    const sourceDir = path.dirname(sourcePath)
+    return path.join(sourceDir, candidatePath)
   }
 
   // TODO: Move into base class, or perhaps introduce some new build pipeline concept?

--- a/lib/builders/knitr.js
+++ b/lib/builders/knitr.js
@@ -5,10 +5,7 @@ import path from 'path'
 import Builder from '../builder'
 
 export default class KnitrBuilder extends Builder {
-  constructor () {
-    super()
-    this.executable = 'Rscript'
-  }
+  executable = 'Rscript'
 
   static canProcess (filePath) {
     return path.extname(filePath) === '.Rnw'

--- a/lib/builders/knitr.js
+++ b/lib/builders/knitr.js
@@ -25,7 +25,12 @@ export default class KnitrBuilder extends Builder {
     return new Promise((resolve) => {
       childProcess.exec(command, options, (error, stdout, stderr) => {
         if (error) {
-          // TODO: Parse output to detect missing 'knitr' library.
+          // Parse error message to detect missing 'knitr' library.
+          if (stderr.match(/there is no package called ‘knitr’/)) {
+            latex.log.error("Knitr package missing")
+            return resolve(-1)
+          }
+
           return resolve(error.code)
         }
 

--- a/lib/builders/knitr.js
+++ b/lib/builders/knitr.js
@@ -30,11 +30,17 @@ export default class KnitrBuilder extends Builder {
   }
 
   constructArgs (filePath) {
+    const outputFilePath = this.resolveOutputPath(filePath)
     const args = [
       '--default-packages=knitr',
-      `-e "knit('${filePath}')"`
+      `-e "knit('${filePath}', '${outputFilePath}')"`
     ]
 
     return args
+  }
+
+  resolveOutputPath (filePath) {
+    // TODO: Add support for `latex.outputDirectory`.
+    return filePath.replace(/\.Rnw$/, '.tex')
   }
 }

--- a/lib/builders/knitr.js
+++ b/lib/builders/knitr.js
@@ -5,6 +5,9 @@ import path from 'path'
 import Builder from '../builder'
 import BuilderRegistry from '../builder-registry'
 
+const MISSING_PACKAGE_PATTERN = /there is no package called ‘knitr’/
+const OUTPUT_PATH_PATTERN = /\[\d+\]\s+"(.*)"/
+
 export default class KnitrBuilder extends Builder {
   executable = 'Rscript'
 
@@ -26,7 +29,7 @@ export default class KnitrBuilder extends Builder {
       childProcess.exec(command, options, (error, stdout, stderr) => {
         if (error) {
           // Parse error message to detect missing 'knitr' library.
-          if (stderr.match(/there is no package called ‘knitr’/)) {
+          if (stderr.match(MISSING_PACKAGE_PATTERN)) {
             latex.log.error('Knitr package missing')
             return resolve(-1)
           }
@@ -34,7 +37,6 @@ export default class KnitrBuilder extends Builder {
           return resolve(error.code)
         }
 
-        // TODO: Make this more robust.
         const texFilePath = this.resolveOutputPath(filePath, stdout)
         const builder = this.getResultBuilder(texFilePath)
         return builder.run(texFilePath).then((code) => resolve(code))
@@ -52,7 +54,8 @@ export default class KnitrBuilder extends Builder {
   }
 
   resolveOutputPath (sourcePath, stdout) {
-    const candidatePath = /\[1\]\s+"(.*)"/.exec(stdout)[1]
+    // TODO: Make this more robust.
+    const candidatePath = OUTPUT_PATH_PATTERN.exec(stdout)[1]
     if (path.isAbsolute(candidatePath)) {
       return candidatePath
     }

--- a/lib/builders/knitr.js
+++ b/lib/builders/knitr.js
@@ -26,14 +26,13 @@ export default class KnitrBuilder extends Builder {
       childProcess.exec(command, options, (error, stdout, stderr) => {
         if (error) {
           // TODO: Parse output to detect missing 'knitr' library.
-          resolve(error.code)
+          return resolve(error.code)
         }
 
         // TODO: Make this more robust.
         const texFilePath = /\[1\]\s+"(.*)"/.exec(stdout)[1]
-
         const builder = this.getResultBuilder(texFilePath)
-        builder.run(texFilePath).then((code) => resolve(code))
+        return builder.run(texFilePath).then((code) => resolve(code))
       })
     })
   }

--- a/lib/builders/knitr.js
+++ b/lib/builders/knitr.js
@@ -30,7 +30,7 @@ export default class KnitrBuilder extends Builder {
         if (error) {
           // Parse error message to detect missing 'knitr' library.
           if (stderr.match(MISSING_PACKAGE_PATTERN)) {
-            latex.log.error('Knitr package missing')
+            latex.log.error('The R package "knitr" could not be loaded.')
             return resolve(-1)
           }
 

--- a/lib/builders/knitr.js
+++ b/lib/builders/knitr.js
@@ -25,8 +25,6 @@ export default class KnitrBuilder extends Builder {
     const command = `${this.executable} ${args.join(' ')}`
     const options = this.constructChildProcessOptions(filePath)
 
-    console.log(process.env.PATH)
-
     return new Promise((resolve) => {
       childProcess.exec(command, options, (error, stdout, stderr) => {
         if (error) {
@@ -53,7 +51,7 @@ export default class KnitrBuilder extends Builder {
   constructArgs (filePath) {
     const args = [
       '--default-packages=knitr',
-      `-e "knit('${filePath}')"`
+      `-e "knit('${filePath.replace(/\\/g, '\\\\')}')"`
     ]
 
     return args

--- a/lib/builders/knitr.js
+++ b/lib/builders/knitr.js
@@ -5,7 +5,7 @@ import path from 'path'
 import Builder from '../builder'
 import BuilderRegistry from '../builder-registry'
 
-const MISSING_PACKAGE_PATTERN = /there is no package called ‘knitr’/
+const MISSING_PACKAGE_PATTERN = /there is no package called 'knitr'/
 const OUTPUT_PATH_PATTERN = /\[\d+\]\s+"(.*)"/
 
 export default class KnitrBuilder extends Builder {
@@ -33,10 +33,6 @@ export default class KnitrBuilder extends Builder {
             latex.log.error('Knitr package missing')
             return resolve(-1)
           }
-
-          console.error(error.message)
-          console.error(stderr)
-          console.error(stdout)
 
           return resolve(error.code)
         }

--- a/lib/builders/knitr.js
+++ b/lib/builders/knitr.js
@@ -5,7 +5,7 @@ import path from 'path'
 import Builder from '../builder'
 import BuilderRegistry from '../builder-registry'
 
-const MISSING_PACKAGE_PATTERN = /there is no package called 'knitr'/
+const MISSING_PACKAGE_PATTERN = /there is no package called .knitr./
 const OUTPUT_PATH_PATTERN = /\[\d+\]\s+"(.*)"/
 
 export default class KnitrBuilder extends Builder {

--- a/lib/builders/knitr.js
+++ b/lib/builders/knitr.js
@@ -46,7 +46,7 @@ export default class KnitrBuilder extends Builder {
 
   constructArgs (filePath) {
     const args = [
-      '--default-packages=knitr',
+      '-e "library(knitr)"',
       `-e "knit('${filePath.replace(/\\/g, '\\\\')}')"`
     ]
 

--- a/lib/builders/knitr.js
+++ b/lib/builders/knitr.js
@@ -1,4 +1,4 @@
-'use babel'
+/** @babel */
 
 import childProcess from 'child_process'
 import path from 'path'

--- a/lib/builders/knitr.js
+++ b/lib/builders/knitr.js
@@ -25,6 +25,8 @@ export default class KnitrBuilder extends Builder {
     const command = `${this.executable} ${args.join(' ')}`
     const options = this.constructChildProcessOptions(filePath)
 
+    console.log(process.env.PATH)
+
     return new Promise((resolve) => {
       childProcess.exec(command, options, (error, stdout, stderr) => {
         if (error) {
@@ -33,6 +35,10 @@ export default class KnitrBuilder extends Builder {
             latex.log.error('Knitr package missing')
             return resolve(-1)
           }
+
+          console.error(error.message)
+          console.error(stderr)
+          console.error(stdout)
 
           return resolve(error.code)
         }

--- a/script/cibuild
+++ b/script/cibuild
@@ -26,6 +26,7 @@ exec_ci() {
 main() {
   import_dependencies
   install_texlive
+  install_knitr
   exec_ci
 }
 

--- a/script/cibuild
+++ b/script/cibuild
@@ -8,7 +8,7 @@ shopt -s nocasematch
 
 import_dependencies() {
   local script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd -P )"
-  local scripts=(install-texlive)
+  local scripts=(install-texlive install-knitr)
 
   source "${script_dir}/${scripts[*]}"
 }

--- a/script/cibuild
+++ b/script/cibuild
@@ -10,7 +10,9 @@ import_dependencies() {
   local script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd -P )"
   local scripts=(install-texlive install-knitr)
 
-  source "${script_dir}/${scripts[*]}"
+  for script in ${scripts[@]}; do
+    source "${script_dir}/${script}"
+  done
 }
 
 exec_ci() {

--- a/script/install-knitr
+++ b/script/install-knitr
@@ -11,5 +11,10 @@ if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
   brew install r
 fi
 
-echo "Installing Knitr..."
-Rscript -e "install.packages('knitr', '$R_LIBS_USER', 'http://cran.us.r-project.org')"
+# Check if we need to install Knitr.
+if [[ ! -d "$R_LIBS_USER" ]]; then
+  echo "Installing Knitr..."
+  Rscript -e "install.packages('knitr', '$R_LIBS_USER', 'http://cran.us.r-project.org')"
+else
+  echo "Using cached installation of Knitr"
+fi

--- a/script/install-knitr
+++ b/script/install-knitr
@@ -12,7 +12,7 @@ if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
 fi
 
 # Check if we need to install Knitr.
-if [[ ! -d "$R_LIBS_USER" ]]; then
+if ! Rscript -e "library(knitr)" &> /dev/null; then
   echo "Installing Knitr..."
   Rscript -e "install.packages('knitr', '$R_LIBS_USER', 'http://cran.us.r-project.org')"
 else

--- a/script/install-knitr
+++ b/script/install-knitr
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Exit on failure, and treat expansion of unset variables as an error.
+set -eu
+
+# Ensure R is installed.
+if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+  echo "Installing R..."
+  brew update
+  brew tap homebrew/science
+  brew install r
+fi
+
+# Set R_LIBS_USER to a path that is user-writable to avoid the need for sudo.
+export R_LIBS_USER="$HOME/R/library"
+mkdir -m 777 -p $R_LIBS_USER
+
+echo "Installing Knitr..."
+Rscript -e "install.packages('knitr', '$R_LIBS_USER', 'http://cran.us.r-project.org')"

--- a/script/install-knitr
+++ b/script/install-knitr
@@ -11,9 +11,5 @@ if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
   brew install r
 fi
 
-# Set R_LIBS_USER to a path that is user-writable to avoid the need for sudo.
-export R_LIBS_USER="$HOME/R/library"
-mkdir -m 777 -p $R_LIBS_USER
-
 echo "Installing Knitr..."
 Rscript -e "install.packages('knitr', '$R_LIBS_USER', 'http://cran.us.r-project.org')"

--- a/script/install-knitr
+++ b/script/install-knitr
@@ -8,10 +8,8 @@ shopt -s nocasematch
 
 ensure_r_installed() {
   if [[ "${APPVEYOR:-}" == true ]]; then
-    echo ${R_HOME}
     echo "Installing R..."
     choco install R.Project --ia="/DIR=\"${R_HOME}\""
-    ls "${R_HOME}"
 
     export PATH="${R_HOME}/bin:${PATH}"
   elif [[ "${TRAVIS_OS_NAME:-}" == "osx" ]]; then

--- a/script/install-knitr
+++ b/script/install-knitr
@@ -24,8 +24,6 @@ ensure_r_installed() {
 install_knitr() {
   ensure_r_installed
 
-  export R_LIBS_USER="${HOME}/R/library"
-
   # Check if we need to install Knitr.
   if ! Rscript -e "library(knitr)" &> /dev/null; then
     echo "Installing Knitr..."

--- a/script/install-knitr
+++ b/script/install-knitr
@@ -8,8 +8,10 @@ shopt -s nocasematch
 
 ensure_r_installed() {
   if [[ "${APPVEYOR:-}" == true ]]; then
+    echo ${R_HOME}
     echo "Installing R..."
     choco install R.Project --ia="/DIR=${R_HOME}"
+    ls ${R_HOME}
 
     export PATH="${R_HOME}/bin:${PATH}"
   elif [[ "${TRAVIS_OS_NAME:-}" == "osx" ]]; then

--- a/script/install-knitr
+++ b/script/install-knitr
@@ -28,9 +28,9 @@ install_knitr() {
     # Make sure the R_LIBS_USER directory exists to make R happy.
     [[ ! -d "${R_LIBS_USER}" ]] && mkdir -p "${R_LIBS_USER}"
 
-    echo "Installing Knitr..."
+    echo "Installing knitr..."
     Rscript -e "install.packages('knitr', repos = 'http://cran.us.r-project.org')"
   else
-    echo "Using cached installation of Knitr"
+    echo "Using cached installation of knitr"
   fi
 }

--- a/script/install-knitr
+++ b/script/install-knitr
@@ -13,6 +13,8 @@ ensure_r_installed() {
 }
 
 install_knitr() {
+  ensure_r_installed
+
   # Check if we need to install Knitr.
   if ! Rscript -e "library(knitr)" &> /dev/null; then
     echo "Installing Knitr..."

--- a/script/install-knitr
+++ b/script/install-knitr
@@ -3,18 +3,21 @@
 # Exit on failure, and treat expansion of unset variables as an error.
 set -eu
 
-# Ensure R is installed.
-if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-  echo "Installing R..."
-  brew update
-  brew tap homebrew/science
-  brew install r
-fi
+ensure_r_installed() {
+  if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
+    echo "Installing R..."
+    brew update
+    brew tap homebrew/science
+    brew install r
+  fi
+}
 
-# Check if we need to install Knitr.
-if ! Rscript -e "library(knitr)" &> /dev/null; then
-  echo "Installing Knitr..."
-  Rscript -e "install.packages('knitr', '$R_LIBS_USER', 'http://cran.us.r-project.org')"
-else
-  echo "Using cached installation of Knitr"
-fi
+install_knitr() {
+  # Check if we need to install Knitr.
+  if ! Rscript -e "library(knitr)" &> /dev/null; then
+    echo "Installing Knitr..."
+    Rscript -e "install.packages('knitr', '${R_LIBS_USER}', 'http://cran.us.r-project.org')"
+  else
+    echo "Using cached installation of Knitr"
+  fi
+}

--- a/script/install-knitr
+++ b/script/install-knitr
@@ -3,8 +3,17 @@
 # Exit on failure, and treat expansion of unset variables as an error.
 set -eu
 
+# Enable case-insensitive pattern matching.
+shopt -s nocasematch
+
 ensure_r_installed() {
-  if [[ "${TRAVIS_OS_NAME:-}" == "osx" ]]; then
+  if [[ "${APPVEYOR}" == true ]]; then
+    echo "Installing R..."
+    local r_root="C:\\R"
+    choco install R.Project --ia="/DIR=${r_root}"
+
+    export PATH="${r_root}/bin:${PATH}"
+  elif [[ "${TRAVIS_OS_NAME:-}" == "osx" ]]; then
     echo "Installing R..."
     brew update
     brew tap homebrew/science

--- a/script/install-knitr
+++ b/script/install-knitr
@@ -9,10 +9,9 @@ shopt -s nocasematch
 ensure_r_installed() {
   if [[ "${APPVEYOR}" == true ]]; then
     echo "Installing R..."
-    local r_root="C:\\R"
-    choco install R.Project --ia="/DIR=${r_root}"
+    choco install R.Project --ia="/DIR=${R_HOME}"
 
-    export PATH="${r_root}/bin:${PATH}"
+    export PATH="${R_HOME}/bin:${PATH}"
   elif [[ "${TRAVIS_OS_NAME:-}" == "osx" ]]; then
     echo "Installing R..."
     brew update
@@ -26,9 +25,11 @@ install_knitr() {
 
   # Check if we need to install Knitr.
   if ! Rscript -e "library(knitr)" &> /dev/null; then
-    echo "Installing Knitr..."
+    # Make sure the R_LIBS_USER directory exists to make R happy.
     [[ ! -d "${R_LIBS_USER}" ]] && mkdir -p "${R_LIBS_USER}"
-    Rscript -e "install.packages('knitr', '${R_LIBS_USER}', 'http://cran.us.r-project.org')"
+
+    echo "Installing Knitr..."
+    Rscript -e "install.packages('knitr', repos = 'http://cran.us.r-project.org')"
   else
     echo "Using cached installation of Knitr"
   fi

--- a/script/install-knitr
+++ b/script/install-knitr
@@ -11,7 +11,7 @@ ensure_r_installed() {
     echo ${R_HOME}
     echo "Installing R..."
     choco install R.Project --ia="/DIR=${R_HOME}"
-    ls ${R_HOME}
+    ls "${R_HOME}"
 
     export PATH="${R_HOME}/bin:${PATH}"
   elif [[ "${TRAVIS_OS_NAME:-}" == "osx" ]]; then

--- a/script/install-knitr
+++ b/script/install-knitr
@@ -10,7 +10,7 @@ ensure_r_installed() {
   if [[ "${APPVEYOR:-}" == true ]]; then
     echo ${R_HOME}
     echo "Installing R..."
-    choco install R.Project --ia="/DIR=${R_HOME}"
+    choco install R.Project --ia="/DIR=\"${R_HOME}\""
     ls "${R_HOME}"
 
     export PATH="${R_HOME}/bin:${PATH}"

--- a/script/install-knitr
+++ b/script/install-knitr
@@ -24,6 +24,8 @@ ensure_r_installed() {
 install_knitr() {
   ensure_r_installed
 
+  export R_LIBS_USER="${HOME}/R/library"
+
   # Check if we need to install Knitr.
   if ! Rscript -e "library(knitr)" &> /dev/null; then
     echo "Installing Knitr..."

--- a/script/install-knitr
+++ b/script/install-knitr
@@ -7,7 +7,7 @@ set -eu
 shopt -s nocasematch
 
 ensure_r_installed() {
-  if [[ "${APPVEYOR}" == true ]]; then
+  if [[ "${APPVEYOR:-}" == true ]]; then
     echo "Installing R..."
     choco install R.Project --ia="/DIR=${R_HOME}"
 

--- a/script/install-knitr
+++ b/script/install-knitr
@@ -4,7 +4,7 @@
 set -eu
 
 ensure_r_installed() {
-  if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
+  if [[ "${TRAVIS_OS_NAME:-}" == "osx" ]]; then
     echo "Installing R..."
     brew update
     brew tap homebrew/science

--- a/script/install-knitr
+++ b/script/install-knitr
@@ -18,6 +18,7 @@ install_knitr() {
   # Check if we need to install Knitr.
   if ! Rscript -e "library(knitr)" &> /dev/null; then
     echo "Installing Knitr..."
+    [[ ! -d "${R_LIBS_USER}" ]] && mkdir -p "${R_LIBS_USER}"
     Rscript -e "install.packages('knitr', '${R_LIBS_USER}', 'http://cran.us.r-project.org')"
   else
     echo "Using cached installation of Knitr"

--- a/spec/build-registry-spec.js
+++ b/spec/build-registry-spec.js
@@ -40,6 +40,11 @@ describe('BuilderRegistry', () => {
       const filePath = path.join(fixturesPath, 'magic-comments', 'latex-builder.tex')
       expect(registry.getBuilder(filePath).name).toEqual('TexifyBuilder')
     })
+
+    it('returns the Knitr builder when presented with an .Rnw file', () => {
+      const filePath = path.join('foo', 'bar.Rnw')
+      expect(registry.getBuilder(filePath).name).toEqual('KnitrBuilder')
+    })
   })
 
   describe('getBuilderFromMagic', () => {

--- a/spec/builders/knitr-spec.js
+++ b/spec/builders/knitr-spec.js
@@ -1,6 +1,7 @@
 'use babel'
 
 import helpers from '../spec-helpers'
+import _ from 'lodash'
 import fs from 'fs-plus'
 import path from 'path'
 import KnitrBuilder from '../../lib/builders/knitr'
@@ -58,6 +59,22 @@ describe('KnitrBuilder', () => {
 
       runs(() => {
         expect(exitCode).toBe(1)
+      })
+    })
+
+    it('detects missing knitr library and logs an error', () => {
+      const env = { 'R_LIBS_USER': '/dev/null', 'R_LIBS_SITE': '/dev/null' }
+      const options = _.merge(builder.constructChildProcessOptions(filePath), { env })
+      spyOn(builder, 'constructChildProcessOptions').andReturn(options)
+      spyOn(latex.log, 'error').andCallThrough()
+
+      waitsForPromise(() => {
+        return builder.run(filePath).then(code => { exitCode = code })
+      })
+
+      runs(() => {
+        expect(exitCode).toBe(-1)
+        expect(latex.log.error).toHaveBeenCalled()
       })
     })
   })

--- a/spec/builders/knitr-spec.js
+++ b/spec/builders/knitr-spec.js
@@ -10,7 +10,7 @@ function getRawFile (filePath) {
 }
 
 describe('KnitrBuilder', () => {
-  let builder, fixturesPath, filePath
+  let builder, fixturesPath, filePath, outputFilePath
 
   beforeEach(() => {
     builder = new KnitrBuilder()

--- a/spec/builders/knitr-spec.js
+++ b/spec/builders/knitr-spec.js
@@ -16,13 +16,14 @@ describe('KnitrBuilder', () => {
     builder = new KnitrBuilder()
     fixturesPath = helpers.cloneFixtures()
     filePath = path.join(fixturesPath, 'knitr', 'file.Rnw')
+    outputFilePath = path.join(fixturesPath, 'knitr', 'file.tex')
   })
 
   describe('constructArgs', () => {
     it('produces default arguments containing expected file path', () => {
       const expectedArgs = [
         '--default-packages=knitr',
-        `-e "knit('${filePath}')"`
+        `-e "knit('${filePath}', '${outputFilePath}')"`
       ]
 
       const args = builder.constructArgs(filePath)
@@ -40,9 +41,7 @@ describe('KnitrBuilder', () => {
 
       runs(() => {
         expect(exitCode).toBe(0)
-
-        const rawFile = getRawFile(filePath.replace('.Rnw', '.tex'))
-        expect(rawFile).toContain('$\\tau \\approx 6.2831853$')
+        expect(getRawFile(outputFilePath)).toContain('$\\tau \\approx 6.2831853$')
       })
     })
 

--- a/spec/builders/knitr-spec.js
+++ b/spec/builders/knitr-spec.js
@@ -11,20 +11,19 @@ function getRawFile (filePath) {
 }
 
 describe('KnitrBuilder', () => {
-  let builder, fixturesPath, filePath, outputFilePath
+  let builder, fixturesPath, filePath
 
   beforeEach(() => {
     builder = new KnitrBuilder()
     fixturesPath = helpers.cloneFixtures()
     filePath = path.join(fixturesPath, 'knitr', 'file.Rnw')
-    outputFilePath = path.join(fixturesPath, 'knitr', 'file.tex')
   })
 
   describe('constructArgs', () => {
     it('produces default arguments containing expected file path', () => {
       const expectedArgs = [
         '--default-packages=knitr',
-        `-e "knit('${filePath}', '${outputFilePath}')"`
+        `-e "knit('${filePath}')"`
       ]
 
       const args = builder.constructArgs(filePath)
@@ -45,6 +44,8 @@ describe('KnitrBuilder', () => {
       })
 
       runs(() => {
+        const outputFilePath = path.join(fixturesPath, 'knitr', 'file.tex')
+
         expect(exitCode).toBe(0)
         expect(getRawFile(outputFilePath)).toContain('$\\tau \\approx 6.2831853$')
       })

--- a/spec/builders/knitr-spec.js
+++ b/spec/builders/knitr-spec.js
@@ -79,4 +79,27 @@ describe('KnitrBuilder', () => {
       })
     })
   })
+
+  describe('resolveOutputPath', () => {
+    let sourcePath, resultPath
+
+    beforeEach(() => {
+      sourcePath = '/var/foo.Rnw'
+      resultPath = '/var/foo.tex'
+    })
+
+    it('detects an absolute path and returns it unchanged', () => {
+      const stdout = `foo\nbar\n\n[1] "${resultPath}"`
+      const resolvedPath = builder.resolveOutputPath(sourcePath, stdout)
+
+      expect(resolvedPath).toBe(resultPath)
+    })
+
+    it('detects a relative path and makes it absolute with respect to the source file', () => {
+      const stdout = `foo\nbar\n\n[1] "${path.basename(resultPath)}"`
+      const resolvedPath = builder.resolveOutputPath(sourcePath, stdout)
+
+      expect(resolvedPath).toBe(resultPath)
+    })
+  })
 })

--- a/spec/builders/knitr-spec.js
+++ b/spec/builders/knitr-spec.js
@@ -1,0 +1,61 @@
+'use babel'
+
+import helpers from '../spec-helpers'
+import fs from 'fs-plus'
+import path from 'path'
+import KnitrBuilder from '../../lib/builders/knitr'
+
+function getRawFile (filePath) {
+  return fs.readFileSync(filePath, {encoding: 'utf-8'})
+}
+
+describe('KnitrBuilder', () => {
+  let builder, fixturesPath, filePath
+
+  beforeEach(() => {
+    builder = new KnitrBuilder()
+    fixturesPath = helpers.cloneFixtures()
+    filePath = path.join(fixturesPath, 'knitr', 'file.Rnw')
+  })
+
+  describe('constructArgs', () => {
+    it('produces default arguments containing expected file path', () => {
+      const expectedArgs = [
+        '--default-packages=knitr',
+        `-e "knit('${filePath}')"`
+      ]
+
+      const args = builder.constructArgs(filePath)
+      expect(args).toEqual(expectedArgs)
+    })
+  })
+
+  describe('run', () => {
+    let exitCode
+
+    it('successfully executes Knitr when given a valid R Sweave file', () => {
+      waitsForPromise(() => {
+        return builder.run(filePath).then(code => { exitCode = code })
+      })
+
+      runs(() => {
+        expect(exitCode).toBe(0)
+
+        const rawFile = getRawFile(filePath.replace('.Rnw', '.tex'))
+        expect(rawFile).toContain('$\\tau \\approx 6.2831853$')
+      })
+    })
+
+    it('fails to execute Knitr when given an invalid file path', () => {
+      filePath = path.join(fixturesPath, 'foo.tex')
+
+      waitsForPromise(() => {
+        return builder.run(filePath).then(code => { exitCode = code })
+      })
+
+      runs(() => {
+        expect(exitCode).toBe(1)
+      })
+    })
+  })
+})

--- a/spec/builders/knitr-spec.js
+++ b/spec/builders/knitr-spec.js
@@ -34,6 +34,10 @@ describe('KnitrBuilder', () => {
   describe('run', () => {
     let exitCode
 
+    beforeEach(() => {
+      atom.config.set('latex.builder', 'latexmk')
+    })
+
     it('successfully executes Knitr when given a valid R Sweave file', () => {
       waitsForPromise(() => {
         return builder.run(filePath).then(code => { exitCode = code })

--- a/spec/builders/knitr-spec.js
+++ b/spec/builders/knitr-spec.js
@@ -23,7 +23,7 @@ describe('KnitrBuilder', () => {
     it('produces default arguments containing expected file path', () => {
       const expectedArgs = [
         '--default-packages=knitr',
-        `-e "knit('${filePath}')"`
+        `-e "knit('${filePath.replace(/\\/g, '\\\\')}')"`
       ]
 
       const args = builder.constructArgs(filePath)
@@ -52,7 +52,7 @@ describe('KnitrBuilder', () => {
     })
 
     it('fails to execute Knitr when given an invalid file path', () => {
-      filePath = path.join(fixturesPath, 'foo.tex')
+      filePath = path.join(fixturesPath, 'foo.Rnw')
 
       waitsForPromise(() => {
         return builder.run(filePath).then(code => { exitCode = code })
@@ -84,8 +84,8 @@ describe('KnitrBuilder', () => {
     let sourcePath, resultPath
 
     beforeEach(() => {
-      sourcePath = '/var/foo.Rnw'
-      resultPath = '/var/foo.tex'
+      sourcePath = path.resolve('/var/foo.Rnw')
+      resultPath = path.resolve('/var/foo.tex')
     })
 
     it('detects an absolute path and returns it unchanged', () => {

--- a/spec/builders/knitr-spec.js
+++ b/spec/builders/knitr-spec.js
@@ -22,7 +22,7 @@ describe('KnitrBuilder', () => {
   describe('constructArgs', () => {
     it('produces default arguments containing expected file path', () => {
       const expectedArgs = [
-        '--default-packages=knitr',
+        '-e "library(knitr)"',
         `-e "knit('${filePath.replace(/\\/g, '\\\\')}')"`
       ]
 

--- a/spec/builders/knitr-spec.js
+++ b/spec/builders/knitr-spec.js
@@ -38,7 +38,7 @@ describe('KnitrBuilder', () => {
       atom.config.set('latex.builder', 'latexmk')
     })
 
-    it('successfully executes Knitr when given a valid R Sweave file', () => {
+    it('successfully executes knitr when given a valid R Sweave file', () => {
       waitsForPromise(() => {
         return builder.run(filePath).then(code => { exitCode = code })
       })
@@ -51,7 +51,7 @@ describe('KnitrBuilder', () => {
       })
     })
 
-    it('fails to execute Knitr when given an invalid file path', () => {
+    it('fails to execute knitr when given an invalid file path', () => {
       filePath = path.join(fixturesPath, 'foo.Rnw')
 
       waitsForPromise(() => {

--- a/spec/builders/knitr-spec.js
+++ b/spec/builders/knitr-spec.js
@@ -1,4 +1,4 @@
-'use babel'
+/** @babel */
 
 import helpers from '../spec-helpers'
 import _ from 'lodash'

--- a/spec/fixtures/knitr/file.Rnw
+++ b/spec/fixtures/knitr/file.Rnw
@@ -1,0 +1,10 @@
+\documentclass{article}
+
+\begin{document}
+\section{\LaTeX + Knitr}
+<<foo, cache=FALSE>>=
+tau = 2 * pi
+@
+
+$\tau \approx \Sexpr{round(tau, 10)}$
+\end{document}

--- a/spec/fixtures/knitr/file.Rnw
+++ b/spec/fixtures/knitr/file.Rnw
@@ -1,7 +1,7 @@
 \documentclass{article}
 
 \begin{document}
-\section{\LaTeX + Knitr}
+\section{\LaTeX + knitr}
 <<foo, cache=FALSE>>=
 tau = 2 * pi
 @


### PR DESCRIPTION
This PR adds support for building Knitr/Sweave documents. It likely has some rough edges, but should be good enough for most users... 🎱

Hoping someone are willing to test this out. It seems to work quite well, but would love some feedback!

TODO:
 - [x] Install R and Knitr as part of CI builds.
 - [x] Parse error message to detect missing 'knitr' library.
 - [x] Parse output to get the path to the resulting .tex file.
 - [x] Execute default builder on resulting .tex file.
 - [x] Get everything working on AppVeyor.
 -  ~~Add support for `latex.outputDirectory`.~~ _Turns out this isn't really necessary, nor useful. Output redirection is handled by `LatexmkBuilder` and `TexifyBuilder`._
 - [ ] Update the "documentation" on the wiki.
   - [ ] Add separate page for this new builder (and possibly the other builders?) with some examples.

---
Resolves: #101