### PR TITLE
Improve test coverage

### DIFF
--- a/lib/builder-registry.js
+++ b/lib/builder-registry.js
@@ -39,9 +39,9 @@ export default class BuilderRegistry {
   }
 
   getAllBuilders () {
-    const moduleDir = path.join(__dirname, 'builders')
+    const moduleDir = this.getModuleDirPath()
     const entries = fs.readdirSync(moduleDir)
-    const builders = entries.map((entry) => require(path.join(moduleDir, entry)))
+    const builders = entries.map(entry => require(path.join(moduleDir, entry)))
 
     return builders
   }
@@ -66,5 +66,9 @@ export default class BuilderRegistry {
 
     latex.log.error(`Unable to resolve builder named ${name} from global configuration, using final fallback ${builders[0].name}.`)
     return builders[0]
+  }
+
+  getModuleDirPath () {
+    return path.join(__dirname, 'builders')
   }
 }

--- a/spec/build-registry-spec.js
+++ b/spec/build-registry-spec.js
@@ -78,10 +78,10 @@ describe('BuilderRegistry', () => {
 
   describe('getAllBuilders', () => {
     it('returns all bundled builders', () => {
-      const moduleDir = registry.getModuleDirPath()
+      const moduleDir = builderRegistry.getModuleDirPath()
       const numModules = fs.readdirSync(moduleDir).length
 
-      const builders = registry.getAllBuilders()
+      const builders = builderRegistry.getAllBuilders()
       expect(builders.length).toBe(numModules)
     })
   })

--- a/spec/build-registry-spec.js
+++ b/spec/build-registry-spec.js
@@ -1,6 +1,7 @@
 /** @babel */
 
 import helpers from './spec-helpers'
+import fs from 'fs-plus'
 import path from 'path'
 import { NullBuilder } from './stubs'
 import BuilderRegistry from '../lib/builder-registry'
@@ -72,6 +73,16 @@ describe('BuilderRegistry', () => {
     it('detects builder magic and outputs builder', () => {
       const filePath = path.join(fixturesPath, 'magic-comments', 'latex-builder.tex')
       expect(builderRegistry.getBuilderFromMagic(filePath)).toEqual('texify')
+    })
+  })
+
+  describe('getAllBuilders', () => {
+    it('returns all bundled builders', () => {
+      const moduleDir = registry.getModuleDirPath()
+      const numModules = fs.readdirSync(moduleDir).length
+
+      const builders = registry.getAllBuilders()
+      expect(builders.length).toBe(numModules)
     })
   })
 })

--- a/spec/builders/knitr-spec.js
+++ b/spec/builders/knitr-spec.js
@@ -114,4 +114,11 @@ describe('KnitrBuilder', () => {
       expect(resolvedPath).toBe(resultPath)
     })
   })
+
+  describe('canProcess', () => {
+    it('returns true when given a file path with a .Rnw extension', () => {
+      const canProcess = KnitrBuilder.canProcess(filePath)
+      expect(canProcess).toBe(true)
+    })
+  })
 })

--- a/spec/builders/knitr-spec.js
+++ b/spec/builders/knitr-spec.js
@@ -17,7 +17,7 @@ describe('KnitrBuilder', () => {
       return helpers.activatePackages()
     })
     builder = new KnitrBuilder()
-    spyOn(builder, 'logStatusCode')
+    spyOn(builder, 'logStatusCode').andCallThrough()
     fixturesPath = helpers.cloneFixtures()
     filePath = path.join(fixturesPath, 'knitr', 'file.Rnw')
   })

--- a/spec/builders/latexmk-spec.js
+++ b/spec/builders/latexmk-spec.js
@@ -438,4 +438,11 @@ describe('LatexmkBuilder', () => {
       })
     })
   })
+
+  describe('canProcess', () => {
+    it('returns true when given a file path with a .tex extension', () => {
+      const canProcess = LatexmkBuilder.canProcess(filePath)
+      expect(canProcess).toBe(true)
+    })
+  })
 })

--- a/spec/builders/latexmk-spec.js
+++ b/spec/builders/latexmk-spec.js
@@ -460,13 +460,14 @@ describe('LatexmkBuilder', () => {
       expect(messages.filter(startsWithPrefix).length).toBe(statusCodes.length)
     })
 
