### PR TITLE
add builder for makefiles

### DIFF
--- a/lib/builders/make.js
+++ b/lib/builders/make.js
@@ -1,0 +1,48 @@
+/** @babel */
+
+import path from 'path'
+import fs from 'fs'
+import Builder from '../builder'
+
+const DEFAULT_MAKEFILE = 'Makefile'
+
+export default class MakeBuilder extends Builder {
+  executable = 'make'
+
+  static canProcess (filePath) {
+    return fs.existsSync(path.join(path.dirname(filePath), DEFAULT_MAKEFILE))
+  }
+
+  async run (filePath, jobname, shouldRebuild) {
+    const args = this.constructArgs(filePath, jobname, shouldRebuild)
+    const command = `${this.executable} ${args.join(' ')}`
+    const options = this.constructChildProcessOptions(filePath, { max_print_line: 1000 })
+
+    const { statusCode } = await latex.process.executeChildProcess(command, options)
+    return statusCode
+  }
+
+  logStatusCode (statusCode) {
+    switch (statusCode) {
+      case 2:
+        latex.log.error('make: failed. See log for details.')
+        break
+      default:
+        super.logStatusCode(statusCode)
+    }
+  }
+
+  constructArgs (filePath, jobname, shouldRebuild) {
+    const args = []
+
+    // Support standard targets (i.e. all, clean, distclean)
+    // https://www.gnu.org/prep/standards/html_node/Standard-Targets.html#Standard-Targets
+
+    if (shouldRebuild) {
+      args.push('clean')
+    }
+    args.push('all')
+
+    return args
+  }
+}

--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
       "type": "string",
       "enum": [
         "latexmk",
-        "texify"
+        "texify",
+        "make"
       ],
       "default": "latexmk",
       "order": 2


### PR DESCRIPTION
A number of older, legacy, and complex projects use Makefiles and this would be really helpful for working with these documents in Atom.

Would you consider adding something like this to build LaTeX documents with make?