### PR TITLE
Add concordance and patchSynctex to KnitrBuilder

### DIFF
--- a/lib/builders/knitr.js
+++ b/lib/builders/knitr.js
@@ -4,7 +4,8 @@ import path from 'path'
 import Builder from '../builder'
 import BuilderRegistry from '../builder-registry'
 
-const MISSING_PACKAGE_PATTERN = /there is no package called .knitr./
+const MISSING_KNITR_PATTERN = /there is no package called .knitr./
+const MISSING_PATCH_SYNCTEX_PATTERN = /there is no package called .patchSynctex./
 const OUTPUT_PATH_PATTERN = /\[\d+\]\s+"(.*)"/
 
 export default class KnitrBuilder extends Builder {
@@ -28,7 +29,7 @@ export default class KnitrBuilder extends Builder {
 
     if (statusCode !== 0) {
       // Parse error message to detect missing 'knitr' library.
-      if (stderr.match(MISSING_PACKAGE_PATTERN)) {
+      if (stderr.match(MISSING_KNITR_PATTERN)) {
         latex.log.error('The R package "knitr" could not be loaded.')
         return -1
       }
@@ -37,13 +38,38 @@ export default class KnitrBuilder extends Builder {
 
     const texFilePath = this.resolveOutputPath(filePath, stdout)
     const builder = this.getResultBuilder(texFilePath)
-    return await builder.run(texFilePath, jobname, shouldRebuild)
+    const code = await builder.run(texFilePath, jobname, shouldRebuild)
+
+    if (code === 0) {
+      const args = this.constructPatchSynctexArgs(texFilePath, jobname)
+      const command = `${this.executable} ${args.join(' ')}`
+
+      const { statusCode, stderr } = await latex.process.executeChildProcess(command, options)
+
+      if (statusCode !== 0) {
+        if (stderr.match(MISSING_PATCH_SYNCTEX_PATTERN)) {
+          latex.log.warning('The R package "patchSynctex" could not be loaded.')
+        }
+      }
+    }
+
+    return code
   }
 
   constructArgs (filePath) {
     const args = [
       '-e "library(knitr)"',
+      '-e "opts_knit\\$set(concordance = TRUE)"',
       `-e "knit('${filePath.replace(/\\/g, '\\\\')}')"`
+    ]
+
+    return args
+  }
+
+  constructPatchSynctexArgs (filePath, jobname) {
+    const args = [
+      '-e "library(patchSynctex)"',
+      `-e "patchSynctex('${filePath.replace(/\\/g, '\\\\')}')"`
     ]
 
     return args

--- a/lib/builders/knitr.js
+++ b/lib/builders/knitr.js
@@ -58,7 +58,7 @@ export default class KnitrBuilder extends Builder {
   constructArgs (filePath) {
     const args = [
       '-e "library(knitr)"',
-      '-e "opts_knit\\$set(concordance = TRUE)"',
+      '-e "opts_knit$set(concordance = TRUE)"',
       `-e "knit('${filePath.replace(/\\/g, '\\\\')}')"`
     ]
 

--- a/lib/builders/knitr.js
+++ b/lib/builders/knitr.js
@@ -4,7 +4,7 @@ import path from 'path'
 import Builder from '../builder'
 import BuilderRegistry from '../builder-registry'
 
-const MISSING_PACKAGE_PATTERN = /there is no package called ‘([^’]+)’/g
+const MISSING_PACKAGE_PATTERN = /there is no package called [‘']([^’']+)[’']/g
 const OUTPUT_PATH_PATTERN = /\[\d+\]\s+"(.*)"/
 
 export default class KnitrBuilder extends Builder {
@@ -29,8 +29,13 @@ export default class KnitrBuilder extends Builder {
     const code = await builder.run(texFilePath, jobname, shouldRebuild)
 
     if (code === 0) {
-      const args = this.constructPatchSynctexArgs(texFilePath, jobname)
-      await this.execRscript(filePath, args, 'Warning')
+      const outputDirectory = atom.config.get('latex.outputDirectory')
+      if (outputDirectory) {
+        const args = this.constructPatchSynctexArgs(texFilePath, jobname)
+        await this.execRscript(filePath, args, 'Warning')
+      } else {
+        latex.log.info('Using an output directory is not compatible with patchSynctex.')
+      }
     }
 
     return code

--- a/lib/builders/knitr.js
+++ b/lib/builders/knitr.js
@@ -4,8 +4,7 @@ import path from 'path'
 import Builder from '../builder'
 import BuilderRegistry from '../builder-registry'
 
-const MISSING_KNITR_PATTERN = /there is no package called .knitr./
-const MISSING_PATCH_SYNCTEX_PATTERN = /there is no package called .patchSynctex./
+const MISSING_PACKAGE_PATTERN = /there is no package called ‘([^’]+)’/g
 const OUTPUT_PATH_PATTERN = /\[\d+\]\s+"(.*)"/
 
 export default class KnitrBuilder extends Builder {
@@ -22,19 +21,8 @@ export default class KnitrBuilder extends Builder {
 
   async run (filePath, jobname, shouldRebuild) {
     const args = this.constructArgs(filePath)
-    const command = `${this.executable} ${args.join(' ')}`
-    const options = this.constructChildProcessOptions(filePath)
-
-    const { statusCode, stdout, stderr } = await latex.process.executeChildProcess(command, options)
-
-    if (statusCode !== 0) {
-      // Parse error message to detect missing 'knitr' library.
-      if (stderr.match(MISSING_KNITR_PATTERN)) {
-        latex.log.error('The R package "knitr" could not be loaded.')
-        return -1
-      }
-      return statusCode
-    }
+    const { statusCode, stdout } = await this.execRscript(filePath, args, 'Error')
+    if (statusCode !== 0) return statusCode
 
     const texFilePath = this.resolveOutputPath(filePath, stdout)
     const builder = this.getResultBuilder(texFilePath)
@@ -42,18 +30,29 @@ export default class KnitrBuilder extends Builder {
 
     if (code === 0) {
       const args = this.constructPatchSynctexArgs(texFilePath, jobname)
-      const command = `${this.executable} ${args.join(' ')}`
-
-      const { statusCode, stderr } = await latex.process.executeChildProcess(command, options)
-
-      if (statusCode !== 0) {
-        if (stderr.match(MISSING_PATCH_SYNCTEX_PATTERN)) {
-          latex.log.warning('The R package "patchSynctex" could not be loaded.')
-        }
-      }
+      await this.execRscript(filePath, args, 'Warning')
     }
 
     return code
+  }
+
+  async execRscript (filePath, args, type) {
+    const command = `${this.executable} ${args.join(' ')}`
+    const options = this.constructChildProcessOptions(filePath)
+
+    let { statusCode, stdout, stderr } = await latex.process.executeChildProcess(command, options)
+
+    if (statusCode !== 0) {
+      // Parse error message to detect missing libraries.
+      let match
+      while ((match = MISSING_PACKAGE_PATTERN.exec(stderr)) !== null) {
+        const text = `The R package "${match[1]}" could not be loaded.`
+        latex.log.showMessage({ type, text })
+        statusCode = -1
+      }
+    }
+
+    return { statusCode, stdout }
   }
 
   constructArgs (filePath) {

--- a/lib/builders/latexmk.js
+++ b/lib/builders/latexmk.js
@@ -95,9 +95,9 @@ export default class LatexmkBuilder extends Builder {
       case 'ps2pdf':
         return '-pdfps'
       case 'dvipdf':
-        return '-pdfdvi -e "\\$dvipdf = \'dvipdf %O %S %D\';"'
+        return '-pdfdvi -e "$dvipdf = \'dvipdf %O %S %D\';"'
       default:
-        return `-pdfdvi -e "\\$dvipdf = \'${producer} %O -o %D %S\';"`
+        return `-pdfdvi -e "$dvipdf = \'${producer} %O -o %D %S\';"`
     }
   }
 }

--- a/lib/latex.js
+++ b/lib/latex.js
@@ -64,14 +64,14 @@ export default class Latex {
 
   createLogProxy () {
     this.log = {
-      error: (statusCode, result, builder) => {
-        this.logger.error(statusCode, result, builder)
+      error: (...args) => {
+        this.logger.error(...args)
       },
-      warning: (message) => {
-        this.logger.warning(message)
+      warning: (...args) => {
+        this.logger.warning(...args)
       },
-      info: (message) => {
-        this.logger.info(message)
+      info: (...args) => {
+        this.logger.info(...args)
       },
       showMessage: (message) => {
         this.logger.showMessage(message)

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -9,15 +9,15 @@ export default class Logger {
   }
 
   error (text, filePath, range, logPath, logRange) {
-    this.showMessage({ type: 'Error', text: text, filePath: filePath, range: range, logPath: logPath, logRange: logRange })
+    this.showMessage({ type: 'Error', text, filePath, range, logPath, logRange })
   }
 
   warning (text, filePath, range, logPath, logRange) {
-    this.showMessage({ type: 'Warning', text: text, filePath: filePath, range: range, logPath: logPath, logRange: logRange })
+    this.showMessage({ type: 'Warning', text, filePath, range, logPath, logRange })
   }
 
   info (text, filePath, range, logPath, logRange) {
-    this.showMessage({ type: 'Info', text: text, filePath: filePath, range: range, logPath: logPath, logRange: logRange })
+    this.showMessage({ type: 'Info', text, filePath, range, logPath, logRange })
   }
 
   showMessage (message) {

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -57,7 +57,7 @@ export default class Logger {
     return _.reduce(messages, (type, message) => {
       if (type === 'Error' || message.type === 'Error') return 'Error'
       if (type === 'Warning' || message.type === 'Warning') return 'Warning'
-      return type
+      return 'Info'
     }, undefined)
   }
 

--- a/lib/process-manager.js
+++ b/lib/process-manager.js
@@ -10,7 +10,7 @@ export default class ProcessManager {
     return new Promise((resolve) => {
       // Windows does not like \$ appearing in command lines so only escape
       // if we need to.
-      if (process.patform !== 'win32') command = command.replace('$', '\\$')
+      if (process.platform !== 'win32') command = command.replace('$', '\\$')
       const { pid } = childProcess.exec(command, options, (error, stdout, stderr) => {
         this.processes.delete(pid)
         resolve({

--- a/lib/process-manager.js
+++ b/lib/process-manager.js
@@ -8,6 +8,9 @@ export default class ProcessManager {
 
   executeChildProcess (command, options) {
     return new Promise((resolve) => {
+      // Windows does not like \$ appearing in command lines so only escape
+      // if we need to.
+      if (process.patform !== 'win32') command = command.replace('$', '\\$')
       const { pid } = childProcess.exec(command, options, (error, stdout, stderr) => {
         this.processes.delete(pid)
         resolve({

--- a/spec/builders/knitr-spec.js
+++ b/spec/builders/knitr-spec.js
@@ -25,7 +25,7 @@ describe('KnitrBuilder', () => {
     it('produces default arguments containing expected file path', () => {
       const expectedArgs = [
         '-e "library(knitr)"',
-        '-e "opts_knit\\$set(concordance = TRUE)"',
+        '-e "opts_knit$set(concordance = TRUE)"',
         `-e "knit('${filePath.replace(/\\/g, '\\\\')}')"`
       ]
 

--- a/spec/builders/knitr-spec.js
+++ b/spec/builders/knitr-spec.js
@@ -25,6 +25,7 @@ describe('KnitrBuilder', () => {
     it('produces default arguments containing expected file path', () => {
       const expectedArgs = [
         '-e "library(knitr)"',
+        '-e "opts_knit\\$set(concordance = TRUE)"',
         `-e "knit('${filePath.replace(/\\/g, '\\\\')}')"`
       ]
 

--- a/spec/builders/knitr-spec.js
+++ b/spec/builders/knitr-spec.js
@@ -70,7 +70,7 @@ describe('KnitrBuilder', () => {
       const env = { 'R_LIBS_USER': '/dev/null', 'R_LIBS_SITE': '/dev/null' }
       const options = _.merge(builder.constructChildProcessOptions(filePath), { env })
       spyOn(builder, 'constructChildProcessOptions').andReturn(options)
-      spyOn(latex.log, 'error').andCallThrough()
+      spyOn(latex.log, 'showMessage').andCallThrough()
 
       waitsForPromise(() => {
         return builder.run(filePath).then(code => { exitCode = code })
@@ -78,7 +78,7 @@ describe('KnitrBuilder', () => {
 
       runs(() => {
         expect(exitCode).toBe(-1)
-        expect(latex.log.error).toHaveBeenCalled()
+        expect(latex.log.showMessage).toHaveBeenCalledWith({ type: 'Error', text: 'The R package "knitr" could not be loaded.'})
       })
     })
   })

--- a/spec/builders/knitr-spec.js
+++ b/spec/builders/knitr-spec.js
@@ -78,7 +78,10 @@ describe('KnitrBuilder', () => {
 
       runs(() => {
         expect(exitCode).toBe(-1)
-        expect(latex.log.showMessage).toHaveBeenCalledWith({ type: 'Error', text: 'The R package "knitr" could not be loaded.'})
+        expect(latex.log.showMessage).toHaveBeenCalledWith({
+          type: 'Error',
+          text: 'The R package "knitr" could not be loaded.'
+        })
       })
     })
   })

--- a/spec/builders/latexmk-spec.js
+++ b/spec/builders/latexmk-spec.js
@@ -84,7 +84,7 @@ describe('LatexmkBuilder', () => {
       atom.config.set('latex.producer', 'dvipdfmx')
       const args = builder.constructArgs(filePath)
       expect(args).toContain('-latex="uplatex"')
-      expect(args).toContain('-pdfdvi -e "\\$dvipdf = \'dvipdfmx %O -o %D %S\';"')
+      expect(args).toContain('-pdfdvi -e "$dvipdf = \'dvipdfmx %O -o %D %S\';"')
       expect(args).not.toContain('-pdf')
     })
 
@@ -93,7 +93,7 @@ describe('LatexmkBuilder', () => {
       atom.config.set('latex.producer', 'dvipdf')
       const args = builder.constructArgs(filePath)
       expect(args).toContain('-latex="uplatex"')
-      expect(args).toContain('-pdfdvi -e "\\$dvipdf = \'dvipdf %O %S %D\';"')
+      expect(args).toContain('-pdfdvi -e "$dvipdf = \'dvipdf %O %S %D\';"')
       expect(args).not.toContain('-pdf')
     })
 


### PR DESCRIPTION
if `patchSynctex` is not available a warning is logged. Also, setting the output directory option appears to break `patchSynctex` so a warning for that might in order.