### PR TITLE
Create a logger that can help with issue reports

### DIFF
--- a/lib/latex.js
+++ b/lib/latex.js
@@ -27,6 +27,7 @@ export default class Latex {
     defineDefaultProperty(this, 'logger')
     defineDefaultProperty(this, 'opener')
 
+    this.observeLoggerConfig()
     this.observeOpenerConfig()
   }
 
@@ -38,8 +39,8 @@ export default class Latex {
   }
 
   getDefaultLogger () {
-    const DefaultLogger = require('./loggers/default-logger')
-    return new DefaultLogger()
+    const Logger = require(`./loggers/${atom.config.get('latex.logger') || 'default'}-logger`)
+    return new Logger()
   }
 
   getDefaultOpener () {
@@ -87,6 +88,11 @@ export default class Latex {
     atom.config.onDidChange('latex.skimPath', callback)
     atom.config.onDidChange('latex.sumatraPath', callback)
     atom.config.onDidChange('latex.okularPath', callback)
+  }
+
+  observeLoggerConfig () {
+    const callback = () => { this['__logger'] = this.getDefaultLogger() }
+    atom.config.onDidChange('latex.logger', callback)
   }
 
   resolveOpenerImplementation (platform) {

--- a/lib/loggers/issue-logger.js
+++ b/lib/loggers/issue-logger.js
@@ -4,26 +4,25 @@ import _ from 'lodash'
 import Logger from '../logger'
 
 export default class IssueLogger extends Logger {
-  destroy () {
-  }
-
   show (label, messages) {
+    const padding = 9
+    const indent = 14
     const stack = _.map(messages,
       message => {
-        let text = `[${message.type}] ${message.type === 'Error' ? '  ' : (message.type === 'Info' ? '   ' : '')} ${message.text}`
+        let text = _.padEnd(`[${_.pad(message.type, padding)}]`, indent) + message.text
         if (message.filePath || message.range) {
-          text += '\n           ' + message.filePath
+          text += '\n' + _.repeat(' ', indent) + message.filePath
           if (message.range) text += ` at line ${message.range[0][0] + 1}`
         }
         return text
       }).join('\n')
     const firstSignificant = _.find(messages, message => message.type === 'Error') ||
       _.find(messages, message => message.type === 'Warning')
+
     atom.notifications.addFatalError(firstSignificant ? firstSignificant.text.replace(/`/g, '\\`') : 'Unknown Error', {
       packageName: 'latex',
       detail: 'various locations',
-      stack: stack,
-      dismissable: false
+      stack: stack
     })
   }
 }

--- a/lib/loggers/issue-logger.js
+++ b/lib/loggers/issue-logger.js
@@ -3,7 +3,7 @@
 import _ from 'lodash'
 import Logger from '../logger'
 
-export default class ReportLogger extends Logger {
+export default class IssueLogger extends Logger {
   destroy () {
   }
 

--- a/lib/loggers/report-logger.js
+++ b/lib/loggers/report-logger.js
@@ -1,0 +1,29 @@
+/** @babel */
+
+import _ from 'lodash'
+import Logger from '../logger'
+
+export default class ReportLogger extends Logger {
+  destroy () {
+  }
+
+  show (label, messages) {
+    const stack = _.map(messages,
+      message => {
+        let text = `[${message.type}] ${message.type === 'Error' ? '  ' : (message.type === 'Info' ? '   ' : '')} ${message.text}`
+        if (message.filePath || message.range) {
+          text += '\n           ' + message.filePath
+          if (message.range) text += ` at line ${message.range[0][0] + 1}`
+        }
+        return text
+      }).join('\n')
+    const firstSignificant = _.find(messages, message => message.type === 'Error') ||
+      _.find(messages, message => message.type === 'Warning')
+    atom.notifications.addFatalError(firstSignificant ? firstSignificant.text.replace(/`/g, '\\`') : 'Unknown Error', {
+      packageName: 'latex',
+      detail: 'various locations',
+      stack: stack,
+      dismissable: false
+    })
+  }
+}

--- a/package.json
+++ b/package.json
@@ -110,11 +110,11 @@
       "order": 6
     },
     "logger": {
-      "description": "The logger to use for reporting error and other messages. The `default` logger highlights rows of the source file, whereas the `report` is used to generate reports for bug reports.",
+      "description": "The logger to use for reporting error and other messages. The `default` logger highlights rows of the source file, whereas the `issue` is used to generate issue reports for GitHub.",
       "type": "string",
       "enum": [
         "default",
-        "report"
+        "issue"
       ],
       "default": "default",
       "order": 7

--- a/package.json
+++ b/package.json
@@ -109,6 +109,16 @@
       "default": true,
       "order": 6
     },
+    "logger": {
+      "description": "The logger to use for reporting error and other messages. The `default` logger highlights rows of the source file, whereas the `report` is used to generate reports for bug reports.",
+      "type": "string",
+      "enum": [
+        "default",
+        "report"
+      ],
+      "default": "default",
+      "order": 7
+    },
     "loggingLevel": {
       "description": "The minimum level of message severity to output in the logger. A logging level of `error` shows only messages indicating catastrophic issues such as undefined symbols, `warning` shows error messages and messages indicating unintended consequences such as bad boxes, and `info` shows all messages including purely informational messages such a font loading.",
       "type": "string",
@@ -118,7 +128,7 @@
         "info"
       ],
       "default": "warning",
-      "order": 7
+      "order": 8
     },
     "cleanExtensions": {
       "type": "array",
@@ -142,13 +152,13 @@
         ".synctex.gz",
         ".toc"
       ],
-      "order": 8
+      "order": 9
     },
     "outputDirectory": {
       "description": "All files generated during a build will be redirected here. Leave blank if you want the build output to be stored in the same directory as the TeX document.",
       "type": "string",
       "default": "",
-      "order": 9
+      "order": 10
     },
     "outputFormat": {
       "description": "Output file format. DVI and PS currently only supported for latexmk.",
@@ -159,72 +169,72 @@
         "ps"
       ],
       "default": "pdf",
-      "order": 10
+      "order": 11
     },
     "moveResultToSourceDirectory": {
       "title": "Move Result to Source Directory",
       "description": "Ensures that the output file produced by a successful build is stored together with the TeX document that produced it.",
       "type": "boolean",
       "default": true,
-      "order": 11
+      "order": 12
     },
     "buildOnSave": {
       "title": "Build on Save",
       "description": "Automatically run builds when files are saved.",
       "type": "boolean",
       "default": false,
-      "order": 12
+      "order": 13
     },
     "openResultAfterBuild": {
       "title": "Open Result after Successful Build",
       "type": "boolean",
       "default": true,
-      "order": 13
+      "order": 14
     },
     "openResultInBackground": {
       "title": "Open Result in Background",
       "type": "boolean",
       "default": true,
-      "order": 14
+      "order": 15
     },
     "alwaysOpenResultInAtom": {
       "title": "Always Open Result in Atom",
       "description": "Always open result in Atom. Depends on the pdf-view package being installed.",
       "type": "boolean",
       "default": false,
-      "order": 15
+      "order": 16
     },
     "skimPath": {
       "description": "Full application path to Skim (macOS).",
       "type": "string",
       "default": "/Applications/Skim.app",
-      "order": 16
+      "order": 17
     },
     "sumatraPath": {
       "title": "SumatraPDF Path",
       "description": "Full application path to SumatraPDF (Windows).",
       "type": "string",
       "default": "C:\\Program Files (x86)\\SumatraPDF\\SumatraPDF.exe",
-      "order": 17
+      "order": 18
     },
     "okularPath": {
       "description": "Full application path to Okular (*nix).",
       "type": "string",
       "default": "/usr/bin/okular",
-      "order": 18
+      "order": 19
     },
     "viewerPath": {
       "title": "Custom PDF Viewer Path",
       "description": "Full application path to your PDF viewer. Overrides Skim and SumatraPDF options.",
       "type": "string",
       "default": "",
-      "order": 19
+      "order": 20
     },
     "useMasterFileSearch": {
       "description": "Enables naive search for master/root file when building distributed documents. Note that this does not affect the equivalent *Magic Comments* functionality.",
       "type": "boolean",
       "default": false,
-      "order": 20
+      "order": 21
     }
   }
 }


### PR DESCRIPTION
This is still very rough around the edges. Mostly just the kernel of an idea of how to use `Logger` to record a filtered version of the LaTeX logs. We could certainly add other data to the report.