-    it('passes through to super class when given non-latex status codes', () => {
-      spyOn(builder.__proto__, 'logStatusCode').andCallThrough()
+    it('passes through to superclass when given non-latex status codes', () => {
+      const superclass = Object.getPrototypeOf(builder)
+      spyOn(superclass, 'logStatusCode').andCallThrough()
 
       const statusCode = 1
       builder.logStatusCode(statusCode)
 
-      expect(builder.__proto__.logStatusCode).toHaveBeenCalledWith(statusCode)
+      expect(superclass.logStatusCode).toHaveBeenCalledWith(statusCode)
     })
   })
 })

--- a/spec/builders/latexmk-spec.js
+++ b/spec/builders/latexmk-spec.js
@@ -459,5 +459,14 @@ describe('LatexmkBuilder', () => {
       expect(messages.length).toBe(statusCodes.length)
       expect(messages.filter(startsWithPrefix).length).toBe(statusCodes.length)
     })
+
+    it('passes through to super class when given non-latex status codes', () => {
+      spyOn(builder.__proto__, 'logStatusCode').andCallThrough()
+
+      const statusCode = 1
+      builder.logStatusCode(statusCode)
+
+      expect(builder.__proto__.logStatusCode).toHaveBeenCalledWith(statusCode)
+    })
   })
 })

--- a/spec/builders/latexmk-spec.js
+++ b/spec/builders/latexmk-spec.js
@@ -445,4 +445,19 @@ describe('LatexmkBuilder', () => {
       expect(canProcess).toBe(true)
     })
   })
+
+  describe('logStatusCode', () => {
+    it('handles latexmk specific status codes', () => {
+      let messages = []
+      spyOn(latex.log, 'error').andCallFake(message => messages.push(message))
+
+      const statusCodes = [10, 11, 12, 13, 20]
+      statusCodes.forEach(statusCode => builder.logStatusCode(statusCode))
+
+      const startsWithPrefix = str => str.startsWith('latexmk:')
+
+      expect(messages.length).toBe(statusCodes.length)
+      expect(messages.filter(startsWithPrefix).length).toBe(statusCodes.length)
+    })
+  })
 })

--- a/spec/builders/latexmk-spec.js
+++ b/spec/builders/latexmk-spec.js
@@ -13,7 +13,6 @@ describe('LatexmkBuilder', () => {
       return helpers.activatePackages()
     })
     builder = new LatexmkBuilder()
-    spyOn(builder, 'logStatusCode')
     fixturesPath = helpers.cloneFixtures()
     filePath = path.join(fixturesPath, 'file.tex')
   })
