### PR TITLE
Fix jobnames bugs associated with Sync and Clean

### DIFF
--- a/lib/composer.js
+++ b/lib/composer.js
@@ -1,5 +1,6 @@
 /** @babel */
 
+import _ from 'lodash'
 import { shell } from 'electron'
 import fs from 'fs-plus'
 import path from 'path'
@@ -127,7 +128,7 @@ export default class Composer {
 
     const jobs = jobnames.map(jobname => this.syncJob(filePath, lineNumber, builder, rootFilePath, jobname))
 
-    await Promise.all(jobs)
+    return await Promise.all(jobs)
   }
 
   async syncJob (filePath, lineNumber, builder, rootFilePath, jobname) {
@@ -146,29 +147,36 @@ export default class Composer {
   async clean () {
     const { filePath } = getEditorDetails()
     if (!filePath || !this.isTexFile(filePath)) {
-      return Promise.reject()
+      return false
     }
 
-    const rootFilePath = this.resolveRootFilePath(filePath)
-    let rootPath = path.dirname(rootFilePath)
+    const { rootFilePath, jobnames } = this.initializeBuild(filePath)
 
-    let outdir = atom.config.get('latex.outputDirectory')
+    const jobs = jobnames.map(jobname => this.cleanJob(rootFilePath, jobname))
+
+    return _.flatten(await Promise.all(jobs))
+  }
+
+  async cleanJob (rootFilePath, jobname) {
+    let { dir, name } = path.parse(rootFilePath)
+
+    const outdir = atom.config.get('latex.outputDirectory')
     if (outdir) {
-      rootPath = path.join(rootPath, outdir)
+      dir = path.join(dir, outdir)
     }
 
-    let rootFile = path.basename(rootFilePath)
-    rootFile = rootFile.substring(0, rootFile.lastIndexOf('.'))
+    if (jobname) {
+      name = jobname
+    }
 
     const cleanExtensions = atom.config.get('latex.cleanExtensions')
-    return Promise.all(cleanExtensions.map(async (extension) => {
-      const candidatePath = path.join(rootPath, rootFile + extension)
-      return new Promise(async (resolve) => {
-        fs.remove(candidatePath, (error) => {
-          return resolve({filePath: candidatePath, error: error})
-        })
-      })
+
+    const exts = cleanExtensions.map(async ext => new Promise(resolve => {
+      const filePath = path.format({ dir, name, ext })
+      fs.remove(filePath, error => resolve({ filePath, error }))
     }))
+
+    return await Promise.all(exts)
   }
 
   setStatusBar (statusBar) {

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -8,8 +8,10 @@ import BuilderRegistry from './builder-registry'
 import { getEditorDetails, heredoc } from './werkzeug'
 
 export default class Composer {
+  outputLookup = new Map()
+  builderRegistry = new BuilderRegistry()
+
   constructor () {
-    this.builderRegistry = new BuilderRegistry()
     this.configChange = atom.config.onDidChange('latex', () => {
       this.rebuildCompleted = new Set()
     })
@@ -110,6 +112,8 @@ export default class Composer {
         if (this.shouldMoveResult()) {
           this.moveResult(result, rootFilePath)
         }
+        // Cache the output file path for sync
+        this.outputLookup.set({ rootFilePath, jobname }, result.outputFilePath)
         this.showResult(result)
       }
     } catch (error) {
@@ -206,7 +210,7 @@ export default class Composer {
   }
 
   resolveOutputFilePath (builder, rootFilePath, jobname) {
-    const label = `${rootFilePath}|${jobname}`
+    const label = { rootFilePath, jobname }
 
     if (this.outputLookup.has(label)) {
       return this.outputLookup.get(label)

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -85,7 +85,7 @@ export default class Composer {
 
     const label = shouldRebuild ? 'LaTeX Rebuild' : 'LaTeX Build'
 
-    latex.setStatus(label, 'highlight', 'sync', true, 'Click to kill LaTeX build.', () => latex.process.killChildProcesses())
+    latex.status.show(label, 'highlight', 'sync', true, 'Click to kill LaTeX build.', () => latex.process.killChildProcesses())
     latex.log.group(label)
 
     const jobs = jobnames.map(jobname => this.buildJob(builder, rootFilePath, jobname, shouldRebuild))

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -105,7 +105,7 @@ export default class Composer {
       }
 
       if (statusCode > 0 || !result || !result.outputFilePath) {
-        this.showError(statusCode, result, builder)
+        this.showError(result)
       } else {
         if (this.shouldMoveResult()) {
           this.moveResult(result, rootFilePath)

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -183,10 +183,6 @@ export default class Composer {
     return await Promise.all(exts)
   }
 
-  setStatusBar (statusBar) {
-    this.statusBar = statusBar
-  }
-
   moveResult (result, filePath) {
     const originalOutputFilePath = result.outputFilePath
     result.outputFilePath = this.alterParentPath(filePath, originalOutputFilePath)

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -17,25 +17,18 @@ export default class Composer {
   destroy () {
   }
 
-  async build (shouldRebuild) {
-    latex.process.killChildProcesses()
-
-    const { editor, filePath } = getEditorDetails()
-
-    if (!filePath) {
-      latex.log.warning('File needs to be saved to disk before it can be TeXified.')
-      return Promise.reject(false)
+  initializeBuild (filePath) {
+    let state = {
+      rootFilePath: this.resolveRootFilePath(filePath)
     }
 
-    if (editor.isModified()) {
-      editor.save() // TODO: Make this configurable?
-    }
-
-    const builder = this.getBuilder(filePath)
-    if (builder == null) {
+    state.builder = this.getBuilder(state.rootFilePath)
+    if (!state.builder) {
       latex.log.warning(`No registered LaTeX builder can process ${filePath}.`)
-      return Promise.reject(false)
-    } else if (Object.getPrototypeOf(builder).constructor.name === 'TexifyBuilder') {
+      return state
+    }
+
+    if (Object.getPrototypeOf(state.builder).constructor.name === 'TexifyBuilder') {
       // -------------------------------------------------------------
       // TODO: Remove this whole block when texify support is removed.
       // -------------------------------------------------------------
@@ -60,16 +53,37 @@ export default class Composer {
       })
     }
 
-    latex.status.show('LaTeX Build', 'highlight', 'sync', true, 'Click to kill LaTeX build.', () => latex.process.killChildProcesses())
+    state.jobnames = state.builder.getJobNamesFromMagic(state.rootFilePath)
 
-    latex.log.group('LaTeX Build')
-    const rootFilePath = this.resolveRootFilePath(filePath)
-    const jobnames = builder.getJobNamesFromMagic(rootFilePath)
+    return state
+  }
+
+  async build (shouldRebuild) {
+    latex.process.killChildProcesses()
+
+    const { editor, filePath } = getEditorDetails()
+
+    if (!filePath) {
+      latex.log.warning('File needs to be saved to disk before it can be TeXified.')
+      return false
+    }
+
+    if (editor.isModified()) {
+      editor.save() // TODO: Make this configurable?
+    }
+
+    const { builder, rootFilePath, jobnames } = this.initializeBuild(filePath)
+    if (!builder) return false
 
     if (this.rebuildCompleted && !this.rebuildCompleted.has(rootFilePath)) {
       shouldRebuild = true
       this.rebuildCompleted.add(rootFilePath)
     }
+
+    const label = shouldRebuild ? 'LaTeX Rebuild' : 'LaTeX Build'
+
+    latex.setStatus(label, 'highlight', 'sync', true, 'Click to kill LaTeX build.', () => latex.process.killChildProcesses())
+    latex.log.group(label)
 
     const jobs = jobnames.map(jobname => this.buildJob(builder, rootFilePath, jobname, shouldRebuild))
 
@@ -102,13 +116,22 @@ export default class Composer {
     }
   }
 
-  sync () {
+  async sync () {
     const { filePath, lineNumber } = getEditorDetails()
     if (!filePath || !this.isTexFile(filePath)) {
       return
     }
 
-    const outputFilePath = this.resolveOutputFilePath(filePath)
+    const { builder, rootFilePath, jobnames } = this.initializeBuild(filePath)
+    if (!builder) return false
+
+    const jobs = jobnames.map(jobname => this.syncJob(filePath, lineNumber, builder, rootFilePath, jobname))
+
+    await Promise.all(jobs)
+  }
+
+  async syncJob (filePath, lineNumber, builder, rootFilePath, jobname) {
+    const outputFilePath = this.resolveOutputFilePath(builder, rootFilePath, jobname)
     if (!outputFilePath) {
       latex.log.warning('Could not resolve path to output file associated with the current file.')
       return
@@ -116,7 +139,7 @@ export default class Composer {
 
     const opener = latex.getOpener()
     if (opener) {
-      opener.open(outputFilePath, filePath, lineNumber)
+      return await opener.open(outputFilePath, filePath, lineNumber)
     }
   }
 
@@ -174,36 +197,24 @@ export default class Composer {
     return finder.getMasterTexPath()
   }
 
-  resolveOutputFilePath (filePath) {
-    let outputFilePath, rootFilePath
+  resolveOutputFilePath (builder, rootFilePath, jobname) {
+    const label = `${rootFilePath}|${jobname}`
 
-    if (this.outputLookup) {
-      outputFilePath = this.outputLookup[filePath]
+    if (this.outputLookup.has(label)) {
+      return this.outputLookup.get(label)
     }
 
-    if (!outputFilePath) {
-      rootFilePath = this.resolveRootFilePath(filePath)
-
-      const builder = this.getBuilder(rootFilePath)
-      if (builder == null) {
-        latex.log.warning(`No registered LaTeX builder can process ${rootFilePath}.`)
-        return null
-      }
-
-      const result = builder.parseLogAndFdbFiles(rootFilePath)
-      if (!result || !result.outputFilePath) {
-        latex.log.warning('Log file parsing failed!')
-        return null
-      }
-
-      this.outputLookup = this.outputLookup || {}
-      this.outputLookup[filePath] = result.outputFilePath
-      outputFilePath = result.outputFilePath
+    const result = builder.parseLogAndFdbFiles(rootFilePath, jobname)
+    if (!result || !result.outputFilePath) {
+      latex.log.warning('Log file parsing failed!')
+      return null
     }
 
+    let outputFilePath = result.outputFilePath
     if (this.shouldMoveResult()) {
       outputFilePath = this.alterParentPath(rootFilePath, outputFilePath)
     }
+    this.outputLookup.set(label, outputFilePath)
 
     return outputFilePath
   }
@@ -218,8 +229,12 @@ export default class Composer {
     }
   }
 
-  showError (statusCode, result, builder) {
-    builder.logStatusCode(statusCode)
+  showError (result) {
+    if (!result) {
+      latex.log.error('Parsing of log files failed.')
+    } else if (!result.outputFilePath) {
+      latex.log.error('No output file detected.')
+    }
   }
 
   isTexFile (filePath) {

--- a/spec/composer-spec.js
+++ b/spec/composer-spec.js
@@ -212,8 +212,8 @@ describe('Composer', () => {
 
     it('deletes all files for the current tex document with jobnames when output has not been redirected', () => {
       const filePath = path.normalize('/a/foo.tex')
-      const filesToDelete = fakeFilePaths(filePath, 'bar')
-      initializeSpies(filePath, ['bar'])
+      const filesToDelete = fakeFilePaths(filePath, 'bar').concat(fakeFilePaths(filePath, 'wibble'))
+      initializeSpies(filePath, ['bar', 'wibble'])
 
       let candidatePaths
       waitsForPromise(() => {

--- a/spec/composer-spec.js
+++ b/spec/composer-spec.js
@@ -48,7 +48,7 @@ describe('Composer', () => {
 
       let result = 'aaaaaaaaaaaa'
       waitsForPromise(() => {
-        return composer.build().catch(r => { result = r })
+        return composer.build().then(r => { result = r })
       })
 
       runs(() => {
@@ -64,7 +64,7 @@ describe('Composer', () => {
 
       let result
       waitsForPromise(() => {
-        return composer.build().catch(r => { result = r })
+        return composer.build().then(r => { result = r })
       })
 
       runs(() => {


### PR DESCRIPTION
Make `latex:clean` and `latex:sync` aware of jobnames.

- [x] Clean jobname support
- [x] Clean specs
- [x] Sync jobname support
- [x] Sync specs

Fixes #211.