### PR TITLE
Add default environment for texify

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -45,8 +45,8 @@ export default class Builder {
     return new LogParser(logFilePath, texFilePath)
   }
 
-  constructChildProcessOptions (filePath) {
-    const env = _.clone(process.env)
+  constructChildProcessOptions (filePath, defaultEnv) {
+    const env = _.assign(defaultEnv || {}, process.env)
     const childPath = this.constructPath()
     if (childPath) {
       env[this.envPathKey] = childPath

--- a/lib/builders/texify.js
+++ b/lib/builders/texify.js
@@ -14,7 +14,7 @@ export default class TexifyBuilder extends Builder {
   run (filePath, jobname) {
     const args = this.constructArgs(filePath, jobname)
     const command = `${this.executable} ${args.join(' ')}`
-    const options = this.constructChildProcessOptions(filePath, { BIBTEX: "biber" })
+    const options = this.constructChildProcessOptions(filePath, { BIBTEX: 'biber' })
 
     return new Promise((resolve) => {
       // TODO: Add support for killing the process.

--- a/lib/builders/texify.js
+++ b/lib/builders/texify.js
@@ -14,7 +14,7 @@ export default class TexifyBuilder extends Builder {
   run (filePath, jobname) {
     const args = this.constructArgs(filePath, jobname)
     const command = `${this.executable} ${args.join(' ')}`
-    const options = this.constructChildProcessOptions(filePath)
+    const options = this.constructChildProcessOptions(filePath, { BIBTEX: "biber" })
 
     return new Promise((resolve) => {
       // TODO: Add support for killing the process.


### PR DESCRIPTION
Only define `BIBTEX` variable if not defined system wide. Should fix #185