### PR TITLE
Add other grammar activation hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,9 @@
     ]
   },
   "activationHooks": [
-    "language-latex:grammar-used"
+    "language-latex:grammar-used",
+    "language-tex:grammar-used",
+    "language-latexsimple:grammar-used"
   ],
   "consumedServices": {
     "status-bar": {


### PR DESCRIPTION
[language-latex](https://atom.io/packages/language-latex) has not been updated for a least a year. The fork [language-tex](https://atom.io/packages/language-tex) is being actively updated and there is also an alternate package [language-latexsimple](https://atom.io/packages/language-latexsimple).