### PR TITLE
Use Xcode 8 and macOS 10.11 on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+language: node_js
+
 branches:
   only:
     - master
@@ -5,12 +7,12 @@ branches:
 git:
   depth: 1
 
-matrix:
-  include:
-    - os: linux
-      sudo: false
-    - os: osx
-      osx_image: xcode8
+os:
+  - linux
+  - osx
+
+sudo: false
+osx_image: xcode8
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: node_js
+language: generic
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+language: node_js
+
 branches:
   only:
     - master
@@ -5,12 +7,12 @@ branches:
 git:
   depth: 1
 
-os:
-  - linux
-  - osx
-
-sudo: false
-osx_image: xcode8
+matrix:
+  include:
+    - os: linux
+      sudo: false
+    - os: osx
+      osx_image: xcode8
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ osx_image: xcode8
 
 env:
   global:
+    - MAKE="make -j8"
     - R_LIBS_USER=${HOME}/R/library
     - APM_TEST_PACKAGES="language-latex pdf-view"
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ os:
   - osx
 
 sudo: false
+osx_image: xcode8
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-language: node_js
-
 branches:
   only:
     - master


### PR DESCRIPTION
Migrate macOS builds on Travis CI to 10.11 and Xcode 8. This might (partially) fix #217.