### PR TITLE
Migrate to centralized build state

### DIFF
--- a/lib/build-state.js
+++ b/lib/build-state.js
@@ -46,6 +46,14 @@ export default class BuildState {
     this.activeJobname = value
   }
 
+  getActiveFilePath () {
+    return this.activeFilePath
+  }
+
+  setActiveFilePath (value) {
+    this.activeFilePath = value
+  }
+
   getLatexEngine () {
     return this.latexEngine
   }

--- a/lib/build-state.js
+++ b/lib/build-state.js
@@ -1,94 +1,55 @@
 /** @babel */
 
-import fs from 'fs-plus'
-import path from 'path'
-import MagicParser from './parsers/magic-parser'
-
-const masterFilePattern = new RegExp('' +
-  '^\\s*' +             // Optional whitespace.
-  '\\\\documentclass' + // Command.
-  '(\\[.*\\])?' +       // Optional command options.
-  '\\{.*\\}'            // Class name.
-)
-
 export default class BuildState {
-  // Create a new MasterTexFinder.
-  // this.param filePath: a file name in the directory to be searched
-  constructor (filePath) {
-    this.settings = {
-      filePath,
-      projectPath: path.dirname(filePath),
-      rootFilePath: this.getMasterTexPath()
-    }
-
-    const magic = new MagicParser(this.rootFilePath).parse()
-
-    this.settings.builder = magic.builder || atom.config.get('latex.builder')
-    this.settings.engine = magic.program || atom.config.get('latex.customEngine') ||
-      atom.config.get('latex.engine') || 'pdflatex'
-    this.settings.jobnames = magic.jobnames ? magic.jobnames.split(/\s+/) : [null]
-    this.settings.outputFormat = magic.format || atom.config.get('latex.outputFormat') || 'pdf'
-    this.settings.outputDirectory = magic.output || atom.config.get('latex.outputDirectory')
-    if (this.settings.outputDirectory) {
-      this.settings.outputDirectory = path.join(this.settings.projectPath, this.settings.outputDirectory)
-    }
-
-    this.queue = [this.settings.rootFilePath]
+  constructor (filePath, projectPath) {
+    this.filePath = filePath
+    this.projectPath = projectPath
   }
 
-  // Returns the list of tex files in the project directory
-  getTexFilesList () {
-    return fs.listSync(this.settings.projectPath, ['.tex'])
+  getFilePath () {
+    return this.filePath
   }
 
-  // Returns true iff path is a master file (contains the documentclass declaration)
-  isMasterFile (filePath) {
-    if (!fs.existsSync(filePath)) { return false }
-
-    const rawFile = fs.readFileSync(filePath, {encoding: 'utf-8'})
-    return masterFilePattern.test(rawFile)
+  getProjectPath () {
+    return this.projectPath
   }
 
-  // Returns an array containing the path to the root file indicated by a magic
-  // comment in this.filePath.
-  // Returns null if no magic comment can be found in this.filePath.
-  getMagicCommentMasterFile () {
-    const magic = new MagicParser(this.filePath).parse()
-    if (!magic || !magic.root) { return null }
-    return path.resolve(this.settings.projectPath, magic.root)
+  getOutputFormat () {
+    return this.outputFormat
   }
 
-  // Returns the list of tex files in the directory where this.filePath lives that
-  // contain a documentclass declaration.
-  searchForMasterFile () {
-    const files = this.getTexFilesList()
-    if (!files) { return null }
-    if (files.length === 0) { return this.settings.filePath }
-    if (files.length === 1) { return files[0] }
-
-    const result = files.filter(p => this.isMasterFile(p))
-    if (result.length === 1) { return result[0] }
-
-    // TODO: Nuke warning?
-    latex.log.warning('Cannot find latex master file')
-    return this.settings.filePath
+  setOutputFormat (value) {
+    this.outputFormat = value
+  }
+  getOutputDirectory () {
+    return this.outputDirectory
   }
 
-  // Returns the a latex master file.
-  //
-  // If this.filePath contains a magic comment uses that comment to determine the master file.
-  // Else if master file search is disabled, returns this.filePath.
-  // Else if the this.filePath is itself a master file, returns this.filePath.
-  // Otherwise it searches the directory where this.filePath is contained for files having a
-  //   'documentclass' declaration.
-  getMasterTexPath () {
-    const masterPath = this.getMagicCommentMasterFile()
-    if (masterPath) { return masterPath }
-    if (!this.isMasterFileSearchEnabled()) { return this.settings.filePath }
-    if (this.isMasterFile(this.settings.filePath)) { return this.settings.filePath }
-
-    return this.searchForMasterFile()
+  setOutputDirectory (value) {
+    this.outputDirectory = value
   }
 
-  isMasterFileSearchEnabled () { return atom.config.get('latex.useMasterFileSearch') }
+  getJobnames () {
+    return this.jobnames
+  }
+
+  setJobnames (value) {
+    this.jobnames = value
+  }
+
+  getLatexEngine () {
+    return this.latexEngine
+  }
+
+  setLatexEngine (value) {
+    this.latexEngine = value
+  }
+
+  getPdfProducer () {
+    return this.pdfProducer
+  }
+
+  setPdfProducer (value) {
+    this.pdfProducer = value
+  }
 }

--- a/lib/build-state.js
+++ b/lib/build-state.js
@@ -4,6 +4,8 @@ export default class BuildState {
   constructor (filePath, projectPath) {
     this.filePath = filePath
     this.projectPath = projectPath
+    this.stages = []
+    this.stageOutputs = {}
   }
 
   getFilePath () {
@@ -46,12 +48,24 @@ export default class BuildState {
     this.activeJobname = value
   }
 
-  getActiveFilePath () {
-    return this.activeFilePath
+  getCurrentStage () {
+    return this.stages[0]
   }
 
-  setActiveFilePath (value) {
-    this.activeFilePath = value
+  shiftStage () {
+    return this.stages.shift()
+  }
+
+  pushStages (...newStages) {
+    Array.prototype.push.apply(this.stages, newStages)
+  }
+
+  getStageOutputs (stage) {
+    return this.stageOutputs[stage]
+  }
+
+  setStageOutputs (stage, outputs) {
+    this.stageOutputs[stage] = outputs
   }
 
   getLatexEngine () {

--- a/lib/build-state.js
+++ b/lib/build-state.js
@@ -1,0 +1,91 @@
+/** @babel */
+
+import fs from 'fs-plus'
+import path from 'path'
+import MagicParser from './parsers/magic-parser'
+
+const masterFilePattern = new RegExp('' +
+  '^\\s*' +             // Optional whitespace.
+  '\\\\documentclass' + // Command.
+  '(\\[.*\\])?' +       // Optional command options.
+  '\\{.*\\}'            // Class name.
+)
+
+export default class BuildState {
+  // Create a new MasterTexFinder.
+  // this.param filePath: a file name in the directory to be searched
+  constructor (filePath) {
+    this.settings = {
+      filePath,
+      projectPath: path.dirname(filePath),
+      rootFilePath: this.getMasterTexPath()
+    }
+
+    const magic = new MagicParser(this.rootFilePath).parse()
+
+    this.settings.builder = magic.builder || atom.config.get('latex.builder')
+    this.settings.engine = magic.program || atom.config.get('latex.customEngine') ||
+      atom.config.get('latex.engine') || 'pdflatex'
+    this.settings.jobnames = magic.jobnames ? magic.jobnames.split(/\s+/) : [null]
+    this.settings.outputFormat = magic.format || atom.config.get('latex.outputFormat') || 'pdf'
+    this.settings.outputDirectory = magic.output || atom.config.get('latex.outputDirectory')
+
+    this.queue = [this.settings.rootFilePath]
+  }
+
+  // Returns the list of tex files in the project directory
+  getTexFilesList () {
+    return fs.listSync(this.projectPath, ['.tex'])
+  }
+
+  // Returns true iff path is a master file (contains the documentclass declaration)
+  isMasterFile (filePath) {
+    if (!fs.existsSync(filePath)) { return false }
+
+    const rawFile = fs.readFileSync(filePath, {encoding: 'utf-8'})
+    return masterFilePattern.test(rawFile)
+  }
+
+  // Returns an array containing the path to the root file indicated by a magic
+  // comment in this.filePath.
+  // Returns null if no magic comment can be found in this.filePath.
+  getMagicCommentMasterFile () {
+    const magic = new MagicParser(this.filePath).parse()
+    if (!magic || !magic.root) { return null }
+    return path.resolve(this.settings.projectPath, magic.root)
+  }
+
+  // Returns the list of tex files in the directory where this.filePath lives that
+  // contain a documentclass declaration.
+  searchForMasterFile () {
+    const files = this.getTexFilesList()
+    if (!files) { return null }
+    if (files.length === 0) { return this.settings.filePath }
+    if (files.length === 1) { return files[0] }
+
+    const result = files.filter(p => this.isMasterFile(p))
+    if (result.length === 1) { return result[0] }
+
+    // TODO: Nuke warning?
+    latex.log.warning('Cannot find latex master file')
+    return this.settings.filePath
+  }
+
+  // Returns the a latex master file.
+  //
+  // If this.filePath contains a magic comment uses that comment to determine the master file.
+  // Else if master file search is disabled, returns this.filePath.
+  // Else if the this.filePath is itself a master file, returns this.filePath.
+  // Otherwise it searches the directory where this.filePath is contained for files having a
+  //   'documentclass' declaration.
+  getMasterTexPath () {
+    const masterPath = this.getMagicCommentMasterFile()
+    if (masterPath) { return masterPath }
+    if (!this.isMasterFileSearchEnabled()) { return this.settings.filePath }
+    if (this.isMasterFile(this.settings.filePath)) { return this.settings.filePath }
+
+    return this.searchForMasterFile()
+  }
+
+  isMasterFileSearchEnabled () { return atom.config.get('latex.useMasterFileSearch') }
+}

--- a/lib/build-state.js
+++ b/lib/build-state.js
@@ -21,6 +21,7 @@ export default class BuildState {
   setOutputFormat (value) {
     this.outputFormat = value
   }
+
   getOutputDirectory () {
     return this.outputDirectory
   }
@@ -35,6 +36,14 @@ export default class BuildState {
 
   setJobnames (value) {
     this.jobnames = value
+  }
+
+  getActiveJobname () {
+    return this.activeJobname
+  }
+
+  setActiveJobname (value) {
+    this.activeJobname = value
   }
 
   getLatexEngine () {

--- a/lib/build-state.js
+++ b/lib/build-state.js
@@ -29,13 +29,16 @@ export default class BuildState {
     this.settings.jobnames = magic.jobnames ? magic.jobnames.split(/\s+/) : [null]
     this.settings.outputFormat = magic.format || atom.config.get('latex.outputFormat') || 'pdf'
     this.settings.outputDirectory = magic.output || atom.config.get('latex.outputDirectory')
+    if (this.settings.outputDirectory) {
+      this.settings.outputDirectory = path.join(this.settings.projectPath, this.settings.outputDirectory)
+    }
 
     this.queue = [this.settings.rootFilePath]
   }
 
   // Returns the list of tex files in the project directory
   getTexFilesList () {
-    return fs.listSync(this.projectPath, ['.tex'])
+    return fs.listSync(this.settings.projectPath, ['.tex'])
   }
 
   // Returns true iff path is a master file (contains the documentclass declaration)

--- a/lib/builder-registry.js
+++ b/lib/builder-registry.js
@@ -27,9 +27,9 @@ export default class BuilderRegistry {
   }
 
   getAllBuilders () {
-    const moduleDir = path.join(__dirname, 'builders')
+    const moduleDir = this.getModuleDirPath()
     const entries = fs.readdirSync(moduleDir)
-    const builders = entries.map((entry) => require(path.join(moduleDir, entry)))
+    const builders = entries.map(entry => require(path.join(moduleDir, entry)))
 
     return builders
   }
@@ -54,5 +54,9 @@ export default class BuilderRegistry {
 
     latex.log.error(`Unable to resolve builder named ${name} from global configuration, using final fallback ${builders[0].name}.`)
     return builders[0]
+  }
+
+  getModuleDirPath () {
+    return path.join(__dirname, 'builders')
   }
 }

--- a/spec/build-registry-spec.js
+++ b/spec/build-registry-spec.js
@@ -1,6 +1,7 @@
 /** @babel */
 
 import helpers from './spec-helpers'
+import fs from 'fs-plus'
 import path from 'path'
 import BuilderRegistry from '../lib/builder-registry'
 import { NullBuilder } from './stubs'
@@ -51,6 +52,16 @@ describe('BuilderRegistry', () => {
     it('detects builder magic and outputs builder', () => {
       const filePath = path.join(fixturesPath, 'magic-comments', 'latex-builder.tex')
       expect(registry.getBuilderFromMagic(filePath)).toEqual('texify')
+    })
+  })
+
+  describe('getAllBuilders', () => {
+    it('returns all bundled builders', () => {
+      const moduleDir = registry.getModuleDirPath()
+      const numModules = fs.readdirSync(moduleDir).length
+
+      const builders = registry.getAllBuilders()
+      expect(builders.length).toBe(numModules)
     })
   })
 })

--- a/spec/builders/knitr-spec.js
+++ b/spec/builders/knitr-spec.js
@@ -104,4 +104,11 @@ describe('KnitrBuilder', () => {
       expect(resolvedPath).toBe(resultPath)
     })
   })
+
+  describe('canProcess', () => {
+    it('returns true when given a file path with a .Rnw extension', () => {
+      const canProcess = KnitrBuilder.canProcess(filePath)
+      expect(canProcess).toBe(true)
+    })
+  })
 })

--- a/spec/builders/latexmk-spec.js
+++ b/spec/builders/latexmk-spec.js
@@ -231,13 +231,14 @@ describe('LatexmkBuilder', () => {
       expect(messages.filter(startsWithPrefix).length).toBe(statusCodes.length)
     })
 
-    it('passes through to super class when given non-latex status codes', () => {
-      spyOn(builder.__proto__, 'logStatusCode').andCallThrough()
+    it('passes through to superclass when given non-latex status codes', () => {
+      const superclass = Object.getPrototypeOf(builder)
+      spyOn(superclass, 'logStatusCode').andCallThrough()
 
       const statusCode = 1
       builder.logStatusCode(statusCode)
 
-      expect(builder.__proto__.logStatusCode).toHaveBeenCalledWith(statusCode)
+      expect(superclass.logStatusCode).toHaveBeenCalledWith(statusCode)
     })
   })
 })

--- a/spec/builders/latexmk-spec.js
+++ b/spec/builders/latexmk-spec.js
@@ -216,4 +216,19 @@ describe('LatexmkBuilder', () => {
       expect(canProcess).toBe(true)
     })
   })
+
+  describe('logStatusCode', () => {
+    it('handles latexmk specific status codes', () => {
+      let messages = []
+      spyOn(latex.log, 'error').andCallFake(message => messages.push(message))
+
+      const statusCodes = [10, 11, 12, 13, 20]
+      statusCodes.forEach(statusCode => builder.logStatusCode(statusCode))
+
+      const startsWithPrefix = str => str.startsWith('latexmk:')
+
+      expect(messages.length).toBe(statusCodes.length)
+      expect(messages.filter(startsWithPrefix).length).toBe(statusCodes.length)
+    })
+  })
 })

--- a/spec/builders/latexmk-spec.js
+++ b/spec/builders/latexmk-spec.js
@@ -209,4 +209,11 @@ describe('LatexmkBuilder', () => {
       })
     })
   })
