### PR TITLE
Add diagnostics report command

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -16,6 +16,7 @@ export default class Builder {
   static canProcess (/* filePath */) {}
   run (/* filePath, jobname */) {}
   constructArgs (/* filePath, jobname */) {}
+  async diagnostics (/* diagnosticsReport */) {}
 
   logStatusCode (statusCode) {
     switch (statusCode) {

--- a/lib/builders/knitr.js
+++ b/lib/builders/knitr.js
@@ -68,4 +68,9 @@ export default class KnitrBuilder extends Builder {
     const BuilderImpl = this.builderRegistry.getBuilder(filePath)
     return new BuilderImpl()
   }
+
+  diagnostics (diagnosticsReport) {
+    const options = this.constructChildProcessOptions('foo.Rnw')
+    return diagnosticsReport.exec('Knitr Test', `${this.executable} --verbose -e "library(knitr)"`, options)
+  }
 }

--- a/lib/builders/latexmk.js
+++ b/lib/builders/latexmk.js
@@ -108,7 +108,9 @@ export default class LatexmkBuilder extends Builder {
   async diagnostics (diagnosticsReport) {
     const options = this.constructChildProcessOptions('foo.tex')
     return diagnosticsReport.exec('Latexmk Test', `${this.executable} -commands`, options)
-      .then(() => diagnosticsReport.exec('TeX Live Test', 'tlmgr conf'), options)
-      .then(() => diagnosticsReport.exec('MiKTeX Test', 'initexmf --report'), options)
+      .then(() => diagnosticsReport.exec('TeX Live Test', 'tlmgr conf', options))
+      .then(() => {
+        if (process.platform === 'win32') diagnosticsReport.exec('MiKTeX Test', 'initexmf --report', options)
+      })
   }
 }

--- a/lib/builders/latexmk.js
+++ b/lib/builders/latexmk.js
@@ -104,4 +104,11 @@ export default class LatexmkBuilder extends Builder {
         return `-pdfdvi -e "\\$dvipdf = \'${producer} %O -o %D %S\';"`
     }
   }
+
+  async diagnostics (diagnosticsReport) {
+    const options = this.constructChildProcessOptions('foo.tex')
+    return diagnosticsReport.exec('Latexmk Test', `${this.executable} -commands`, options)
+      .then(() => diagnosticsReport.exec('TeX Live Test', 'tlmgr conf'), options)
+      .then(() => diagnosticsReport.exec('MiKTeX Test', 'initexmf --report'), options)
+  }
 }

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -5,6 +5,9 @@ import fs from 'fs-plus'
 import path from 'path'
 import BuilderRegistry from './builder-registry'
 import { heredoc } from './werkzeug'
+import DiagnosticsReport from './diagnostics-report'
+import os from 'os'
+import _ from 'lodash'
 
 export default class Composer {
   constructor () {
@@ -141,6 +144,28 @@ export default class Composer {
         })
       })
     }))
+  }
+
+  diagnostics () {
+    const diagnosticsReport = new DiagnosticsReport()
+
+    diagnosticsReport.addSection('System Properties')
+    diagnosticsReport.addProperty('Atom Version', atom.getVersion())
+    diagnosticsReport.addProperty('Platform', os.platform())
+    diagnosticsReport.addProperty('Release', os.release())
+
+    diagnosticsReport.addSection('LaTeX Settings')
+    diagnosticsReport.addJsonBlock(atom.config.get('latex'))
+
+    diagnosticsReport.addSection('Environment')
+    diagnosticsReport.addJsonBlock(_.pick(process.env, [
+      'PATH',
+      'Path'
+    ]))
+
+    latex.logger.diagnostics(diagnosticsReport)
+      .then(() => this.getBuilder('foo.tex').diagnostics(diagnosticsReport))
+      .then(() => diagnosticsReport.report())
   }
 
   setStatusBar (statusBar) {

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -163,8 +163,8 @@ export default class Composer {
       'Path'
     ]))
 
-    latex.logger.diagnostics(diagnosticsReport)
-      .then(() => this.getBuilder('foo.tex').diagnostics(diagnosticsReport))
+    Promise.all(_.map(this.builderRegistry.getAllBuilders(), BuilderImpl => new BuilderImpl().diagnostics(diagnosticsReport)))
+      .then(() => latex.logger.diagnostics(diagnosticsReport))
       .then(() => diagnosticsReport.report())
   }
 

