### PR TITLE
Add support for Evince with SyncTex

### DIFF
--- a/lib/latex.js
+++ b/lib/latex.js
@@ -117,6 +117,10 @@ export default class Latex {
         if (this.okularExecutableExists()) {
           return require('./openers/okular-opener')
         }
+
+        if (this.evinceExecutableExists()) {
+          return require('./openers/evince-opener')
+        }
     }
 
     if (this.hasPdfViewerPackage()) {
@@ -144,6 +148,10 @@ export default class Latex {
 
   okularExecutableExists () {
     return fs.existsSync(atom.config.get('latex.okularPath'))
+  }
+
+  evinceExecutableExists () {
+    return fs.existsSync(atom.config.get('latex.evincePath'))
   }
 
   viewerExecutableExists () {

--- a/lib/openers/evince-opener.js
+++ b/lib/openers/evince-opener.js
@@ -4,78 +4,89 @@ import Opener from '../opener'
 import dbus from 'dbus-native'
 import url from 'url'
 
-function SyncSource (uri, point) {
+const EVINCE_OBJECT = '/org/gnome/evince/Evince'
+const EVINCE_APPLICATION_INTERFACE = 'org.gnome.evince.Application'
+
+const DAEMON_SERVICE = 'org.gnome.evince.Daemon'
+const DAEMON_OBJECT = '/org/gnome/evince/Daemon'
+const DAEMON_INTERFACE = 'org.gnome.evince.Daemon'
+
+const WINDOW_INTERFACE = 'org.gnome.evince.Window'
+
+function syncSource (uri, point) {
   atom.workspace.open(url.parse(uri).pathname).then(editor => editor.setCursorBufferPosition(point))
+}
+
+function getInterface (bus, serviceName, objectName, interfaceName) {
+  return new Promise((resolve, reject) => {
+    bus.getInterface(serviceName, objectName, interfaceName, (error, interfaceInstance) => {
+      if (error) {
+        reject(error)
+      } else {
+        resolve(interfaceInstance)
+      }
+    })
+  })
+}
+
+function getWindowList (application) {
+  return new Promise((resolve, reject) => {
+    application.GetWindowList((error, windowNames) => {
+      if (error) {
+        reject(error)
+      } else {
+        resolve(windowNames)
+      }
+    })
+  })
+}
+
+function findDocument (daemon, filePath) {
+  return new Promise((resolve, reject) => {
+    const uri = url.format({ protocol: 'file:', slashes: true, pathname: filePath })
+    console.log(uri)
+    daemon.FindDocument(uri, true, (error, documentName) => {
+      console.log('sdf')
+      if (error) {
+        reject(error)
+      } else {
+        resolve(documentName)
+      }
+    })
+  })
 }
 
 export default class EvinceOpener extends Opener {
   constructor () {
     super()
     this.bus = dbus.sessionBus()
-    this.daemon = null
     this.windows = {}
   }
 
-  getDaemon (callback) {
-    if (this.daemon) return callback(null, this.daemon)
-    this.bus.getInterface('org.gnome.evince.Daemon', '/org/gnome/evince/Daemon', 'org.gnome.evince.Daemon',
-      (error, daemon) => {
-        if (error) return callback(error, null)
-        this.daemon = daemon
-        callback(null, daemon)
-      })
-  }
+  async getWindow (filePath, texPath) {
+    if (this.windows[texPath]) return this.windows[texPath]
 
-  getWindow (filePath, texPath, callback) {
-    const findDocument = (daemon) => {
-      // The daemon seems to require the file protocol
-      const uri = url.format({ protocol: 'file:', slashes: true, pathname: filePath })
-      daemon.FindDocument(uri, true, (error, name) => {
-        if (error) return callback(error)
-        getApplication(name)
-      })
-    }
+    const daemon = await getInterface(this.bus, DAEMON_SERVICE, DAEMON_OBJECT, DAEMON_INTERFACE)
+    const documentName = await findDocument(daemon, filePath)
+    const application = await getInterface(this.bus, documentName, EVINCE_OBJECT, EVINCE_APPLICATION_INTERFACE)
+    const windows = await getWindowList(application)
+    const windowInterface = await getInterface(this.bus, documentName, windows[0], WINDOW_INTERFACE)
 
-    const getApplication = (name) => {
-      this.bus.getInterface(name, '/org/gnome/evince/Evince', 'org.gnome.evince.Application', (error, application) => {
-        if (error) return callback(error)
-        getWindowList(application, name)
-      })
-    }
+    this.windows[texPath] = windowInterface
+    windowInterface.on('SyncSource', syncSource)
+    windowInterface.on('Closed', () => delete this.windows[texPath])
 
-    const getWindowList = (application, name) => {
-      application.GetWindowList((error, windowNames) => {
-        if (error || windowNames.length === 0) return callback(error)
-        _getWindow(name, windowNames[0])
-      })
-    }
-
-    const _getWindow = (name, windowName) => {
-      this.bus.getInterface(name, windowName, 'org.gnome.evince.Window', (error, windowInterface) => {
-        if (error) return callback(error)
-        this.windows[texPath] = windowInterface
-        windowInterface.on('SyncSource', SyncSource)
-        windowInterface.on('Closed', () => delete this.windows[texPath])
-        // Hack: a small wait seems to help when the document is opened for the
-        // first time.
-        setTimeout(() => callback(null, windowInterface), 200)
-      })
-    }
-
-    if (this.windows[texPath]) return callback(null, this.windows[texPath])
-    this.getDaemon((error, daemon) => {
-      if (error) return callback(error)
-      findDocument(daemon)
-    })
+    return windowInterface
   }
 
   open (filePath, texPath, lineNumber, callback) {
-    this.getWindow(filePath, texPath, (error, windowInterface) => {
-      if (!error) {
-        // The window interface does not seem to work with file protocol
+    this.getWindow(filePath, texPath)
+      .then(windowInterface => {
+        console.log(windowInterface)
         windowInterface.SyncView(texPath, [lineNumber, 0], 0)
-      }
-      if (callback) callback(error)
-    })
+        if (callback) callback(0)
+      }, error => {
+        if (callback) callback(error)
+      })
   }
 }

--- a/lib/openers/evince-opener.js
+++ b/lib/openers/evince-opener.js
@@ -22,7 +22,7 @@ export default class EvinceOpener extends Opener {
       (error, daemon) => {
         if (error) return callback(error, null)
         this.daemon = daemon
-        callback(daemon)
+        callback(null, daemon)
       })
   }
 
@@ -70,10 +70,8 @@ export default class EvinceOpener extends Opener {
   }
 
   open (filePath, texPath, lineNumber, callback) {
-    console.log(lineNumber)
     this.getWindow(filePath, texPath, (error, windowInterface) => {
       if (!error) {
-        console.log(windowInterface)
         // The window interface does not seem to work with file protocol
         windowInterface.SyncView(texPath, [lineNumber, 0], 0)
       }

--- a/lib/openers/evince-opener.js
+++ b/lib/openers/evince-opener.js
@@ -29,9 +29,9 @@ function getInterface (bus, serviceName, objectName, interfaceName) {
   })
 }
 
-function getWindowList (application) {
+function getWindowList (applicationInterface) {
   return new Promise((resolve, reject) => {
-    application.GetWindowList((error, windowNames) => {
+    applicationInterface.GetWindowList((error, windowNames) => {
       if (error) {
         reject(error)
       } else {
@@ -41,12 +41,10 @@ function getWindowList (application) {
   })
 }
 
-function findDocument (daemon, filePath) {
+function findDocument (daemonInterface, filePath) {
   return new Promise((resolve, reject) => {
     const uri = url.format({ protocol: 'file:', slashes: true, pathname: filePath })
-    console.log(uri)
-    daemon.FindDocument(uri, true, (error, documentName) => {
-      console.log('sdf')
+    daemonInterface.FindDocument(uri, true, (error, documentName) => {
       if (error) {
         reject(error)
       } else {
@@ -66,11 +64,11 @@ export default class EvinceOpener extends Opener {
   async getWindow (filePath, texPath) {
     if (this.windows[texPath]) return this.windows[texPath]
 
-    const daemon = await getInterface(this.bus, DAEMON_SERVICE, DAEMON_OBJECT, DAEMON_INTERFACE)
-    const documentName = await findDocument(daemon, filePath)
-    const application = await getInterface(this.bus, documentName, EVINCE_OBJECT, EVINCE_APPLICATION_INTERFACE)
-    const windows = await getWindowList(application)
-    const windowInterface = await getInterface(this.bus, documentName, windows[0], WINDOW_INTERFACE)
+    const daemonInterface = await getInterface(this.bus, DAEMON_SERVICE, DAEMON_OBJECT, DAEMON_INTERFACE)
+    const documentName = await findDocument(daemonInterface, filePath)
+    const applicationInterface = await getInterface(this.bus, documentName, EVINCE_OBJECT, EVINCE_APPLICATION_INTERFACE)
+    const windowNames = await getWindowList(applicationInterface)
+    const windowInterface = await getInterface(this.bus, documentName, windowNames[0], WINDOW_INTERFACE)
 
     this.windows[texPath] = windowInterface
     windowInterface.on('SyncSource', syncSource)
@@ -82,7 +80,6 @@ export default class EvinceOpener extends Opener {
   open (filePath, texPath, lineNumber, callback) {
     this.getWindow(filePath, texPath)
       .then(windowInterface => {
-        console.log(windowInterface)
         windowInterface.SyncView(texPath, [lineNumber, 0], 0)
         if (callback) callback(0)
       }, error => {

--- a/lib/openers/evince-opener.js
+++ b/lib/openers/evince-opener.js
@@ -1,6 +1,5 @@
 /** @babel */
 
-import childProcess from 'child_process'
 import Opener from '../opener'
 import dbus from 'dbus-native'
 import url from 'url'
@@ -29,7 +28,6 @@ export default class EvinceOpener extends Opener {
   }
 
   getWindow (filePath, texPath, callback) {
-
     const findDocument = (daemon) => {
       // The daemon seems to require the file protocol
       daemon.FindDocument('file://' + filePath, true, (error, name) => {

--- a/lib/openers/evince-opener.js
+++ b/lib/openers/evince-opener.js
@@ -13,13 +13,16 @@ const DAEMON_INTERFACE = 'org.gnome.evince.Daemon'
 
 const WINDOW_INTERFACE = 'org.gnome.evince.Window'
 
+const GTK_APPLICATION_OBJECT = '/org/gtk/Application/anonymous'
+const GTK_APPLICATION_INTERFACE = 'org.freedesktop.Application'
+
 function syncSource (uri, point) {
   atom.workspace.open(url.parse(uri).pathname).then(editor => editor.setCursorBufferPosition(point))
 }
 
-function getInterface (bus, serviceName, objectName, interfaceName) {
+function getInterface (bus, serviceName, objectPath, interfaceName) {
   return new Promise((resolve, reject) => {
-    bus.getInterface(serviceName, objectName, interfaceName, (error, interfaceInstance) => {
+    bus.getInterface(serviceName, objectPath, interfaceName, (error, interfaceInstance) => {
       if (error) {
         reject(error)
       } else {
@@ -29,9 +32,9 @@ function getInterface (bus, serviceName, objectName, interfaceName) {
   })
 }
 
-function getWindowList (applicationInterface) {
+function getWindowList (evinceApplication) {
   return new Promise((resolve, reject) => {
-    applicationInterface.GetWindowList((error, windowNames) => {
+    evinceApplication.GetWindowList((error, windowNames) => {
       if (error) {
         reject(error)
       } else {
@@ -41,10 +44,10 @@ function getWindowList (applicationInterface) {
   })
 }
 
-function findDocument (daemonInterface, filePath) {
+function findDocument (daemon, filePath) {
   return new Promise((resolve, reject) => {
     const uri = url.format({ protocol: 'file:', slashes: true, pathname: filePath })
-    daemonInterface.FindDocument(uri, true, (error, documentName) => {
+    daemon.FindDocument(uri, true, (error, documentName) => {
       if (error) {
         reject(error)
       } else {
@@ -64,23 +67,39 @@ export default class EvinceOpener extends Opener {
   async getWindow (filePath, texPath) {
     if (this.windows[texPath]) return this.windows[texPath]
 
-    const daemonInterface = await getInterface(this.bus, DAEMON_SERVICE, DAEMON_OBJECT, DAEMON_INTERFACE)
-    const documentName = await findDocument(daemonInterface, filePath)
-    const applicationInterface = await getInterface(this.bus, documentName, EVINCE_OBJECT, EVINCE_APPLICATION_INTERFACE)
-    const windowNames = await getWindowList(applicationInterface)
-    const windowInterface = await getInterface(this.bus, documentName, windowNames[0], WINDOW_INTERFACE)
+    // First get the Evince daemon interface so we can find the internal document name
+    const daemon = await getInterface(this.bus, DAEMON_SERVICE, DAEMON_OBJECT, DAEMON_INTERFACE)
+    const documentName = await findDocument(daemon, filePath)
 
-    this.windows[texPath] = windowInterface
-    windowInterface.on('SyncSource', syncSource)
-    windowInterface.on('Closed', () => delete this.windows[texPath])
+    // Get the application interface and get the window list of the application
+    const evinceApplication = await getInterface(this.bus, documentName, EVINCE_OBJECT, EVINCE_APPLICATION_INTERFACE)
+    const windowNames = await getWindowList(evinceApplication)
 
-    return windowInterface
+    // Get the window interface of the of the first (only) window and get the
+    // GTK/FreeDesktop application interface so we can activate the window
+    const interfaces = {
+      evinceWindow: await getInterface(this.bus, documentName, windowNames[0], WINDOW_INTERFACE),
+      gtkApplication: await getInterface(this.bus, documentName, GTK_APPLICATION_OBJECT, GTK_APPLICATION_INTERFACE)
+    }
+
+    interfaces.evinceWindow.on('SyncSource', syncSource)
+    interfaces.evinceWindow.on('Closed', () => delete this.windows[texPath])
+    this.windows[texPath] = interfaces
+
+    // This seems to help with future syncs
+    interfaces.evinceWindow.SyncView(texPath, [0, 0], 0)
+
+    return interfaces
   }
 
   open (filePath, texPath, lineNumber, callback) {
     this.getWindow(filePath, texPath)
-      .then(windowInterface => {
-        windowInterface.SyncView(texPath, [lineNumber, 0], 0)
+      .then(interfaces => {
+        if (!this.shouldOpenInBackground()) {
+          interfaces.gtkApplication.Activate({})
+        }
+        // SyncView seems to want to activate the window sometimes
+        interfaces.evinceWindow.SyncView(texPath, [lineNumber, 0], 0)
         if (callback) callback(0)
       }, error => {
         if (callback) callback(error)

--- a/lib/openers/evince-opener.js
+++ b/lib/openers/evince-opener.js
@@ -1,0 +1,81 @@
+/** @babel */
+
+import childProcess from 'child_process'
+import Opener from '../opener'
+import dbus from 'dbus-native'
+import url from 'url'
+
+function SyncSource (uri, point) {
+  atom.workspace.open(url.parse(uri).pathname).then(editor => editor.setCursorBufferPosition(point))
+}
+
+export default class EvinceOpener extends Opener {
+  constructor () {
+    super()
+    this.bus = dbus.sessionBus()
+    this.bus.signals.on('SyncSource', () => console.log(arguments))
+    this.daemon = null
+    this.windows = {}
+  }
+
+  getDaemon (callback) {
+    if (this.daemon) return callback(null, this.daemon)
+    this.bus.getInterface('org.gnome.evince.Daemon', '/org/gnome/evince/Daemon', 'org.gnome.evince.Daemon',
+      (error, daemon) => {
+        if (error) return callback(error, null)
+        this.daemon = daemon
+        callback(daemon)
+      })
+  }
+
+  getWindow (filePath, texPath, callback) {
+
+    const findDocument = (daemon) => {
+      // The daemon seems to require the file protocol
+      daemon.FindDocument('file://' + filePath, true, (error, name) => {
+        if (error) return callback(error)
+        getApplication(name)
+      })
+    }
+
+    const getApplication = (name) => {
+      this.bus.getInterface(name, '/org/gnome/evince/Evince', 'org.gnome.evince.Application', (error, application) => {
+        if (error) return callback(error)
+        getWindowList(application, name)
+      })
+    }
+
+    const getWindowList = (application, name) => {
+      application.GetWindowList((error, windowNames) => {
+        if (error || windowNames.length === 0) return callback(error)
+        _getWindow(name, windowNames[0])
+      })
+    }
+
+    const _getWindow = (name, windowName) => {
+      this.bus.getInterface(name, windowName, 'org.gnome.evince.Window', (error, windowInterface) => {
+        if (error) return callback(error)
+        this.windows[texPath] = windowInterface
+        windowInterface.on('SyncSource', SyncSource)
+        windowInterface.on('Closed', () => delete this.windows[texPath])
+        callback(null, windowInterface)
+      })
+    }
+
+    if (this.windows[texPath]) return callback(null, this.windows[texPath])
+    this.getDaemon((error, daemon) => {
+      if (error) return callback(error)
+      findDocument(daemon)
+    })
+  }
+
+  open (filePath, texPath, lineNumber, callback) {
+    this.getWindow(filePath, texPath, (error, windowInterface) => {
+      if (!error) {
+        // The window interface does not seem to work with file protocol
+        windowInterface.SyncView(texPath, [lineNumber, 0], 0)
+      }
+      if (callback) callback(error)
+    })
+  }
+}

--- a/lib/openers/evince-opener.js
+++ b/lib/openers/evince-opener.js
@@ -12,7 +12,6 @@ export default class EvinceOpener extends Opener {
   constructor () {
     super()
     this.bus = dbus.sessionBus()
-    this.bus.signals.on('SyncSource', () => console.log(arguments))
     this.daemon = null
     this.windows = {}
   }
@@ -30,7 +29,8 @@ export default class EvinceOpener extends Opener {
   getWindow (filePath, texPath, callback) {
     const findDocument = (daemon) => {
       // The daemon seems to require the file protocol
-      daemon.FindDocument('file://' + filePath, true, (error, name) => {
+      const uri = url.format({ protocol: 'file:', slashes: true, pathname: filePath })
+      daemon.FindDocument(uri, true, (error, name) => {
         if (error) return callback(error)
         getApplication(name)
       })
@@ -56,7 +56,9 @@ export default class EvinceOpener extends Opener {
         this.windows[texPath] = windowInterface
         windowInterface.on('SyncSource', SyncSource)
         windowInterface.on('Closed', () => delete this.windows[texPath])
-        callback(null, windowInterface)
+        // Hack: a small wait seems to help when the document is opened for the
+        // first time.
+        setTimeout(() => callback(null, windowInterface), 200)
       })
     }
 
@@ -68,8 +70,10 @@ export default class EvinceOpener extends Opener {
   }
 
   open (filePath, texPath, lineNumber, callback) {
+    console.log(lineNumber)
     this.getWindow(filePath, texPath, (error, windowInterface) => {
       if (!error) {
+        console.log(windowInterface)
         // The window interface does not seem to work with file protocol
         windowInterface.SyncView(texPath, [lineNumber, 0], 0)
       }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "main": "./lib/main",
   "repository": "https://github.com/thomasjo/atom-latex",
   "dependencies": {
+    "dbus-native": "^0.2.0",
     "etch": "0.7.1",
     "fs-plus": "^2.9.1",
     "lodash": "^4.13.1",
@@ -213,18 +214,24 @@
       "default": "/usr/bin/okular",
       "order": 18
     },
+    "evincePath": {
+      "description": "Full application path to Evince (*nix).",
+      "type": "string",
+      "default": "/usr/bin/evince",
+      "order": 19
+    },
     "viewerPath": {
       "title": "Custom PDF Viewer Path",
       "description": "Full application path to your PDF viewer. Overrides Skim and SumatraPDF options.",
       "type": "string",
       "default": "",
-      "order": 19
+      "order": 20
     },
     "useMasterFileSearch": {
       "description": "Enables naive search for master/root file when building distributed documents. Note that this does not affect the equivalent *Magic Comments* functionality.",
       "type": "boolean",
       "default": false,
-      "order": 20
+      "order": 21
     }
   }
 }


### PR DESCRIPTION
This PR addresses #162. It is currently a bit of callback hell, but SyncTeX forward and backward are working.

## Remaining issues

- [x] Determine if `dbus.sessionBus()` needs to be disposed of. *It does not, although if we allow the user to change the opener we may need to call `removeListener`*
- [x] It should be possible to listen to all Evince instances and respond to `SyncSource` even if a build has not been done yet by listening to [add_signal_receiver](https://dbus.freedesktop.org/doc/dbus-python/api/dbus.bus.BusConnection-class.html#add_signal_receiver), but I have not been able figure out how do this using dbus-native. The current functionality matches that of okular, etc. *It's done with `addMatch` but it seems useless, since Evince does not start sending `SyncSource` until it receives `SyncView`.*
- [x] Improve the opener logic. Evince is only called if Okular is not present. Maybe the user should be able to choose? *I'll do it in another PR*
- [x] Test on old versions of Evince. dbus does not appear to be versioned like COM. The GNOME team added `timestamp` parameter to [`SyncView`](https://github.com/GNOME/evince/blob/d681da676c4a52590330426ba18196ddcfbb8037/shell/ev-gdbus.xml) in version [2.91.0](https://github.com/GNOME/evince/blob/master/NEWS). If we do not pass this parameter (zero works) then current versions break. Passing this parameter may cause old versions to break, so we may need to inspect the method signature. *Evince 2.91.0 was released in 2011, so I think we are okay assuming the `s(ii)u` signature.*
- [x] Investigate support for opening in foreground vs. background. *Done, although SyncView seems a little fickle about window activation so it may not be perfect.*