+
+  describe('canProcess', () => {
+    it('returns true when given a file path with a .tex extension', () => {
+      const canProcess = LatexmkBuilder.canProcess(filePath)
+      expect(canProcess).toBe(true)
+    })
+  })
 })

--- a/spec/builders/latexmk-spec.js
+++ b/spec/builders/latexmk-spec.js
@@ -230,5 +230,14 @@ describe('LatexmkBuilder', () => {
       expect(messages.length).toBe(statusCodes.length)
       expect(messages.filter(startsWithPrefix).length).toBe(statusCodes.length)
     })
+
+    it('passes through to super class when given non-latex status codes', () => {
+      spyOn(builder.__proto__, 'logStatusCode').andCallThrough()
+
+      const statusCode = 1
+      builder.logStatusCode(statusCode)
+
+      expect(builder.__proto__.logStatusCode).toHaveBeenCalledWith(statusCode)
+    })
   })
 })

--- a/spec/composer-spec.js
+++ b/spec/composer-spec.js
@@ -271,4 +271,45 @@ describe('Composer', () => {
       expect(composer.getBuilder(filePath)).toBeNull()
     })
   })
+
+  describe('sync', () => {
+    it('silently does nothing when the current editor is transient', () => {
+      spyOn(composer, 'getEditorDetails').andReturn({ filePath: null })
+      spyOn(composer, 'resolveOutputFilePath').andCallThrough()
+      spyOn(latex, 'getOpener').andCallThrough()
+
+      composer.sync()
+
+      expect(composer.resolveOutputFilePath).not.toHaveBeenCalled()
+      expect(latex.getOpener).not.toHaveBeenCalled()
+    })
+
+    it('logs a warning and returns when an output file cannot be resolved', () => {
+      spyOn(composer, 'getEditorDetails').andReturn({ filePath: 'file.tex', lineNumber: 1 })
+      spyOn(composer, 'resolveOutputFilePath').andReturn()
+      spyOn(latex, 'getOpener').andCallThrough()
+      spyOn(latex.log, 'warning').andCallThrough()
+
+      composer.sync()
+
+      expect(latex.log.warning).toHaveBeenCalled()
+      expect(latex.getOpener).not.toHaveBeenCalled()
+    })
+
+    it('launches the opener using editor metadata and resolved output file', () => {
+      const filePath = 'file.tex'
+      const lineNumber = 1
+      const outputFilePath = 'file.pdf'
+      spyOn(composer, 'getEditorDetails').andReturn({ filePath, lineNumber })
+      spyOn(composer, 'resolveOutputFilePath').andReturn(outputFilePath)
+
+      const opener = jasmine.createSpyObj('MockOpener', ['open'])
+      console.log(opener)
+      spyOn(latex, 'getOpener').andReturn(opener)
+
+      composer.sync()
+
+      expect(opener.open).toHaveBeenCalledWith(outputFilePath, filePath, lineNumber)
+    })
+  })
 })

