### PR TITLE
Use escaped double quotes in keymaps

### DIFF
--- a/keymaps/latex.json
+++ b/keymaps/latex.json
@@ -1,5 +1,5 @@
 {
-  "atom-text-editor[data-grammar~='latex']": {
+  "atom-text-editor[data-grammar~=\"latex\"]": {
     "ctrl-alt-b": "latex:build",
     "ctrl-alt-s": "latex:sync",
     "ctrl-alt-c": "latex:clean"


### PR DESCRIPTION
The copy button in Atom's settings seems to assume keymaps are written in CSON
and does not escape single quotes.

Fixes #187