@@ -142,6 +141,10 @@ describe('LatexmkBuilder', () => {
 
   describe('run', () => {
     let exitCode, parsedLog
+
+    beforeEach(() => {
+      spyOn(builder, 'logStatusCode').andCallThrough()
+    })
 
     it('successfully executes latexmk when given a valid TeX file', () => {
       waitsForPromise(() => {
@@ -460,14 +463,15 @@ describe('LatexmkBuilder', () => {
       expect(messages.filter(startsWithPrefix).length).toBe(statusCodes.length)
     })
 
-    it('passes through to superclass when given non-latex status codes', () => {
+    it('passes through to superclass when given non-latexmk status codes', () => {
+      const stderr = 'wibble'
       const superclass = Object.getPrototypeOf(builder)
       spyOn(superclass, 'logStatusCode').andCallThrough()
 
       const statusCode = 1
-      builder.logStatusCode(statusCode)
+      builder.logStatusCode(statusCode, stderr)
 
-      expect(superclass.logStatusCode).toHaveBeenCalledWith(statusCode)
+      expect(superclass.logStatusCode).toHaveBeenCalledWith(statusCode, stderr)
     })
   })
 })

--- a/spec/builders/texify-spec.js
+++ b/spec/builders/texify-spec.js
@@ -14,7 +14,7 @@ if (process.env.TEX_DIST === 'miktex') {
         return helpers.activatePackages()
       })
       builder = new TexifyBuilder()
-      spyOn(builder, 'logStatusCode')
+      spyOn(builder, 'logStatusCode').andCallThrough()
       fixturesPath = helpers.cloneFixtures()
       filePath = path.join(fixturesPath, 'file.tex')
     })

--- a/spec/composer-spec.js
+++ b/spec/composer-spec.js
@@ -401,11 +401,13 @@ describe('Composer', () => {
   })
 
   describe('moveResult', () => {
+    let composer
     const texFilePath = path.normalize('/angle/gronk.tex')
     const outputFilePath = path.normalize('/angle/dangle/gronk.pdf')
     const result = { outputFilePath }
 
     beforeEach(() => {
+      composer = new Composer()
       spyOn(fs, 'removeSync')
       spyOn(fs, 'moveSync')
     })

--- a/spec/composer-spec.js
+++ b/spec/composer-spec.js
@@ -399,4 +399,39 @@ describe('Composer', () => {
       })
     })
   })
+
+  describe('moveResult', () => {
+    const texFilePath = '/angle/gronk.tex'
+    const outputFilePath = '/angle/dangle/gronk.pdf'
+    const result = { outputFilePath }
+
+    beforeEach(() => {
+      spyOn(fs, 'removeSync')
+      spyOn(fs, 'moveSync')
+    })
+
+    it('verifies that the output file and the synctex file are moved when they exist', () => {
+      const destOutputFilePath = '/angle/gronk.pdf'
+      const syncTexPath = '/angle/dangle/gronk.synctex.gz'
+      const destSyncTexPath = '/angle/gronk.synctex.gz'
+
+      spyOn(fs, 'existsSync').andReturn(true)
+
+      composer.moveResult(result, texFilePath)
+      expect(fs.removeSync).toHaveBeenCalledWith(destOutputFilePath)
+      expect(fs.removeSync).toHaveBeenCalledWith(destSyncTexPath)
+      expect(fs.moveSync).toHaveBeenCalledWith(outputFilePath, destOutputFilePath)
+      expect(fs.moveSync).toHaveBeenCalledWith(syncTexPath, destSyncTexPath)
+    })
+
+    it('verifies that the output file and the synctex file are not moved when they do not exist', () => {
+      spyOn(fs, 'existsSync').andReturn(false)
+
+      composer.moveResult(result, texFilePath)
+      expect(fs.removeSync).not.toHaveBeenCalled()
+      expect(fs.removeSync).not.toHaveBeenCalled()
+      expect(fs.moveSync).not.toHaveBeenCalled()
+      expect(fs.moveSync).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/spec/composer-spec.js
+++ b/spec/composer-spec.js
@@ -401,8 +401,8 @@ describe('Composer', () => {
   })
 
   describe('moveResult', () => {
-    const texFilePath = '/angle/gronk.tex'
-    const outputFilePath = '/angle/dangle/gronk.pdf'
+    const texFilePath = path.normalize('/angle/gronk.tex')
+    const outputFilePath = path.normalize('/angle/dangle/gronk.pdf')
     const result = { outputFilePath }
 
     beforeEach(() => {
@@ -411,9 +411,9 @@ describe('Composer', () => {
     })
 
     it('verifies that the output file and the synctex file are moved when they exist', () => {
-      const destOutputFilePath = '/angle/gronk.pdf'
-      const syncTexPath = '/angle/dangle/gronk.synctex.gz'
-      const destSyncTexPath = '/angle/gronk.synctex.gz'
+      const destOutputFilePath = path.normalize('/angle/gronk.pdf')
+      const syncTexPath = path.normalize('/angle/dangle/gronk.synctex.gz')
+      const destSyncTexPath = path.normalize('/angle/gronk.synctex.gz')
 
       spyOn(fs, 'existsSync').andReturn(true)
 


### PR DESCRIPTION
This PR is a direct extension of #216.

---
- [x] `KnitrBuilder` has OK coverage, but **should** be improved.
  - [x] `canProcess`.
- [x] `LatexmkBuilder` has OK coverage, but **should** be improved.
  - [x] `canProcess`.
  - [x] `logStatusCode`.
  - [x] All permutations supported by `constructArgs`.
- [x] `DefaultLogger` has zero coverage, which **must** be improved.
  - [x] `showErrorMarkersInEditor`
  - [x] `sync`
- [x] `FdbParser` has reasonable coverage, but **can** be improved.
- [ ] `LogParser` has reasonable coverage, but **can** be improved.
- [x] `BuilderRegistry` has poor coverage, which **must** be improved.
  - [x] `getAllBuilders`.
- [ ] `Composer` has less than ideal coverage, which **should** be improved.
  - [x] `sync` — might need too much mocking to be worth it however.
  - [x] `moveResult`.
  - [ ] `resolveOutputFilePath`.
  - [ ] `showResult`
- [ ] `Latex` has OK coverage, but the tests **should** be improved.
  - [ ] Status bar indicator functionality.

---

Resolves #216 