--- a/spec/composer-spec.js
+++ b/spec/composer-spec.js
@@ -274,7 +274,7 @@ describe('Composer', () => {
 
   describe('sync', () => {
     it('silently does nothing when the current editor is transient', () => {
-      spyOn(composer, 'getEditorDetails').andReturn({ filePath: null })
+      spyOn(werkzeug, 'getEditorDetails').andReturn({ filePath: null })
       spyOn(composer, 'resolveOutputFilePath').andCallThrough()
       spyOn(latex, 'getOpener').andCallThrough()
 
@@ -285,7 +285,7 @@ describe('Composer', () => {
     })
 
     it('logs a warning and returns when an output file cannot be resolved', () => {
-      spyOn(composer, 'getEditorDetails').andReturn({ filePath: 'file.tex', lineNumber: 1 })
+      spyOn(werkzeug, 'getEditorDetails').andReturn({ filePath: 'file.tex', lineNumber: 1 })
       spyOn(composer, 'resolveOutputFilePath').andReturn()
       spyOn(latex, 'getOpener').andCallThrough()
       spyOn(latex.log, 'warning').andCallThrough()
@@ -300,11 +300,10 @@ describe('Composer', () => {
       const filePath = 'file.tex'
       const lineNumber = 1
       const outputFilePath = 'file.pdf'
-      spyOn(composer, 'getEditorDetails').andReturn({ filePath, lineNumber })
+      spyOn(werkzeug, 'getEditorDetails').andReturn({ filePath, lineNumber })
       spyOn(composer, 'resolveOutputFilePath').andReturn(outputFilePath)
 
       const opener = jasmine.createSpyObj('MockOpener', ['open'])
-      console.log(opener)
       spyOn(latex, 'getOpener').andReturn(opener)
 
       composer.sync()

--- a/spec/composer-spec.js
+++ b/spec/composer-spec.js
@@ -314,8 +314,8 @@ describe('Composer', () => {
   })
 
   describe('moveResult', () => {
-    const texFilePath = '/angle/gronk.tex'
-    const outputFilePath = '/angle/dangle/gronk.pdf'
+    const texFilePath = path.normalize('/angle/gronk.tex')
+    const outputFilePath = path.normalize('/angle/dangle/gronk.pdf')
     const result = { outputFilePath }
 
     beforeEach(() => {
@@ -324,9 +324,9 @@ describe('Composer', () => {
     })
 
     it('verifies that the output file and the synctex file are moved when they exist', () => {
-      const destOutputFilePath = '/angle/gronk.pdf'
-      const syncTexPath = '/angle/dangle/gronk.synctex.gz'
-      const destSyncTexPath = '/angle/gronk.synctex.gz'
+      const destOutputFilePath = path.normalize('/angle/gronk.pdf')
+      const syncTexPath = path.normalize('/angle/dangle/gronk.synctex.gz')
+      const destSyncTexPath = path.normalize('/angle/gronk.synctex.gz')
 
       spyOn(fs, 'existsSync').andReturn(true)
 

--- a/spec/composer-spec.js
+++ b/spec/composer-spec.js
@@ -312,4 +312,39 @@ describe('Composer', () => {
       expect(opener.open).toHaveBeenCalledWith(outputFilePath, filePath, lineNumber)
     })
   })
+
+  describe('moveResult', () => {
+    const texFilePath = '/angle/gronk.tex'
+    const outputFilePath = '/angle/dangle/gronk.pdf'
+    const result = { outputFilePath }
+
+    beforeEach(() => {
+      spyOn(fs, 'removeSync')
+      spyOn(fs, 'moveSync')
+    })
+
+    it('verifies that the output file and the synctex file are moved when they exist', () => {
+      const destOutputFilePath = '/angle/gronk.pdf'
+      const syncTexPath = '/angle/dangle/gronk.synctex.gz'
+      const destSyncTexPath = '/angle/gronk.synctex.gz'
+
+      spyOn(fs, 'existsSync').andReturn(true)
+
+      composer.moveResult(result, texFilePath)
+      expect(fs.removeSync).toHaveBeenCalledWith(destOutputFilePath)
+      expect(fs.removeSync).toHaveBeenCalledWith(destSyncTexPath)
+      expect(fs.moveSync).toHaveBeenCalledWith(outputFilePath, destOutputFilePath)
+      expect(fs.moveSync).toHaveBeenCalledWith(syncTexPath, destSyncTexPath)
+    })
+
+    it('verifies that the output file and the synctex file are not moved when they do not exist', () => {
+      spyOn(fs, 'existsSync').andReturn(false)
+
+      composer.moveResult(result, texFilePath)
+      expect(fs.removeSync).not.toHaveBeenCalled()
+      expect(fs.removeSync).not.toHaveBeenCalled()
+      expect(fs.moveSync).not.toHaveBeenCalled()
+      expect(fs.moveSync).not.toHaveBeenCalled()
+    })
+  })
 })


### PR DESCRIPTION
This PR is intended to start the process to migrate to a centralized build state. This is needed to make it possible to address #211 and #213, but also create the framework to explore solutions for #220 and #179.  A centralized build state might also help move the second stage builder resolution code out of `KnitrBuilder`.

Right now only the `BuildState` class has been added but not used anywhere as we want to move gradually in refactoring as we will need to rewrite specs, etc.