### PR TITLE
Deprecate texify support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,32 @@ from the command line.
 
 ## Prerequisites
 ### TeX distribution
-Since this package relies upon `latexmk`, a reasonably up to date and working
-TeX distribution is required. The only current officially supported
-distributions are [TeX Live](https://www.tug.org/texlive/), and
-[MiKTeX](http://miktex.org/). Although the latter is not as well tested and
-supported as TeX Live, hence using TeX Live is highly recommended.
+Since this package relies upon `latexmk`, a reasonably up-to-date and working
+TeX distribution is required. The only officially supported distributions are
+[TeX Live](https://www.tug.org/texlive/), and [MiKTeX](http://miktex.org/).
+Although, the latter is not as well tested and supported as TeX Live, hence
+using TeX Live is highly recommended.
 
-You need to ensure that the package can find your TeX distribution; to help the
-package find the distribution's binaries, you need to configure the *TeX Path*
-configuration variable to point to the folder containing the binaries. This can
-be done either in the settings view, or directly in your `config.cson` file.
+You need to ensure that the package can find your TeX distribution's binaries;
+by default the package uses your `PATH` environment variable, as well as the
+following search paths on Linux and macOS
+
+1. `/usr/texbin`
+2. `/Library/TeX/texbin`
+
+and on Windows it uses
+
+1. `%SystemDrive%\texlive\2016\bin\win32`
+2. `%SystemDrive%\texlive\2015\bin\win32`
+3. `%SystemDrive%\texlive\2014\bin\win32`
+4. `%ProgramFiles%\MiKTeX 2.9\miktex\bin\x64`
+5. `%ProgramFiles(x86)%\MiKTeX 2.9\miktex\bin`
+
+If your TeX distribution's binaries are not installed in one of those locations
+or discoverable via the `PATH` environment variable, you will need to help the
+package find the binaries. This can be done by setting the *TeX Path*
+configuration option to point to the folder containing the binaries, either in
+the settings view, or directly in your `config.cson` file.
 
 #### TeX Live
 If you're using TeX Live and have installed to the default location then no
@@ -49,19 +65,3 @@ some important features. As an example, there's no proper error and warning
 handling.
 
 Any and all help is greatly appreciated!
-
-### TODO
-Current wish list, in a semi-prioritized order.
-
-- [X] Improved build output parsing;
-  - [X] Error handling.
-  - [X] Warnings, and other non-critical messages.
-- [ ] Improved display of errors, warnings and other non-critical messages.
-- [ ] Project-specific settings;
-  - [ ] Setting to override the output directory.
-  - [X] Setting to override the builder.
-
-If you see something that's missing, or disagree with the prioritization,
-consider submitting a [feature request](https://github.com/thomasjo/atom-latex/issues?labels=feature&state=open),
-and if you're feeling super helpful, submit a pull request with an updated TODO
-list :sparkling_heart:

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ from the command line.
 
 ## Prerequisites
 ### TeX distribution
-Since this package relies upon either `latexmk` or `texify`, a reasonably up to
-date and working TeX distribution is required. The only current officially
-supported distributions are [TeX Live](https://www.tug.org/texlive/), and
+Since this package relies upon `latexmk`, a reasonably up to date and working
+TeX distribution is required. The only current officially supported
+distributions are [TeX Live](https://www.tug.org/texlive/), and
 [MiKTeX](http://miktex.org/). Although the latter is not as well tested and
 supported as TeX Live, hence using TeX Live is highly recommended.
 
@@ -28,9 +28,8 @@ If you're using TeX Live and have installed to the default location then no
 further action should be required.
 
 #### MiKTeX
-If you're using MikTeX and have installed to the default location then all you
-should need to do is change the *Builder* to `texify`. This can be done either
-in the settings view, or directly in your `config.cson` file.
+If you're using MikTeX and have not installed the required `latexmk` package,
+please read the instructions on how to [use `latexmk` with MiKTeX](https://github.com/thomasjo/atom-latex/wiki/Using-latexmk-with-MiKTeX)
 
 ## Usage
 Invoke the `build` command by pressing the default keybind `ctrl-alt-b` while in

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -1,8 +1,10 @@
 /** @babel */
 
+import { shell } from 'electron'
 import fs from 'fs-plus'
 import path from 'path'
 import BuilderRegistry from './builder-registry'
+import { heredoc } from './werkzeug'
 
 export default class Composer {
   constructor () {
@@ -30,6 +32,29 @@ export default class Composer {
     if (builder == null) {
       latex.log.warning(`No registered LaTeX builder can process ${filePath}.`)
       return Promise.reject(false)
+    } else if (Object.getPrototypeOf(builder).constructor.name === 'TexifyBuilder') {
+      // -------------------------------------------------------------
+      // TODO: Remove this whole block when texify support is removed.
+      // -------------------------------------------------------------
+      const message = `LaTeX: The texify builder has been deprecated`
+      const description = heredoc(`
+        Support for the \`texify\` builder has been deprecated in favor of \`latexmk\`, and will be
+        removed soon.`)
+
+      const title = 'How to use latexmk with MiKTeX'
+      const url = 'https://github.com/thomasjo/atom-latex/wiki/Using-latexmk-with-MiKTeX'
+      const openUrl = (event) => {
+        // NOTE: Horrible hack due to a bug in atom/notifications module...
+        const element = event.target.parentElement.parentElement.parentElement.parentElement
+        const notification = element.getModel()
+        notification.dismiss()
+
+        shell.openExternal(url)
+      }
+
+      atom.notifications.addWarning(message, {
+        dismissable: true, description, buttons: [{ text: title, onDidClick: openUrl }]
+      })
     }
 
     this.destroyErrorIndicator()


### PR DESCRIPTION
This PR officially deprecates our `texify` support. The user is presented with a fairly annoying warning notification. Clicking the button opens the wiki page ["Using-latexmk-with-MiKTeX"](https://github.com/thomasjo/atom-latex/wiki/Using-latexmk-with-MiKTeX).

<img width="960" alt="file1_tex_ __users_thomasjo_scratch_latex_test1" src="https://cloud.githubusercontent.com/assets/3622/18671117/214c4dcc-7f43-11e6-954b-46e6e62db45e.png">