--- a/lib/diagnostics-report.js
+++ b/lib/diagnostics-report.js
@@ -1,0 +1,68 @@
+/** @babel */
+
+import childProcess from 'child_process'
+import _ from 'lodash'
+
+export default class DiagnosticsReport {
+  constructor () {
+    this.summary = 'Detailed Markdown formatted diagnostics placed on clipboard.\n\n'
+    this.detailed = '# Detailed LaTeX Diagnostics\n\n'
+  }
+
+  addSection (title) {
+    this.detailed += `## ${title}\n\n`
+  }
+
+  addSubSection (title) {
+    this.detailed += `### ${title}\n\n`
+  }
+
+  addSummary (text, includeDetailed) {
+    this.summary += text
+    if (includeDetailed) this.detailed += text + '\n'
+  }
+
+  addCodeBlock (text, grammar) {
+    this.detailed += grammar ? `\`\`\`${grammar}\n` : '```\n'
+    this.detailed += text + (_.endsWith(text, '\n') ? '' : '\n') + '```\n'
+  }
+
+  addJsonBlock (value) {
+    this.addCodeBlock(JSON.stringify(value, null, 2), 'json')
+  }
+
+  addDetailed (text) {
+    this.detailed += text + '\n'
+  }
+
+  addProperty (name, value) {
+    this.detailed += `${name}: ${value}\n`
+  }
+
+  exec (title, command, options) {
+    return new Promise((resolve) => {
+      childProcess.exec(command, options || {}, (error, stdout, stderr) => {
+        this.addSection(title)
+        if (error) {
+          this.addSummary(`\`${command}\` execution failed with a status code of ${error.code}.\n`, true)
+        } else {
+          this.addSummary(`\`${command}\` execution succeeded.\n`, true)
+        }
+        if (stderr) {
+          this.addSubSection('stderr')
+          this.addCodeBlock(stderr)
+        }
+        if (stdout) {
+          this.addSubSection('stdout')
+          this.addCodeBlock(stdout)
+        }
+        resolve()
+      })
+    })
+  }
+
+  report () {
+    atom.clipboard.write(this.detailed)
+    atom.notifications.addInfo('LaTeX diagnostics completed', { detail: this.summary })
+  }
+}

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -50,6 +50,28 @@ export default class Logger {
     }))
   }
 
