### PR TITLE
Assign outputFilePath in resolveOutputFilePath

### DIFF
--- a/lib/composer.js
+++ b/lib/composer.js
@@ -162,6 +162,7 @@ export default class Composer {
 
       this.outputLookup = this.outputLookup || {}
       this.outputLookup[filePath] = result.outputFilePath
+      outputFilePath = result.outputFilePath
     }
 
     if (this.shouldMoveResult()) {


### PR DESCRIPTION
Assignment of `outputFilePath` is missing in `resolveOutputFilePath`. I think this may have happened at the conversion from CoffeeScript to Javascript at 30a2dcb8a9a5e714ee026fc72ef741d7f578d46a