### PR TITLE
Readline fix for Mac CI

### DIFF
--- a/script/install-knitr
+++ b/script/install-knitr
@@ -16,6 +16,8 @@ ensure_r_installed() {
     echo "Installing R..."
     brew update
     brew tap homebrew/science
+    brew install readline
+    brew link --force readline
     brew install r
   fi
 }

--- a/script/install-knitr
+++ b/script/install-knitr
@@ -16,8 +16,8 @@ ensure_r_installed() {
     echo "Installing R..."
     brew update
     brew tap homebrew/science
-    brew install readline
-    brew link --force readline
+    brew tap homebrew/versions
+    brew install readline6
     brew install r
   fi
 }


### PR DESCRIPTION
Something is probably broken in the R packages. Looks like they added a readline/gettext dependency and are assuming that they are linked.