+  async diagnostics (diagnosticsReport) {
+    // Remove all info messages
+    const messages = _.filter(this.messages, message => message.type !== 'Info')
+    if (messages.length === 0) return
+
+    diagnosticsReport.addSection('Log Messages')
+    let detailed =
+      '| Type | Message |\n' +
+      '|:----:|:--------|\n'
+
+    for (const message of messages) {
+      const icon = message.type === 'Error' ? ':exclamation:' : ':warning:'
+      detailed += `| ${icon} | ${message.text} `
+      if (message.filePath) {
+        detailed += `<br> *[${message.filePath}${message.range ? ':' + message.range[0][0] : ''}]* `
+      }
+      detailed += '|\n'
+    }
+
+    diagnosticsReport.addDetailed(detailed)
+  }
+
   show (/* label, messages */) {}
 
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -10,7 +10,8 @@ export default {
     this.disposables.add(atom.commands.add('atom-workspace', {
       'latex:build': () => this.composer.build(),
       'latex:clean': () => this.composer.clean(),
-      'latex:sync': () => this.composer.sync()
+      'latex:sync': () => this.composer.sync(),
+      'latex:diagnostics': () => this.composer.diagnostics()
     }))
 
     this.disposables.add(atom.workspace.observeTextEditors(editor => {

--- a/menus/latex.json
+++ b/menus/latex.json
@@ -7,7 +7,8 @@
           "label": "LaTeX",
           "submenu": [
             { "label": "Build", "command": "latex:build" },
-            { "label": "Clean", "command": "latex:clean" }
+            { "label": "Clean", "command": "latex:clean" },
+            { "label": "Diagnostics", "command": "latex:diagnostics" }
           ]
         }
       ]


### PR DESCRIPTION
This PR is a start on a diagnostics report to aid with troubleshooting. A command `latex:diagnostics` command is added that will execute various diagnostics and information collection. A summary (currently very simplistic) will be displayed in a notification box and detailed information will put put on the clipboard.

*Sample report output (`initexmf --report` is run on win32):*

# Detailed LaTeX Diagnostics

## System Properties

Atom Version: 1.10.2
Platform: linux
Release: 4.7.4-1.1-MANJARO
## LaTeX Settings

```json
{
  "enableShellEscape": true,
  "logger": "issue",
  "loggingLevel": "info",
  "moveResultToSourceDirectory": false,
  "openResultInBackground": false,
  "outputDirectory": "output",
  "texPath": "",
  "builder": "latexmk",
  "engine": "pdflatex",
  "customEngine": "",
  "enableSynctex": true,
  "cleanExtensions": [
    ".aux",
    ".bbl",
    ".blg",
    ".fdb_latexmk",
    ".fls",
    ".lof",
    ".log",
    ".lol",
    ".lot",
    ".nav",
    ".out",
    ".pdf",
    ".snm",
    ".synctex.gz",
    ".toc"
  ],
  "outputFormat": "pdf",
  "buildOnSave": false,
  "openResultAfterBuild": true,
  "alwaysOpenResultInAtom": false,
  "skimPath": "/Applications/Skim.app",
  "sumatraPath": "C:\\Program Files (x86)\\SumatraPDF\\SumatraPDF.exe",
  "okularPath": "/usr/bin/okular",
  "evincePath": "/usr/bin/evince",
  "viewerPath": "",
  "useMasterFileSearch": false
}
```
## Environment

```json
{
  "PATH": "/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/lib/jvm/default/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:/usr/local/bin"
}
```
## Latexmk Test

`latexmk -commands` execution succeeded.

### stderr

```
Commands used by latexmk:
   To run latex, I use "latex %O %S"
   To run pdflatex, I use "pdflatex %O %S"
   To run biber, I use "biber %O %B"
   To run bibtex, I use "bibtex %O %B"
   To run makeindex, I use "makeindex %O -o %D %S"
   To make a ps file from a dvi file, I use "dvips %O -o %D %S"
   To make a ps file from a dvi file with landscape format, I use "dvips -tlandscape %O -o %D %S"
   To make a pdf file from a dvi file, I use "dvipdf %O %S %D"
   To make a pdf file from a ps file, I use "ps2pdf  %O %S %D"
   To view a pdf file, I use "start evince"
   To view a ps file, I use "start gv %O %S"
   To view a ps file in landscape format, I use "start gv -swap %O %S"
   To view a dvi file, I use "start xdvi %O %S"
   To view a dvi file in landscape format, I use "start xdvi -paper usr %O %S"
   To print a ps file, I use "lpr %O %S"
   To print a dvi file, I use "NONE $lpr_dvi variable is not configured to allow printing of dvi files"
   To print a pdf file, I use "NONE $lpr_pdf variable is not configured to allow printing of pdf files"
   To find running processes, I use "ps -f -u yitzi", 
      and the process number is at position 1
Notes:
  Command starting with "start" is run detached
  Command that is just "start" without any other command, is
     used under MS-Windows to run the command the operating system
     has associated with the relevant file.
  Command starting with "NONE" is not used at all
```
## Knitr Test

`Rscript --verbose -e "library(knitr)"` execution succeeded.

### stderr

```
running
  '/usr/lib/R/bin/R --slave --no-restore -e library(knitr)'

```
## TeX Live Test

`tlmgr conf` execution succeeded.

### stdout

```
=========================== version information ==========================
tlmgr revision 41476 (2016-06-18 02:45:25 +0200)
tlmgr using installation: /usr/local/texlive/2016
TeX Live (http://tug.org/texlive) version 2016

==================== executables found by searching PATH =================
PATH: /usr/local/bin:/usr/texbin:/Library/TeX/texbin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/lib/jvm/default/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:/usr/local/bin
kpsewhich: /usr/local/bin/kpsewhich
updmap: /usr/local/bin/updmap
fmtutil: /usr/local/bin/fmtutil
tlmgr: /usr/local/bin/tlmgr
tex: /usr/local/bin/tex
pdftex: /usr/local/bin/pdftex
mktexpk: /usr/local/bin/mktexpk
dvips: /usr/local/bin/dvips
dvipdfmx: /usr/local/bin/dvipdfmx
=========================== active config files ==========================
texmf.cnf: /usr/local/texlive/2016/texmf.cnf
texmf.cnf: /usr/local/texlive/2016/texmf-dist/web2c/texmf.cnf
updmap.cfg: /usr/local/texlive/2016/texmf-dist/web2c/updmap.cfg
fmtutil.cnf: /usr/local/texlive/2016/texmf-dist/web2c/fmtutil.cnf
config.ps: /usr/local/texlive/2016/texmf-config/dvips/config/config.ps
mktex.cnf: /usr/local/texlive/2016/texmf-dist/web2c/mktex.cnf
pdftexconfig.tex: /usr/local/texlive/2016/texmf-config/tex/generic/config/pdftexconfig.tex
============================= font map files =============================
psfonts.map: /usr/local/texlive/2016/texmf-var/fonts/map/dvips/updmap/psfonts.map
pdftex.map: /usr/local/texlive/2016/texmf-var/fonts/map/pdftex/updmap/pdftex.map
ps2pk.map: /usr/local/texlive/2016/texmf-var/fonts/map/dvips/updmap/ps2pk.map
kanjix.map: /usr/local/texlive/2016/texmf-var/fonts/map/dvipdfmx/updmap/kanjix.map
=========================== kpathsea variables ===========================
TEXMFMAIN=/usr/local/texlive/2016/texmf-dist
TEXMFDIST=/usr/local/texlive/2016/texmf-dist
TEXMFLOCAL=/usr/local/texlive/texmf-local
TEXMFSYSVAR=/usr/local/texlive/2016/texmf-var
TEXMFSYSCONFIG=/usr/local/texlive/2016/texmf-config
TEXMFVAR=/home/yitzi/.texlive2016/texmf-var
TEXMFCONFIG=/home/yitzi/.texlive2016/texmf-config
TEXMFHOME=/home/yitzi/texmf
VARTEXFONTS=/home/yitzi/.texlive2016/texmf-var/fonts
TEXMF={/home/yitzi/.texlive2016/texmf-config,/home/yitzi/.texlive2016/texmf-var,/home/yitzi/texmf,!!/usr/local/texlive/2016/texmf-config,!!/usr/local/texlive/2016/texmf-var,!!/usr/local/texlive/texmf-local,!!/usr/local/texlive/2016/texmf-dist}
SYSTEXMF=/usr/local/texlive/2016/texmf-var:/usr/local/texlive/texmf-local:/usr/local/texlive/2016/texmf-dist
TEXMFDBS={!!/usr/local/texlive/2016/texmf-config,!!/usr/local/texlive/2016/texmf-var,!!/usr/local/texlive/texmf-local,!!/usr/local/texlive/2016/texmf-dist}
WEB2C={/home/yitzi/.texlive2016/texmf-config,/home/yitzi/.texlive2016/texmf-var,/home/yitzi/texmf,!!/usr/local/texlive/2016/texmf-config,!!/usr/local/texlive/2016/texmf-var,!!/usr/local/texlive/texmf-local,!!/usr/local/texlive/2016/texmf-dist}/web2c
TEXPSHEADERS=.:{/home/yitzi/.texlive2016/texmf-config,/home/yitzi/.texlive2016/texmf-var,/home/yitzi/texmf,!!/usr/local/texlive/2016/texmf-config,!!/usr/local/texlive/2016/texmf-var,!!/usr/local/texlive/texmf-local,!!/usr/local/texlive/2016/texmf-dist}/{dvips,fonts/{enc,type1,type42,type3}}//
TEXCONFIG={/home/yitzi/.texlive2016/texmf-config,/home/yitzi/.texlive2016/texmf-var,/home/yitzi/texmf,!!/usr/local/texlive/2016/texmf-config,!!/usr/local/texlive/2016/texmf-var,!!/usr/local/texlive/texmf-local,!!/usr/local/texlive/2016/texmf-dist}/dvips//
ENCFONTS=.:{/home/yitzi/.texlive2016/texmf-config,/home/yitzi/.texlive2016/texmf-var,/home/yitzi/texmf,!!/usr/local/texlive/2016/texmf-config,!!/usr/local/texlive/2016/texmf-var,!!/usr/local/texlive/texmf-local,!!/usr/local/texlive/2016/texmf-dist}/fonts/enc//
TEXFONTMAPS=.:{/home/yitzi/.texlive2016/texmf-config,/home/yitzi/.texlive2016/texmf-var,/home/yitzi/texmf,!!/usr/local/texlive/2016/texmf-config,!!/usr/local/texlive/2016/texmf-var,!!/usr/local/texlive/texmf-local,!!/usr/local/texlive/2016/texmf-dist}/fonts/map/{kpsewhich,pdftex,dvips,}//
==== kpathsea variables from environment only (ok if no output here) ====
```
## Log Messages

| Type | Message |
|:----:|:--------|
| :warning: | Class foo: Nebulous class issue <br> *[/home/yitzi/Documents/git/atom-latex/spec/fixtures/error-warning.tex]* |
| :warning: | Class foo: Nebulous class issue <br> *[/home/yitzi/Documents/git/atom-latex/spec/fixtures/error-warning.tex]* |
| :warning: | Package bar: Nebulous package issue <br> *[/home/yitzi/Documents/git/atom-latex/spec/fixtures/error-warning.tex]* |
| :warning: | Package bar: Nebulous package issue <br> *[/home/yitzi/Documents/git/atom-latex/spec/fixtures/error-warning.tex]* |
| :warning: | There were undefined references <br> *[/home/yitzi/Documents/git/atom-latex/spec/fixtures/error-warning.tex]* |
| :warning: | There were undefined references <br> *[/home/yitzi/Documents/git/atom-latex/spec/fixtures/error-warning.tex]* |
| :exclamation: | There's no line here to end <br> *[/home/yitzi/Documents/git/atom-latex/spec/fixtures/error-warning.tex:10]* |
| :exclamation: | There's no line here to end <br> *[/home/yitzi/Documents/git/atom-latex/spec/fixtures/error-warning.tex:10]* |
| :exclamation: | Argument of \@sect has an extra } <br> *[/home/yitzi/Documents/git/atom-latex/spec/fixtures/error-warning.tex:15]* |
| :exclamation: | Argument of \@sect has an extra } <br> *[/home/yitzi/Documents/git/atom-latex/spec/fixtures/error-warning.tex:15]* |
| :exclamation: | Paragraph ended before \@sect was complete <br> *[/home/yitzi/Documents/git/atom-latex/spec/fixtures/error-warning.tex:15]* |
| :exclamation: | Paragraph ended before \@sect was complete <br> *[/home/yitzi/Documents/git/atom-latex/spec/fixtures/error-warning.tex:15]* |
| :exclamation: | Extra alignment tab has been changed to \cr <br> *[/home/yitzi/Documents/git/atom-latex/spec/fixtures/error-warning.tex:24]* |
| :exclamation: | Extra alignment tab has been changed to \cr <br> *[/home/yitzi/Documents/git/atom-latex/spec/fixtures/error-warning.tex:24]* |
| :warning: | Reference `tab:snafu' on page 1 undefined <br> *[/home/yitzi/Documents/git/atom-latex/spec/fixtures/error-warning.tex:28]* |
| :warning: | Reference `tab:snafu' on page 1 undefined <br> *[/home/yitzi/Documents/git/atom-latex/spec/fixtures/error-warning.tex:28]* |
| :exclamation: | Class foo: Significant class issue <br> *[/home/yitzi/Documents/git/atom-latex/spec/fixtures/error-warning.tex:31]* |
| :exclamation: | Class foo: Significant class issue <br> *[/home/yitzi/Documents/git/atom-latex/spec/fixtures/error-warning.tex:31]* |
| :warning: | Class foo: Class issue <br> *[/home/yitzi/Documents/git/atom-latex/spec/fixtures/error-warning.tex:32]* |
| :warning: | Class foo: Class issue <br> *[/home/yitzi/Documents/git/atom-latex/spec/fixtures/error-warning.tex:32]* |
| :exclamation: | Package bar: Significant package issue <br> *[/home/yitzi/Documents/git/atom-latex/spec/fixtures/error-warning.tex:37]* |
| :exclamation: | Package bar: Significant package issue <br> *[/home/yitzi/Documents/git/atom-latex/spec/fixtures/error-warning.tex:37]* |
| :warning: | Package bar: Package issue <br> *[/home/yitzi/Documents/git/atom-latex/spec/fixtures/error-warning.tex:38]* |
| :warning: | Package bar: Package issue <br> *[/home/yitzi/Documents/git/atom-latex/spec/fixtures/error-warning.tex:38]* |

