### PR TITLE
Add Opener Registry

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -6,9 +6,7 @@ import path from 'path'
 import LogParser from './parsers/log-parser'
 import MagicParser from './parsers/magic-parser'
 import FdbParser from './parsers/fdb-parser'
-import { heredoc } from './werkzeug.js'
-
-const OUTPUT_EXTENSION_PATTERNS = [/^\.pdf$/i, /^\.ps$/i, /^\.(?:dvi|xdv)$/i]
+import { heredoc, isPdfFile, isPsFile, isDviFile } from './werkzeug.js'
 
 export default class Builder {
   envPathKey = this.getEnvironmentPathKey(process.platform)
@@ -217,22 +215,22 @@ export default class Builder {
     if (result) {
       result.fdb = this.parseFdbFile(texFilePath, jobname)
       if (result.fdb) {
-        const allOutputs = result.fdb.ps2pdf || result.fdb.dvipdf ||
+        const rootPath = path.dirname(texFilePath)
+        const outputs = result.fdb.ps2pdf || result.fdb.dvipdf ||
           result.fdb.dvips || result.fdb.latex || result.fdb.pdflatex
 
-        for (const pattern of OUTPUT_EXTENSION_PATTERNS) {
-          const outputs = _.filter(allOutputs, output => path.extname(output).match(pattern))
-          if (!outputs.length) continue
+        let output = outputs.find(output => isPdfFile(output))
 
-          let output = _.find(outputs, output => path.isAbsolute(output))
-          if (output) {
-            result.outputFilePath = path.normalize(output)
-          } else {
-            const rootPath = path.dirname(texFilePath)
-            result.outputFilePath = path.resolve(rootPath, path.normalize(outputs[0]))
-          }
+        if (!output) {
+          output = outputs.find(output => isPsFile(output))
+        }
 
-          break
+        if (!output) {
+          output = outputs.find(output => isDviFile(output))
+        }
+
+        if (output) {
+          result.outputFilePath = path.resolve(rootPath, path.normalize(output))
         }
       }
     }

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -209,13 +209,12 @@ export default class Builder {
     return new FdbParser(fdbFilePath)
   }
 
-  parseLogAndFdbFiles (texFilePath, jobname) {
+  parseLogAndFdbFiles (rootPath, texFilePath, jobname) {
     const result = this.parseLogFile(texFilePath, jobname)
 
     if (result) {
       result.fdb = this.parseFdbFile(texFilePath, jobname)
       if (result.fdb) {
-        const rootPath = path.dirname(texFilePath)
         const outputs = result.fdb.ps2pdf || result.fdb.dvipdf ||
           result.fdb.dvips || result.fdb.latex || result.fdb.pdflatex
 

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -54,6 +54,7 @@ export default class Builder {
     }
 
     return {
+      allowKill: true,
       encoding: 'utf8',
       maxBuffer: 52428800, // Set process' max buffer size to 50 MB.
       cwd: path.dirname(filePath), // Run process with sensible CWD.

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -100,7 +100,8 @@ export default class Composer {
   async buildJob (builder, rootFilePath, jobname, shouldRebuild) {
     try {
       const statusCode = await builder.run(rootFilePath, jobname, shouldRebuild)
-      const result = builder.parseLogAndFdbFiles(rootFilePath, jobname)
+      const rootPath = path.dirname(rootFilePath)
+      const result = builder.parseLogAndFdbFiles(rootPath, rootFilePath, jobname)
 
       if (result) {
         for (const message of result.messages) {
@@ -258,7 +259,8 @@ export default class Composer {
       return this.outputLookup.get(label)
     }
 
-    const result = builder.parseLogAndFdbFiles(rootFilePath, jobname)
+    const rootPath = path.dirname(rootFilePath)
+    const result = builder.parseLogAndFdbFiles(rootPath, rootFilePath, jobname)
     if (!result || !result.outputFilePath) {
       latex.log.warning('Log file parsing failed!')
       return null

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -142,10 +142,7 @@ export default class Composer {
       return
     }
 
-    const opener = latex.getOpener()
-    if (opener) {
-      return await opener.open(outputFilePath, filePath, lineNumber)
-    }
+    return await latex.opener.open(outputFilePath, filePath, lineNumber)
   }
 
   async clean () {
@@ -277,11 +274,8 @@ export default class Composer {
   async showResult (result) {
     if (!this.shouldOpenResult()) { return }
 
-    const opener = latex.getOpener()
-    if (opener) {
-      const { filePath, lineNumber } = getEditorDetails()
-      await opener.open(result.outputFilePath, filePath, lineNumber)
-    }
+    const { filePath, lineNumber } = getEditorDetails()
+    return await latex.opener.open(result.outputFilePath, filePath, lineNumber)
   }
 
   showError (result) {

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -135,7 +135,7 @@ export default class Composer {
 
     const jobs = jobnames.map(jobname => this.syncJob(filePath, lineNumber, builder, rootFilePath, jobname))
 
-    return await Promise.all(jobs)
+    await Promise.all(jobs)
   }
 
   async syncJob (filePath, lineNumber, builder, rootFilePath, jobname) {
@@ -145,7 +145,7 @@ export default class Composer {
       return
     }
 
-    return await latex.opener.open(outputFilePath, filePath, lineNumber)
+    await latex.opener.open(outputFilePath, filePath, lineNumber)
   }
 
   async clean () {
@@ -279,7 +279,7 @@ export default class Composer {
     if (!this.shouldOpenResult()) { return }
 
     const { filePath, lineNumber } = getEditorDetails()
-    return await latex.opener.open(result.outputFilePath, filePath, lineNumber)
+    await latex.opener.open(result.outputFilePath, filePath, lineNumber)
   }
 
   showError (result) {

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -312,6 +312,7 @@ export default class Composer {
   async checkEnvironment () {
     // TODO: remove after grace period
     this.checkCleanExtensions()
+    this.checkOpenerSetting()
   }
 
   checkCleanExtensions () {
@@ -338,5 +339,13 @@ export default class Composer {
       Your custom extensions in the \`Clean Extensions\` settings have
       been migrated to the new setting \`Clean Patterns\`.`)
     atom.notifications.addInfo(message, { description })
+  }
+
+  checkOpenerSetting () {
+    const alwaysOpenResultInAtom = atom.config.get('latex.alwaysOpenResultInAtom')
+    if (!alwaysOpenResultInAtom) return
+
+    atom.config.unset('latex.alwaysOpenResultInAtom')
+    atom.config.set('latex.opener', 'pdf-view')
   }
 }

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -20,6 +20,8 @@ export default class Composer {
     this.checkEnvironment()
   }
 
+  destroy () {}
+
   initializeBuild (filePath) {
     let state = {
       rootFilePath: this.resolveRootFilePath(filePath)

--- a/lib/latex.js
+++ b/lib/latex.js
@@ -1,10 +1,9 @@
 /** @babel */
 
-import fs from 'fs-plus'
 import _ from 'lodash'
-import { heredoc } from './werkzeug'
 import ProcessManager from './process-manager'
 import StatusIndicator from './status-indicator'
+import OpenerRegistry from './opener-registry'
 
 function defineDefaultProperty (target, property) {
   const shadowProperty = `__${property}`
@@ -25,18 +24,14 @@ function defineDefaultProperty (target, property) {
 export default class Latex {
   process = new ProcessManager()
   status = new StatusIndicator()
+  opener = new OpenerRegistry()
 
   constructor () {
     this.createLogProxy()
-
     defineDefaultProperty(this, 'logger')
-    defineDefaultProperty(this, 'opener')
-
-    this.observeOpenerConfig()
   }
 
   getLogger () { return this.logger }
-  getOpener () { return this.opener }
 
   setLogger (logger) {
     this.logger = logger
@@ -45,21 +40,6 @@ export default class Latex {
   getDefaultLogger () {
     const DefaultLogger = require('./loggers/default-logger')
     return new DefaultLogger()
-  }
-
-  getDefaultOpener () {
-    const OpenerImpl = this.resolveOpenerImplementation(process.platform)
-    if (OpenerImpl) {
-      return new OpenerImpl()
-    }
-
-    if (this['__logger'] && this.log) {
-      this.log.warning(heredoc(`
-        No PDF opener found.
-        For cross-platform viewing, consider installing the pdf-view package.
-        `)
-      )
-    }
   }
 
   createLogProxy () {
@@ -95,84 +75,5 @@ export default class Latex {
         this.logger.hide()
       }
     }
-  }
-
-  observeOpenerConfig () {
-    const callback = () => { this['__opener'] = this.getDefaultOpener() }
-    atom.config.onDidChange('latex.alwaysOpenResultInAtom', callback)
-    atom.config.onDidChange('latex.skimPath', callback)
-    atom.config.onDidChange('latex.sumatraPath', callback)
-    atom.config.onDidChange('latex.okularPath', callback)
-  }
-
-  resolveOpenerImplementation (platform) {
-    if (this.hasPdfViewerPackage() && this.shouldOpenResultInAtom()) {
-      return require('./openers/atompdf-opener')
-    }
-
-    if (this.viewerExecutableExists()) {
-      return require('./openers/custom-opener')
-    }
-
-    switch (platform) {
-      case 'darwin':
-        if (this.skimExecutableExists()) {
-          return require('./openers/skim-opener')
-        }
-
-        return require('./openers/preview-opener')
-
-      case 'win32':
-        if (this.sumatraExecutableExists()) {
-          return require('./openers/sumatra-opener')
-        }
-
-        break
-
-      case 'linux':
-        if (this.okularExecutableExists()) {
-          return require('./openers/okular-opener')
-        }
-
-        if (this.evinceExecutableExists()) {
-          return require('./openers/evince-opener')
-        }
-
-        return require('./openers/xdg-opener')
-    }
-
-    if (this.hasPdfViewerPackage()) {
-      return require('./openers/atompdf-opener')
-    }
-
-    return null
-  }
-
-  hasPdfViewerPackage () {
-    return !!atom.packages.resolvePackagePath('pdf-view')
-  }
-
-  shouldOpenResultInAtom () {
-    return atom.config.get('latex.alwaysOpenResultInAtom')
-  }
-
-  skimExecutableExists () {
-    return fs.existsSync(atom.config.get('latex.skimPath'))
-  }
-
-  sumatraExecutableExists () {
-    return fs.existsSync(atom.config.get('latex.sumatraPath'))
-  }
-
-  okularExecutableExists () {
-    return fs.existsSync(atom.config.get('latex.okularPath'))
-  }
-
-  evinceExecutableExists () {
-    return fs.existsSync(atom.config.get('latex.evincePath'))
-  }
-
-  viewerExecutableExists () {
-    return fs.existsSync(atom.config.get('latex.viewerPath'))
   }
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -8,10 +8,10 @@ export default {
     this.disposables = new CompositeDisposable()
 
     this.disposables.add(atom.commands.add('atom-workspace', {
-      'latex:build': () => this.composer.build(false),
-      'latex:rebuild': () => this.composer.build(true),
-      'latex:clean': () => this.composer.clean(),
-      'latex:sync': () => this.composer.sync(),
+      'latex:build': () => composer.build(false),
+      'latex:rebuild': () => composer.build(true),
+      'latex:clean': () => composer.clean(),
+      'latex:sync': () => composer.sync(),
       'latex:kill': () => latex.process.killChildProcesses(),
       'latex:sync-log': () => latex.log.sync(),
       'core:close': () => latex.log.hide(),
@@ -23,7 +23,7 @@ export default {
         // Let's play it safe; only trigger builds for the active editor.
         const activeEditor = atom.workspace.getActiveTextEditor()
         if (editor === activeEditor && atom.config.get('latex.buildOnSave')) {
-          this.composer.build()
+          composer.build()
         }
       }))
     }))
@@ -35,9 +35,9 @@ export default {
       delete this.disposables
     }
 
-    if (this.composer) {
-      this.composer.destroy()
-      delete this.composer
+    if (global.composer) {
+      composer.destroy()
+      delete global.composer
     }
 
     if (global.latex) {
@@ -54,13 +54,12 @@ export default {
   },
 
   bootstrap () {
-    if (this.composer && global.latex) { return }
+    if (global.composer && global.latex) { return }
 
     const Latex = require('./latex')
     const Composer = require('./composer')
 
     global.latex = new Latex()
-    latex.opener.initializeOpeners()
-    this.composer = new Composer()
+    global.composer = new Composer()
   }
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -60,6 +60,7 @@ export default {
     const Composer = require('./composer')
 
     global.latex = new Latex()
+    latex.opener.initializeOpeners()
     this.composer = new Composer()
   }
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -49,7 +49,7 @@ export default {
     this.bootstrap()
     latex.status.attachStatusBar(statusBar)
     return new Disposable(() => {
-      latex.status.detachStatusBar()
+      if (latex) latex.status.detachStatusBar()
     })
   },
 

--- a/lib/opener-registry.js
+++ b/lib/opener-registry.js
@@ -21,6 +21,10 @@ export default class OpenerRegistry {
   }
 
   async open (filePath, texPath, lineNumber) {
+    const name = atom.config.get('latex.opener')
+    const openResultInBackground = atom.config.get('latex.openResultInBackground')
+    const enableSynctex = atom.config.get('latex.enableSynctex')
+
     let openers = _.filter(this.openers, opener => opener.canOpen(filePath))
 
     if (!openers.length) {
@@ -30,9 +34,19 @@ export default class OpenerRegistry {
 
     let opener
 
-    const name = atom.config.get('latex.opener')
     if (name !== 'automatic') {
       opener = _.find(openers, opener => opener.getName() === name)
+    }
+
+    if (!opener && enableSynctex) {
+      // If the user wants openResultInBackground also and there is an opener
+      // that supports that and SyncTeX it will be the first one because of
+      // the priority sort.
+      opener = _.find(openers, opener => opener.hasSynctex())
+    }
+
+    if (!opener && openResultInBackground) {
+      opener = _.find(openers, opener => opener.canOpenInBackground())
     }
 
     if (!opener) opener = openers[0]

--- a/lib/opener-registry.js
+++ b/lib/opener-registry.js
@@ -1,0 +1,53 @@
+/** @babel */
+
+import _ from 'lodash'
+import fs from 'fs-plus'
+import path from 'path'
+import { heredoc } from './werkzeug'
+
+export default class OpenerRegistry {
+  constructor () {
+    this.createOpeners()
+  }
+
+  async createOpeners () {
+    const moduleDir = path.join(__dirname, 'openers')
+    const entries = fs.readdirSync(moduleDir)
+    this.openers = entries.map(entry => {
+      const OpenerImpl = require(path.join(moduleDir, entry))
+      return new OpenerImpl()
+    })
+  }
+
+  async open (filePath, texPath, lineNumber) {
+    let openers = []
+
+    for (const opener of this.openers) {
+      if (opener.canOpen(filePath)) {
+        openers.push(opener)
+      }
+    }
+
+    openers = _.orderBy(openers, [opener => opener.hasSynctex(), opener => opener.canOpenInBackground()], ['desc', 'desc'])
+
+    if (!openers.length) {
+      latex.log.warning(heredoc(`
+        No PDF opener found.
+        For cross-platform viewing, consider installing the pdf-view package.
+        `)
+      )
+      return
+    }
+
+    let opener
+
+    const name = atom.config.get('latex.opener')
+    if (name !== 'automatic') {
+      opener = _.find(openers, { name })
+    }
+
+    if (!opener) opener = openers[0]
+    console.log(opener)
+    return await opener.open(filePath, texPath, lineNumber)
+  }
+}

--- a/lib/opener-registry.js
+++ b/lib/opener-registry.js
@@ -17,7 +17,7 @@ export default class OpenerRegistry {
       if (openerName !== 'automatic') {
         const name = `${openerName}-opener`
         const OpenerImpl = require(path.format({ dir, name, ext }))
-        this.openers.set(name, new OpenerImpl())
+        this.openers.set(openerName, new OpenerImpl())
       }
     }
   }
@@ -30,21 +30,22 @@ export default class OpenerRegistry {
       opener = this.findOpener(filePath)
     }
 
-    if (opener) return await opener.open(filePath, texPath, lineNumber)
+    if (opener) {
+      return await opener.open(filePath, texPath, lineNumber)
+    } else {
+      latex.log.warning(`No opener found that can open ${filePath}.`)
+    }
   }
 
   findOpener (filePath) {
     const openResultInBackground = atom.config.get('latex.openResultInBackground')
     const enableSynctex = atom.config.get('latex.enableSynctex')
-    const candidates = _.filter(Array.from(this.openers.values()), opener => opener.canOpen(filePath))
+    const candidates = Array.from(this.openers.values()).filter(opener => opener.canOpen(filePath))
     const rankedCandidates = _.orderBy(candidates,
       [opener => opener.hasSynctex(), opener => opener.canOpenInBackground()],
       ['desc', 'desc'])
 
-    if (!rankedCandidates.length) {
-      latex.log.warning(`No opener found that can open ${filePath}.`)
-      return
-    }
+    if (!rankedCandidates.length) return
 
     if (enableSynctex) {
       // If the user wants openResultInBackground also and there is an opener

--- a/lib/opener-registry.js
+++ b/lib/opener-registry.js
@@ -38,11 +38,12 @@ export default class OpenerRegistry {
     const openResultInBackground = atom.config.get('latex.openResultInBackground')
     const enableSynctex = atom.config.get('latex.enableSynctex')
     const candidates = Array.from(this.openers.values()).filter(opener => opener.canOpen(filePath))
+
+    if (!candidates.length) return
+
     const rankedCandidates = _.orderBy(candidates,
       [opener => opener.hasSynctex(), opener => opener.canOpenInBackground()],
       ['desc', 'desc'])
-
-    if (!rankedCandidates.length) return
 
     if (enableSynctex) {
       // If the user wants openResultInBackground also and there is an opener

--- a/lib/opener-registry.js
+++ b/lib/opener-registry.js
@@ -4,15 +4,12 @@ import _ from 'lodash'
 import path from 'path'
 
 export default class OpenerRegistry {
-  constructor () {
-    this.initializeOpeners()
-  }
+  openers = new Map()
 
   async initializeOpeners () {
     const schema = atom.config.getSchema('latex.opener')
     const dir = path.join(__dirname, 'openers')
     const ext = '.js'
-    this.openers = new Map()
     for (const openerName of schema.enum) {
       if (openerName !== 'automatic') {
         const name = `${openerName}-opener`

--- a/lib/opener-registry.js
+++ b/lib/opener-registry.js
@@ -3,7 +3,6 @@
 import _ from 'lodash'
 import fs from 'fs-plus'
 import path from 'path'
-import { heredoc } from './werkzeug'
 
 export default class OpenerRegistry {
   constructor () {
@@ -17,25 +16,15 @@ export default class OpenerRegistry {
       const OpenerImpl = require(path.join(moduleDir, entry))
       return new OpenerImpl()
     })
+    // Sort the openers into decreasing priority
+    this.openers = _.orderBy(this.openers, [opener => opener.hasSynctex(), opener => opener.canOpenInBackground()], ['desc', 'desc'])
   }
 
   async open (filePath, texPath, lineNumber) {
-    let openers = []
-
-    for (const opener of this.openers) {
-      if (opener.canOpen(filePath)) {
-        openers.push(opener)
-      }
-    }
-
-    openers = _.orderBy(openers, [opener => opener.hasSynctex(), opener => opener.canOpenInBackground()], ['desc', 'desc'])
+    let openers = _.filter(this.openers, opener => opener.canOpen(filePath))
 
     if (!openers.length) {
-      latex.log.warning(heredoc(`
-        No PDF opener found.
-        For cross-platform viewing, consider installing the pdf-view package.
-        `)
-      )
+      latex.log.warning(`No opener found that can open ${filePath}.`)
       return
     }
 
@@ -47,7 +36,7 @@ export default class OpenerRegistry {
     }
 
     if (!opener) opener = openers[0]
-    console.log(opener)
+
     return await opener.open(filePath, texPath, lineNumber)
   }
 }

--- a/lib/opener-registry.js
+++ b/lib/opener-registry.js
@@ -1,56 +1,64 @@
 /** @babel */
 
 import _ from 'lodash'
-import fs from 'fs-plus'
 import path from 'path'
 
 export default class OpenerRegistry {
   constructor () {
-    this.createOpeners()
+    this.initializeOpeners()
   }
 
-  async createOpeners () {
-    const moduleDir = path.join(__dirname, 'openers')
-    const entries = fs.readdirSync(moduleDir)
-    this.openers = entries.map(entry => {
-      const OpenerImpl = require(path.join(moduleDir, entry))
-      return new OpenerImpl()
-    })
-    // Sort the openers into decreasing priority
-    this.openers = _.orderBy(this.openers, [opener => opener.hasSynctex(), opener => opener.canOpenInBackground()], ['desc', 'desc'])
+  async initializeOpeners () {
+    const schema = atom.config.getSchema('latex.opener')
+    const dir = path.join(__dirname, 'openers')
+    const ext = '.js'
+    this.openers = new Map()
+    for (const openerName of schema.enum) {
+      if (openerName !== 'automatic') {
+        const name = `${openerName}-opener`
+        const OpenerImpl = require(path.format({ dir, name, ext }))
+        this.openers.set(name, new OpenerImpl())
+      }
+    }
   }
 
   async open (filePath, texPath, lineNumber) {
     const name = atom.config.get('latex.opener')
+    let opener = this.openers.get(name)
+
+    if (!opener || !opener.canOpen(filePath)) {
+      opener = this.findOpener(filePath)
+    }
+
+    if (opener) return await opener.open(filePath, texPath, lineNumber)
+  }
+
+  findOpener (filePath) {
     const openResultInBackground = atom.config.get('latex.openResultInBackground')
     const enableSynctex = atom.config.get('latex.enableSynctex')
+    const candidates = _.filter(Array.from(this.openers.values()), opener => opener.canOpen(filePath))
+    const rankedCandidates = _.orderBy(candidates,
+      [opener => opener.hasSynctex(), opener => opener.canOpenInBackground()],
+      ['desc', 'desc'])
 
-    let openers = _.filter(this.openers, opener => opener.canOpen(filePath))
-
-    if (!openers.length) {
+    if (!rankedCandidates.length) {
       latex.log.warning(`No opener found that can open ${filePath}.`)
       return
     }
 
-    let opener
-
-    if (name !== 'automatic') {
-      opener = _.find(openers, opener => opener.getName() === name)
-    }
-
-    if (!opener && enableSynctex) {
+    if (enableSynctex) {
       // If the user wants openResultInBackground also and there is an opener
       // that supports that and SyncTeX it will be the first one because of
       // the priority sort.
-      opener = _.find(openers, opener => opener.hasSynctex())
+      const opener = rankedCandidates.find(opener => opener.hasSynctex())
+      if (opener) return opener
     }
 
-    if (!opener && openResultInBackground) {
-      opener = _.find(openers, opener => opener.canOpenInBackground())
+    if (openResultInBackground) {
+      const opener = rankedCandidates.find(opener => opener.canOpenInBackground())
+      if (opener) return opener
     }
 
-    if (!opener) opener = openers[0]
-
-    return await opener.open(filePath, texPath, lineNumber)
+    return rankedCandidates[0]
   }
 }

--- a/lib/opener-registry.js
+++ b/lib/opener-registry.js
@@ -43,7 +43,7 @@ export default class OpenerRegistry {
 
     const name = atom.config.get('latex.opener')
     if (name !== 'automatic') {
-      opener = _.find(openers, { name })
+      opener = _.find(openers, opener => opener.getName() === name)
     }
 
     if (!opener) opener = openers[0]

--- a/lib/opener-registry.js
+++ b/lib/opener-registry.js
@@ -10,7 +10,7 @@ export default class OpenerRegistry {
     this.initializeOpeners()
   }
 
-  async initializeOpeners () {
+  initializeOpeners () {
     const schema = atom.config.getSchema('latex.opener')
     const dir = path.join(__dirname, 'openers')
     const ext = '.js'

--- a/lib/opener-registry.js
+++ b/lib/opener-registry.js
@@ -6,6 +6,10 @@ import path from 'path'
 export default class OpenerRegistry {
   openers = new Map()
 
+  constructor () {
+    this.initializeOpeners()
+  }
+
   async initializeOpeners () {
     const schema = atom.config.getSchema('latex.opener')
     const dir = path.join(__dirname, 'openers')

--- a/lib/opener.js
+++ b/lib/opener.js
@@ -1,22 +1,7 @@
 /** @babel */
 
-import ChildProcess from 'child_process'
-import { promisify } from './werkzeug'
-
-const exec = promisify(ChildProcess.exec)
-
 export default class Opener {
   async open (filePath, texPath, lineNumber) {}
-
-  async executeChildProcess (command) {
-    try {
-      await exec(command)
-      return true
-    } catch (error) {
-      latex.log.error(`An error occured while trying to run opener (${error.code})`)
-      return false
-    }
-  }
 
   shouldOpenInBackground () {
     return atom.config.get('latex.openResultInBackground')

--- a/lib/opener.js
+++ b/lib/opener.js
@@ -21,4 +21,16 @@ export default class Opener {
   shouldOpenInBackground () {
     return atom.config.get('latex.openResultInBackground')
   }
+
+  canOpen (filePath) {
+    return false
+  }
+
+  hasSynctex () {
+    return false
+  }
+
+  canOpenInBackground () {
+    return false
+  }
 }

--- a/lib/opener.js
+++ b/lib/opener.js
@@ -33,6 +33,4 @@ export default class Opener {
   canOpenInBackground () {
     return false
   }
-
-  getName () {}
 }

--- a/lib/opener.js
+++ b/lib/opener.js
@@ -33,4 +33,6 @@ export default class Opener {
   canOpenInBackground () {
     return false
   }
+
+  getName () {}
 }

--- a/lib/openers/atompdf-opener.js
+++ b/lib/openers/atompdf-opener.js
@@ -28,4 +28,8 @@ export default class AtomPdfOpener extends Opener {
   canOpen (filePath) {
     return !!atom.packages.resolvePackagePath('pdf-view') && isPdfFile(filePath)
   }
+
+  getName () {
+    return 'pdf-view'
+  }
 }

--- a/lib/openers/atompdf-opener.js
+++ b/lib/openers/atompdf-opener.js
@@ -1,6 +1,7 @@
 /** @babel */
 
 import Opener from '../opener'
+import { isPdfFile } from '../werkzeug'
 
 function forwardSync (pdfView, texPath, lineNumber) {
   if (pdfView != null && pdfView.forwardSync != null) {
@@ -22,5 +23,9 @@ export default class AtomPdfOpener extends Opener {
     atom.workspace.open(filePath, {'split': 'right'}).then(forwardSync)
 
     return true
+  }
+
+  canOpen (filePath) {
+    return !!atom.packages.resolvePackagePath('pdf-view') && isPdfFile(filePath)
   }
 }

--- a/lib/openers/atompdf-opener.js
+++ b/lib/openers/atompdf-opener.js
@@ -26,7 +26,7 @@ export default class AtomPdfOpener extends Opener {
   }
 
   canOpen (filePath) {
-    return !!atom.packages.resolvePackagePath('pdf-view') && isPdfFile(filePath)
+    return isPdfFile(filePath) && atom.packages.isPackageActive('pdf-view')
   }
 
   getName () {

--- a/lib/openers/custom-opener.js
+++ b/lib/openers/custom-opener.js
@@ -1,6 +1,8 @@
 /** @babel */
 
+import fs from 'fs-plus'
 import Opener from '../opener'
+import { isPdfFile } from '../werkzeug'
 
 export default class CustomOpener extends Opener {
   // Custom PDF viewer does not support texPath and lineNumber.
@@ -8,5 +10,9 @@ export default class CustomOpener extends Opener {
     const command = `"${atom.config.get('latex.viewerPath')}" "${filePath}"`
 
     return this.executeChildProcess(command)
+  }
+
+  canOpen (filePath) {
+    return isPdfFile(filePath) && fs.existsSync(atom.config.get('latex.viewerPath'))
   }
 }

--- a/lib/openers/custom-opener.js
+++ b/lib/openers/custom-opener.js
@@ -15,4 +15,8 @@ export default class CustomOpener extends Opener {
   canOpen (filePath) {
     return isPdfFile(filePath) && fs.existsSync(atom.config.get('latex.viewerPath'))
   }
+
+  getName () {
+    return 'custom'
+  }
 }

--- a/lib/openers/custom-opener.js
+++ b/lib/openers/custom-opener.js
@@ -15,8 +15,4 @@ export default class CustomOpener extends Opener {
   canOpen (filePath) {
     return isPdfFile(filePath) && fs.existsSync(atom.config.get('latex.viewerPath'))
   }
-
-  getName () {
-    return 'custom'
-  }
 }

--- a/lib/openers/custom-opener.js
+++ b/lib/openers/custom-opener.js
@@ -9,7 +9,7 @@ export default class CustomOpener extends Opener {
   async open (filePath, texPath, lineNumber) {
     const command = `"${atom.config.get('latex.viewerPath')}" "${filePath}"`
 
-    return this.executeChildProcess(command)
+    await latex.process.executeChildProcess(command, { showError: true })
   }
 
   canOpen (filePath) {

--- a/lib/openers/evince-opener.js
+++ b/lib/openers/evince-opener.js
@@ -90,10 +90,6 @@ export default class EvinceOpener extends Opener {
     return true
   }
 
-  getName () {
-    return 'evince'
-  }
-
   getInterface (serviceName, objectPath, interfaceName) {
     return new Promise((resolve, reject) => {
       this.bus.getInterface(serviceName, objectPath, interfaceName, (error, interfaceInstance) => {

--- a/lib/openers/evince-opener.js
+++ b/lib/openers/evince-opener.js
@@ -126,4 +126,8 @@ export default class EvinceOpener extends Opener {
   canOpenInBackground () {
     return true
   }
+
+  getName () {
+    return 'evince'
+  }
 }

--- a/lib/openers/evince-opener.js
+++ b/lib/openers/evince-opener.js
@@ -19,43 +19,6 @@ function syncSource (uri, point) {
   atom.workspace.open(url.parse(uri).pathname).then(editor => editor.setCursorBufferPosition(point))
 }
 
-function getInterface (bus, serviceName, objectPath, interfaceName) {
-  return new Promise((resolve, reject) => {
-    bus.getInterface(serviceName, objectPath, interfaceName, (error, interfaceInstance) => {
-      if (error) {
-        reject(error)
-      } else {
-        resolve(interfaceInstance)
-      }
-    })
-  })
-}
-
-function getWindowList (evinceApplication) {
-  return new Promise((resolve, reject) => {
-    evinceApplication.GetWindowList((error, windowNames) => {
-      if (error) {
-        reject(error)
-      } else {
-        resolve(windowNames)
-      }
-    })
-  })
-}
-
-function findDocument (daemon, filePath) {
-  return new Promise((resolve, reject) => {
-    const uri = url.format({ protocol: 'file:', slashes: true, pathname: filePath })
-    daemon.FindDocument(uri, true, (error, documentName) => {
-      if (error) {
-        reject(error)
-      } else {
-        resolve(documentName)
-      }
-    })
-  })
-}
-
 export default class EvinceOpener extends Opener {
   constructor () {
     super()
@@ -67,25 +30,25 @@ export default class EvinceOpener extends Opener {
     if (process.platform === 'linux') {
       const dbus = require('dbus-native')
       this.bus = dbus.sessionBus()
-      this.daemon = await getInterface(this.bus, DAEMON_SERVICE, DAEMON_OBJECT, DAEMON_INTERFACE)
+      this.daemon = await this.getInterface(DAEMON_SERVICE, DAEMON_OBJECT, DAEMON_INTERFACE)
     }
   }
 
   async getWindow (filePath, texPath) {
     if (this.windows[texPath]) return this.windows[texPath]
 
-    // First get the Evince daemon interface so we can find the internal document name
-    const documentName = await findDocument(this.daemon, filePath)
+    // First find the internal document name
+    const documentName = await this.findDocument(filePath)
 
     // Get the application interface and get the window list of the application
-    const evinceApplication = await getInterface(this.bus, documentName, EVINCE_OBJECT, EVINCE_APPLICATION_INTERFACE)
-    const windowNames = await getWindowList(evinceApplication)
+    const evinceApplication = await this.getInterface(documentName, EVINCE_OBJECT, EVINCE_APPLICATION_INTERFACE)
+    const windowNames = await this.getWindowList(evinceApplication)
 
     // Get the window interface of the of the first (only) window and get the
     // GTK/FreeDesktop application interface so we can activate the window
     const interfaces = {
-      evinceWindow: await getInterface(this.bus, documentName, windowNames[0], WINDOW_INTERFACE),
-      gtkApplication: await getInterface(this.bus, documentName, GTK_APPLICATION_OBJECT, GTK_APPLICATION_INTERFACE)
+      evinceWindow: await this.getInterface(documentName, windowNames[0], WINDOW_INTERFACE),
+      gtkApplication: await this.getInterface(documentName, GTK_APPLICATION_OBJECT, GTK_APPLICATION_INTERFACE)
     }
 
     interfaces.evinceWindow.on('SyncSource', syncSource)
@@ -129,5 +92,42 @@ export default class EvinceOpener extends Opener {
 
   getName () {
     return 'evince'
+  }
+
+  getInterface (serviceName, objectPath, interfaceName) {
+    return new Promise((resolve, reject) => {
+      this.bus.getInterface(serviceName, objectPath, interfaceName, (error, interfaceInstance) => {
+        if (error) {
+          reject(error)
+        } else {
+          resolve(interfaceInstance)
+        }
+      })
+    })
+  }
+
+  getWindowList (evinceApplication) {
+    return new Promise((resolve, reject) => {
+      evinceApplication.GetWindowList((error, windowNames) => {
+        if (error) {
+          reject(error)
+        } else {
+          resolve(windowNames)
+        }
+      })
+    })
+  }
+
+  findDocument (filePath) {
+    return new Promise((resolve, reject) => {
+      const uri = url.format({ protocol: 'file:', slashes: true, pathname: filePath })
+      this.daemon.FindDocument(uri, true, (error, documentName) => {
+        if (error) {
+          reject(error)
+        } else {
+          resolve(documentName)
+        }
+      })
+    })
   }
 }

--- a/lib/openers/evince-opener.js
+++ b/lib/openers/evince-opener.js
@@ -1,7 +1,6 @@
 /** @babel */
 
 import Opener from '../opener'
-import dbus from 'dbus-native'
 import url from 'url'
 
 const EVINCE_OBJECT = '/org/gnome/evince/Evince'
@@ -60,16 +59,23 @@ function findDocument (daemon, filePath) {
 export default class EvinceOpener extends Opener {
   constructor () {
     super()
-    this.bus = dbus.sessionBus()
     this.windows = {}
+    this.initialize()
+  }
+
+  async initialize () {
+    if (process.platform === 'linux') {
+      const dbus = require('dbus-native')
+      this.bus = dbus.sessionBus()
+      this.daemon = await getInterface(this.bus, DAEMON_SERVICE, DAEMON_OBJECT, DAEMON_INTERFACE)
+    }
   }
 
   async getWindow (filePath, texPath) {
     if (this.windows[texPath]) return this.windows[texPath]
 
     // First get the Evince daemon interface so we can find the internal document name
-    const daemon = await getInterface(this.bus, DAEMON_SERVICE, DAEMON_OBJECT, DAEMON_INTERFACE)
-    const documentName = await findDocument(daemon, filePath)
+    const documentName = await findDocument(this.daemon, filePath)
 
     // Get the application interface and get the window list of the application
     const evinceApplication = await getInterface(this.bus, documentName, EVINCE_OBJECT, EVINCE_APPLICATION_INTERFACE)
@@ -107,5 +113,17 @@ export default class EvinceOpener extends Opener {
       latex.log.error('An error occured while trying to run Evince opener')
       return false
     }
+  }
+
+  canOpen (filePath) {
+    return !!this.daemon
+  }
+
+  hasSynctex () {
+    return true
+  }
+
+  canOpenInBackground () {
+    return true
   }
 }

--- a/lib/openers/evince-opener.js
+++ b/lib/openers/evince-opener.js
@@ -27,11 +27,13 @@ export default class EvinceOpener extends Opener {
   }
 
   async initialize () {
-    if (process.platform === 'linux') {
-      const dbus = require('dbus-native')
-      this.bus = dbus.sessionBus()
-      this.daemon = await this.getInterface(DAEMON_SERVICE, DAEMON_OBJECT, DAEMON_INTERFACE)
-    }
+    try {
+      if (process.platform === 'linux') {
+        const dbus = require('dbus-native')
+        this.bus = dbus.sessionBus()
+        this.daemon = await this.getInterface(DAEMON_SERVICE, DAEMON_OBJECT, DAEMON_INTERFACE)
+      }
+    } catch (e) {}
   }
 
   async getWindow (filePath, texPath) {

--- a/lib/openers/okular-opener.js
+++ b/lib/openers/okular-opener.js
@@ -28,4 +28,8 @@ export default class OkularOpener extends Opener {
   canOpenInBackground () {
     return true
   }
+
+  getName () {
+    return 'okular'
+  }
 }

--- a/lib/openers/okular-opener.js
+++ b/lib/openers/okular-opener.js
@@ -1,5 +1,6 @@
 /** @babel */
 
+import fs from 'fs-plus'
 import Opener from '../opener'
 
 export default class OkularOpener extends Opener {
@@ -14,5 +15,17 @@ export default class OkularOpener extends Opener {
     const command = `"${okularPath}" ${args.join(' ')}`
 
     return this.executeChildProcess(command)
+  }
+
+  canOpen (filePath) {
+    return process.platform === 'linux' && fs.existsSync(atom.config.get('latex.okularPath'))
+  }
+
+  hasSynctex () {
+    return true
+  }
+
+  canOpenInBackground () {
+    return true
   }
 }

--- a/lib/openers/okular-opener.js
+++ b/lib/openers/okular-opener.js
@@ -28,8 +28,4 @@ export default class OkularOpener extends Opener {
   canOpenInBackground () {
     return true
   }
-
-  getName () {
-    return 'okular'
-  }
 }

--- a/lib/openers/okular-opener.js
+++ b/lib/openers/okular-opener.js
@@ -14,7 +14,7 @@ export default class OkularOpener extends Opener {
 
     const command = `"${okularPath}" ${args.join(' ')}`
 
-    return this.executeChildProcess(command)
+    await latex.process.executeChildProcess(command, { showError: true })
   }
 
   canOpen (filePath) {

--- a/lib/openers/pdf-view-opener.js
+++ b/lib/openers/pdf-view-opener.js
@@ -28,8 +28,4 @@ export default class PdfViewOpener extends Opener {
   canOpen (filePath) {
     return isPdfFile(filePath) && atom.packages.isPackageActive('pdf-view')
   }
-
-  getName () {
-    return 'pdf-view'
-  }
 }

--- a/lib/openers/pdf-view-opener.js
+++ b/lib/openers/pdf-view-opener.js
@@ -9,7 +9,7 @@ function forwardSync (pdfView, texPath, lineNumber) {
   }
 }
 
-export default class AtomPdfOpener extends Opener {
+export default class PdfViewOpener extends Opener {
   async open (filePath, texPath, lineNumber) {
     const openPaneItems = atom.workspace.getPaneItems()
     for (const openPaneItem of openPaneItems) {

--- a/lib/openers/preview-opener.js
+++ b/lib/openers/preview-opener.js
@@ -1,6 +1,7 @@
 /** @babel */
 
 import Opener from '../opener'
+import { isPdfFile, isPsFile } from '../werkzeug'
 
 export default class PreviewOpener extends Opener {
   async open (filePath, texPath, lineNumber) {
@@ -10,5 +11,17 @@ export default class PreviewOpener extends Opener {
     }
 
     return this.executeChildProcess(command)
+  }
+
+  canOpen (filePath) {
+    return process.platform === 'darwin' && (isPdfFile(filePath) || isPsFile(filePath))
+  }
+
+  hasSynctex () {
+    return false
+  }
+
+  canOpenInBackground () {
+    return false
   }
 }

--- a/lib/openers/preview-opener.js
+++ b/lib/openers/preview-opener.js
@@ -10,7 +10,7 @@ export default class PreviewOpener extends Opener {
       command = command.replace(/\-g\s/, '')
     }
 
-    return this.executeChildProcess(command)
+    await latex.process.executeChildProcess(command, { showError: true })
   }
 
   canOpen (filePath) {

--- a/lib/openers/preview-opener.js
+++ b/lib/openers/preview-opener.js
@@ -20,8 +20,4 @@ export default class PreviewOpener extends Opener {
   canOpenInBackground () {
     return true
   }
-
-  getName () {
-    return 'preview'
-  }
 }

--- a/lib/openers/preview-opener.js
+++ b/lib/openers/preview-opener.js
@@ -17,12 +17,8 @@ export default class PreviewOpener extends Opener {
     return process.platform === 'darwin' && (isPdfFile(filePath) || isPsFile(filePath))
   }
 
-  hasSynctex () {
-    return false
-  }
-
   canOpenInBackground () {
-    return false
+    return true
   }
 
   getName () {

--- a/lib/openers/preview-opener.js
+++ b/lib/openers/preview-opener.js
@@ -24,4 +24,8 @@ export default class PreviewOpener extends Opener {
   canOpenInBackground () {
     return false
   }
+
+  getName () {
+    return 'preview'
+  }
 }

--- a/lib/openers/skim-opener.js
+++ b/lib/openers/skim-opener.js
@@ -27,7 +27,7 @@ export default class SkimOpener extends Opener {
       "
       `)
 
-    return this.executeChildProcess(command)
+    await latex.process.executeChildProcess(command, { showError: true })
   }
 
   canOpen (filePath) {

--- a/lib/openers/skim-opener.js
+++ b/lib/openers/skim-opener.js
@@ -41,8 +41,4 @@ export default class SkimOpener extends Opener {
   canOpenInBackground () {
     return true
   }
-
-  getName () {
-    return 'skim'
-  }
 }

--- a/lib/openers/skim-opener.js
+++ b/lib/openers/skim-opener.js
@@ -1,5 +1,6 @@
 /** @babel */
 
+import fs from 'fs-plus'
 import { heredoc } from '../werkzeug'
 import Opener from '../opener'
 
@@ -27,5 +28,17 @@ export default class SkimOpener extends Opener {
       `)
 
     return this.executeChildProcess(command)
+  }
+
+  canOpen (filePath) {
+    return process.platform === 'darwin' && fs.existsSync(atom.config.get('latex.skimPath'))
+  }
+
+  hasSynctex () {
+    return true
+  }
+
+  canOpenInBackground () {
+    return true
   }
 }

--- a/lib/openers/skim-opener.js
+++ b/lib/openers/skim-opener.js
@@ -41,4 +41,8 @@ export default class SkimOpener extends Opener {
   canOpenInBackground () {
     return true
   }
+
+  getName () {
+    return 'skim'
+  }
 }

--- a/lib/openers/sumatra-opener.js
+++ b/lib/openers/sumatra-opener.js
@@ -1,6 +1,8 @@
 /** @babel */
 
+import fs from 'fs-plus'
 import Opener from '../opener'
+import { isPdfFile } from '../werkzeug'
 
 export default class SumatraOpener extends Opener {
   async open (filePath, texPath, lineNumber) {
@@ -20,5 +22,14 @@ export default class SumatraOpener extends Opener {
     const command = `${sumatraPath} ${args.join(' ')}`
 
     return this.executeChildProcess(command)
+  }
+
+  canOpen (filePath) {
+    return process.platform === 'win32' && isPdfFile(filePath) &&
+      fs.existsSync(atom.config.get('latex.sumatraPath'))
+  }
+
+  hasSynctex () {
+    return true
   }
 }

--- a/lib/openers/sumatra-opener.js
+++ b/lib/openers/sumatra-opener.js
@@ -32,8 +32,4 @@ export default class SumatraOpener extends Opener {
   hasSynctex () {
     return true
   }
-
-  getName () {
-    return 'sumatra'
-  }
 }

--- a/lib/openers/sumatra-opener.js
+++ b/lib/openers/sumatra-opener.js
@@ -9,19 +9,17 @@ export default class SumatraOpener extends Opener {
     const sumatraPath = `"${atom.config.get('latex.sumatraPath')}"`
     const atomPath = `"${process.argv[0]}"`
     const args = [
-      '-reuse-instance',
       '-forward-search',
       `"${texPath}"`,
-      `"${lineNumber}"`,
+      lineNumber,
       `"${filePath}"`,
       '-inverse-search',
-      ['"\\"', `${atomPath}`, '\\"'].join(''),
-      '\\"%f:%l\\"'
+      `"\\"${atomPath}\\" \\"%f:%l\\""`
     ]
 
     const command = `${sumatraPath} ${args.join(' ')}`
 
-    return this.executeChildProcess(command)
+    await latex.process.executeChildProcess(command)
   }
 
   canOpen (filePath) {

--- a/lib/openers/sumatra-opener.js
+++ b/lib/openers/sumatra-opener.js
@@ -32,4 +32,8 @@ export default class SumatraOpener extends Opener {
   hasSynctex () {
     return true
   }
+
+  getName () {
+    return 'sumatra'
+  }
 }

--- a/lib/openers/sumatra-opener.js
+++ b/lib/openers/sumatra-opener.js
@@ -12,9 +12,9 @@ export default class SumatraOpener extends Opener {
       '-forward-search',
       `"${texPath}"`,
       lineNumber,
-      `"${filePath}"`,
       '-inverse-search',
-      `"\\"${atomPath}\\" \\"%f:%l\\""`
+      `"\\"${atomPath}\\" \\"%f:%l\\""`,
+      `"${filePath}"`
     ]
 
     const command = `${sumatraPath} ${args.join(' ')}`

--- a/lib/openers/xdg-open-opener.js
+++ b/lib/openers/xdg-open-opener.js
@@ -2,7 +2,7 @@
 
 import Opener from '../opener'
 
-export default class XdgOpener extends Opener {
+export default class XdgOpenOpener extends Opener {
   // xdg-open does not support texPath and lineNumber.
   async open (filePath, texPath, lineNumber) {
     const command = `xdg-open "${filePath}"`

--- a/lib/openers/xdg-open-opener.js
+++ b/lib/openers/xdg-open-opener.js
@@ -7,7 +7,7 @@ export default class XdgOpenOpener extends Opener {
   async open (filePath, texPath, lineNumber) {
     const command = `xdg-open "${filePath}"`
 
-    return this.executeChildProcess(command)
+    await latex.process.executeChildProcess(command, { showError: true })
   }
 
   canOpen (filePath) {

--- a/lib/openers/xdg-open-opener.js
+++ b/lib/openers/xdg-open-opener.js
@@ -13,8 +13,4 @@ export default class XdgOpenOpener extends Opener {
   canOpen (filePath) {
     return process.platform === 'linux'
   }
-
-  getName () {
-    return 'xdg-open'
-  }
 }

--- a/lib/openers/xdg-opener.js
+++ b/lib/openers/xdg-opener.js
@@ -9,4 +9,8 @@ export default class XdgOpener extends Opener {
 
     return this.executeChildProcess(command)
   }
+
+  canOpen (filePath) {
+    return process.platform === 'linux'
+  }
 }

--- a/lib/openers/xdg-opener.js
+++ b/lib/openers/xdg-opener.js
@@ -13,4 +13,8 @@ export default class XdgOpener extends Opener {
   canOpen (filePath) {
     return process.platform === 'linux'
   }
+
+  getName () {
+    return 'xdg-open'
+  }
 }

--- a/lib/process-manager.js
+++ b/lib/process-manager.js
@@ -7,7 +7,7 @@ import _ from 'lodash'
 export default class ProcessManager {
   processes = new Set()
 
-  executeChildProcess (command, options) {
+  executeChildProcess (command, options = {}) {
     const { allowKill, showError } = options
     options = _.omit(options, 'allowKill', 'showError')
     return new Promise((resolve) => {

--- a/lib/process-manager.js
+++ b/lib/process-manager.js
@@ -2,24 +2,34 @@
 
 import childProcess from 'child_process'
 import kill from 'tree-kill'
+import _ from 'lodash'
 
 export default class ProcessManager {
   processes = new Set()
 
   executeChildProcess (command, options) {
+    const { allowKill, showError } = options
+    options = _.omit(options, 'allowKill', 'showError')
     return new Promise((resolve) => {
       // Windows does not like \$ appearing in command lines so only escape
       // if we need to.
       if (process.platform !== 'win32') command = command.replace('$', '\\$')
       const { pid } = childProcess.exec(command, options, (error, stdout, stderr) => {
-        this.processes.delete(pid)
+        if (allowKill) {
+          this.processes.delete(pid)
+        }
+        if (error && showError) {
+          latex.log.error(`An error occured while trying to run "${command}" (${error.code}).`)
+        }
         resolve({
           statusCode: error ? error.code : 0,
           stdout,
           stderr
         })
       })
-      this.processes.add(pid)
+      if (allowKill) {
+        this.processes.add(pid)
+      }
     })
   }
 

--- a/lib/werkzeug.js
+++ b/lib/werkzeug.js
@@ -34,5 +34,17 @@ export default {
 
   replacePropertiesInString (text, properties) {
     return _.reduce(properties, (current, value, name) => current.replace(`{${name}}`, value), text)
+  },
+
+  isPdfFile (filePath) {
+    return !!filePath.match(/^\.pdf$/i)
+  },
+
+  isPsFile (filePath) {
+    return !!filePath.match(/^\.ps/i)
+  },
+
+  isDviFile (filePath) {
+    return !!filePath.match(/^\.(?:dvi|xdv)$/i)
   }
 }

--- a/lib/werkzeug.js
+++ b/lib/werkzeug.js
@@ -37,14 +37,14 @@ export default {
   },
 
   isPdfFile (filePath) {
-    return !!filePath.match(/^\.pdf$/i)
+    return !!filePath.match(/\.pdf$/i)
   },
 
   isPsFile (filePath) {
-    return !!filePath.match(/^\.ps/i)
+    return !!filePath.match(/\.ps/i)
   },
 
   isDviFile (filePath) {
-    return !!filePath.match(/^\.(?:dvi|xdv)$/i)
+    return !!filePath.match(/\.(?:dvi|xdv)$/i)
   }
 }

--- a/package.json
+++ b/package.json
@@ -256,24 +256,18 @@
       "default": "/usr/bin/okular",
       "order": 19
     },
-    "evincePath": {
-      "description": "Full application path to Evince (*nix).",
-      "type": "string",
-      "default": "/usr/bin/evince",
-      "order": 20
-    },
     "viewerPath": {
       "title": "Custom PDF Viewer Path",
       "description": "Full application path to your PDF viewer. Overrides Skim and SumatraPDF options.",
       "type": "string",
       "default": "",
-      "order": 21
+      "order": 20
     },
     "useMasterFileSearch": {
       "description": "Enables naive search for master/root file when building distributed documents. Note that this does not affect the equivalent *Magic Comments* functionality.",
       "type": "boolean",
       "default": false,
-      "order": 22
+      "order": 21
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "parser": "babel-eslint",
     "globals": [
       "atom",
+      "composer",
       "latex",
       "afterEach",
       "beforeEach",

--- a/package.json
+++ b/package.json
@@ -221,11 +221,20 @@
       "default": true,
       "order": 15
     },
-    "alwaysOpenResultInAtom": {
-      "title": "Always Open Result in Atom",
-      "description": "Always open result in Atom. Depends on the pdf-view package being installed.",
-      "type": "boolean",
-      "default": false,
+    "opener": {
+      "type": "string",
+      "enum": [
+        "automatic",
+        "evince",
+        "okular",
+        "pdf-view",
+        "preview",
+        "skim",
+        "sumatra",
+        "xdg-open",
+        "custom"
+      ],
+      "default": "automatic",
       "order": 16
     },
     "skimPath": {

--- a/spec/builder-spec.js
+++ b/spec/builder-spec.js
@@ -140,9 +140,12 @@ describe('Builder', () => {
     it('verifys that fdb file output overrides log file output', () => {
       spyOn(builder, 'getLogParser').andReturn({ parse: () => ({ outputFilePath: 'bar.pdf' }) })
       spyOn(builder, 'getOutputDirectory').andReturn('')
-      const result = builder.parseLogAndFdbFiles(process.platform === 'win32' ? filePathWin32 : filePath)
+      const rootPath = process.platform === 'win32' ? 'C:\\foo' : '/foo'
+      const myFilePath = process.platform === 'win32' ? filePathWin32 : filePath
+      const outputFilePath = process.platform === 'win32' ? 'C:\\foo\\output\\file.pdf' : '/foo/output/file.pdf'
+      const result = builder.parseLogAndFdbFiles(rootPath, myFilePath)
 
-      expect(result.outputFilePath).toEqual(process.platform === 'win32' ? 'C:\\foo\\output\\file.pdf' : '/foo/output/file.pdf')
+      expect(result.outputFilePath).toEqual(outputFilePath)
     })
   })
 

--- a/spec/builders/knitr-spec.js
+++ b/spec/builders/knitr-spec.js
@@ -20,8 +20,6 @@ describe('KnitrBuilder', () => {
     builder = new KnitrBuilder()
     fixturesPath = helpers.cloneFixtures()
     filePath = path.join(fixturesPath, 'knitr', 'file.Rnw')
-    atom.config.set('latex.engine', 'pdflatex')
-    atom.config.set('latex.outputFormat', 'pdf')
   })
 
   describe('constructArgs', () => {

--- a/spec/builders/knitr-spec.js
+++ b/spec/builders/knitr-spec.js
@@ -14,6 +14,9 @@ describe('KnitrBuilder', () => {
   let builder, fixturesPath, filePath
 
   beforeEach(() => {
+    waitsForPromise(() => {
+      return helpers.activatePackages()
+    })
     builder = new KnitrBuilder()
     fixturesPath = helpers.cloneFixtures()
     filePath = path.join(fixturesPath, 'knitr', 'file.Rnw')

--- a/spec/builders/latexmk-spec.js
+++ b/spec/builders/latexmk-spec.js
@@ -15,9 +15,6 @@ describe('LatexmkBuilder', () => {
     builder = new LatexmkBuilder()
     fixturesPath = helpers.cloneFixtures()
     filePath = path.join(fixturesPath, 'file.tex')
-    atom.config.set('latex.engine', 'pdflatex')
-    atom.config.set('latex.outputFormat', 'pdf')
-    atom.config.set('latex.outputDirectory', '')
   })
 
   describe('constructArgs', () => {

--- a/spec/builders/latexmk-spec.js
+++ b/spec/builders/latexmk-spec.js
@@ -9,6 +9,9 @@ describe('LatexmkBuilder', () => {
   let builder, fixturesPath, filePath
 
   beforeEach(() => {
+    waitsForPromise(() => {
+      return helpers.activatePackages()
+    })
     builder = new LatexmkBuilder()
     fixturesPath = helpers.cloneFixtures()
     filePath = path.join(fixturesPath, 'file.tex')

--- a/spec/builders/texify-spec.js
+++ b/spec/builders/texify-spec.js
@@ -17,7 +17,6 @@ if (process.env.TEX_DIST === 'miktex') {
       builder = new TexifyBuilder()
       fixturesPath = helpers.cloneFixtures()
       filePath = path.join(fixturesPath, 'file.tex')
-      atom.config.set('latex.outputDirectory', '')
     })
 
     describe('constructArgs', () => {

--- a/spec/builders/texify-spec.js
+++ b/spec/builders/texify-spec.js
@@ -11,6 +11,9 @@ if (process.env.TEX_DIST === 'miktex') {
     let builder, fixturesPath, filePath
 
     beforeEach(() => {
+      waitsForPromise(() => {
+        return helpers.activatePackages()
+      })
       builder = new TexifyBuilder()
       fixturesPath = helpers.cloneFixtures()
       filePath = path.join(fixturesPath, 'file.tex')

--- a/spec/composer-spec.js
+++ b/spec/composer-spec.js
@@ -12,6 +12,7 @@ describe('Composer', () => {
 
   beforeEach(() => {
     atom.config.set('latex.builder', 'latexmk')
+    atom.config.set('latex.opener', 'automatic')
     composer = new Composer()
   })
 

--- a/spec/composer-spec.js
+++ b/spec/composer-spec.js
@@ -1,19 +1,13 @@
 /** @babel */
 
-import './spec-bootstrap'
 import helpers from './spec-helpers'
 import fs from 'fs-plus'
 import path from 'path'
-import Composer from '../lib/composer'
 import werkzeug from '../lib/werkzeug'
 
 describe('Composer', () => {
-  let composer
-
   beforeEach(() => {
-    atom.config.set('latex.builder', 'latexmk')
-    atom.config.set('latex.opener', 'automatic')
-    composer = new Composer()
+    waitsForPromise(() => helpers.activatePackages())
   })
 
   describe('build', () => {
@@ -199,21 +193,33 @@ describe('Composer', () => {
 
     it('deletes aux file but leaves log file when log file is not in cleanPatterns', () => {
       initializeSpies(path.join(fixturesPath, 'foo.tex'))
-      composer.clean()
-      expect(fs.removeSync).toHaveBeenCalledWith(path.join(fixturesPath, 'foo.aux'))
-      expect(fs.removeSync).not.toHaveBeenCalledWith(path.join(fixturesPath, '_minted-foo'))
-      expect(fs.removeSync).not.toHaveBeenCalledWith(path.join(fixturesPath, 'foo.log'))
+
+      waitsForPromise(() => {
+        return composer.clean().catch(r => r)
+      })
+
+      runs(() => {
+        expect(fs.removeSync).toHaveBeenCalledWith(path.join(fixturesPath, 'foo.aux'))
+        expect(fs.removeSync).not.toHaveBeenCalledWith(path.join(fixturesPath, '_minted-foo'))
+        expect(fs.removeSync).not.toHaveBeenCalledWith(path.join(fixturesPath, 'foo.log'))
+      })
     })
 
     it('deletes aux files but leaves log files when log file is not in cleanPatterns with jobnames', () => {
       initializeSpies(path.join(fixturesPath, 'foo.tex'), ['bar', 'wibble'])
-      composer.clean()
-      expect(fs.removeSync).toHaveBeenCalledWith(path.join(fixturesPath, 'bar.aux'))
-      expect(fs.removeSync).not.toHaveBeenCalledWith(path.join(fixturesPath, 'bar.log'))
-      expect(fs.removeSync).not.toHaveBeenCalledWith(path.join(fixturesPath, '_minted-bar'))
-      expect(fs.removeSync).toHaveBeenCalledWith(path.join(fixturesPath, 'wibble.aux'))
-      expect(fs.removeSync).not.toHaveBeenCalledWith(path.join(fixturesPath, 'wibble.log'))
-      expect(fs.removeSync).toHaveBeenCalledWith(path.join(fixturesPath, '_minted-wibble'))
+
+      waitsForPromise(() => {
+        return composer.clean().catch(r => r)
+      })
+
+      runs(() => {
+        expect(fs.removeSync).toHaveBeenCalledWith(path.join(fixturesPath, 'bar.aux'))
+        expect(fs.removeSync).not.toHaveBeenCalledWith(path.join(fixturesPath, 'bar.log'))
+        expect(fs.removeSync).not.toHaveBeenCalledWith(path.join(fixturesPath, '_minted-bar'))
+        expect(fs.removeSync).toHaveBeenCalledWith(path.join(fixturesPath, 'wibble.aux'))
+        expect(fs.removeSync).not.toHaveBeenCalledWith(path.join(fixturesPath, 'wibble.log'))
+        expect(fs.removeSync).toHaveBeenCalledWith(path.join(fixturesPath, '_minted-wibble'))
+      })
     })
 
     it('stops immediately if the file is not a TeX document', () => {

--- a/spec/composer-spec.js
+++ b/spec/composer-spec.js
@@ -290,24 +290,24 @@ describe('Composer', () => {
     it('silently does nothing when the current editor is transient', () => {
       spyOn(werkzeug, 'getEditorDetails').andReturn({ filePath: null })
       spyOn(composer, 'resolveOutputFilePath').andCallThrough()
-      spyOn(latex, 'getOpener').andCallThrough()
+      spyOn(latex.opener, 'open').andReturn(true)
 
       composer.sync()
 
       expect(composer.resolveOutputFilePath).not.toHaveBeenCalled()
-      expect(latex.getOpener).not.toHaveBeenCalled()
+      expect(latex.opener.open).not.toHaveBeenCalled()
     })
 
     it('logs a warning and returns when an output file cannot be resolved', () => {
       spyOn(werkzeug, 'getEditorDetails').andReturn({ filePath: 'file.tex', lineNumber: 1 })
       spyOn(composer, 'resolveOutputFilePath').andReturn()
-      spyOn(latex, 'getOpener').andCallThrough()
+      spyOn(latex.opener, 'open').andReturn(true)
       spyOn(latex.log, 'warning').andCallThrough()
 
       composer.sync()
 
       expect(latex.log.warning).toHaveBeenCalled()
-      expect(latex.getOpener).not.toHaveBeenCalled()
+      expect(latex.opener.open).not.toHaveBeenCalled()
     })
 
     it('launches the opener using editor metadata and resolved output file', () => {
@@ -317,12 +317,11 @@ describe('Composer', () => {
       spyOn(werkzeug, 'getEditorDetails').andReturn({ filePath, lineNumber })
       spyOn(composer, 'resolveOutputFilePath').andReturn(outputFilePath)
 
-      const opener = jasmine.createSpyObj('MockOpener', ['open'])
-      spyOn(latex, 'getOpener').andReturn(opener)
+      spyOn(latex.opener, 'open').andReturn(true)
 
       composer.sync()
 
-      expect(opener.open).toHaveBeenCalledWith(outputFilePath, filePath, lineNumber)
+      expect(latex.opener.open).toHaveBeenCalledWith(outputFilePath, filePath, lineNumber)
     })
 
     it('launches the opener using editor metadata and resolved output file with jobnames', () => {
@@ -336,13 +335,12 @@ describe('Composer', () => {
       spyOn(composer, 'resolveOutputFilePath').andCallFake((builder, rootFilePath, jobname) => jobname + '.pdf')
       spyOn(composer, 'initializeBuild').andReturn({ rootFilePath, builder, jobnames })
 
-      const opener = jasmine.createSpyObj('MockOpener', ['open'])
-      spyOn(latex, 'getOpener').andReturn(opener)
+      spyOn(latex.opener, 'open').andReturn(true)
 
       composer.sync()
 
-      expect(opener.open).toHaveBeenCalledWith('foo.pdf', filePath, lineNumber)
-      expect(opener.open).toHaveBeenCalledWith('bar.pdf', filePath, lineNumber)
+      expect(latex.opener.open).toHaveBeenCalledWith('foo.pdf', filePath, lineNumber)
+      expect(latex.opener.open).toHaveBeenCalledWith('bar.pdf', filePath, lineNumber)
     })
   })
 })

--- a/spec/latex-spec.js
+++ b/spec/latex-spec.js
@@ -2,7 +2,6 @@
 
 import './spec-helpers'
 import Latex from '../lib/latex'
-import { NullOpener } from './stubs'
 
 describe('Latex', () => {
   let latex, globalLatex
@@ -19,10 +18,9 @@ describe('Latex', () => {
 
   describe('initialize', () => {
     it('initializes all properties', () => {
-      spyOn(latex, 'resolveOpenerImplementation').andReturn(NullOpener)
-
       expect(latex.logger).toBeDefined()
       expect(latex.opener).toBeDefined()
+      expect(latex.process).toBeDefined()
     })
   })
 
@@ -31,15 +29,6 @@ describe('Latex', () => {
       const defaultLogger = latex.getDefaultLogger()
 
       expect(defaultLogger.constructor.name).toBe('DefaultLogger')
-    })
-  })
-
-  describe('getDefaultOpener', () => {
-    it('returns an instance of a resolved implementation of Opener', () => {
-      spyOn(latex, 'resolveOpenerImplementation').andReturn(NullOpener)
-      const defaultOpener = latex.getDefaultOpener()
-
-      expect(defaultOpener.constructor.name).toBe(NullOpener.name)
     })
   })
 
@@ -73,103 +62,6 @@ describe('Latex', () => {
       latex.log.info(message)
 
       expect(logger.info).toHaveBeenCalledWith(message)
-    })
-  })
-
-  describe('resolveOpenerImplementation', () => {
-    it('returns SkimOpener when installed, and running on macOS', () => {
-      spyOn(latex, 'skimExecutableExists').andReturn(true)
-      const opener = latex.resolveOpenerImplementation('darwin')
-
-      expect(opener.name).toBe('SkimOpener')
-    })
-
-    it('returns PreviewOpener when Skim is not installed, and running on macOS', () => {
-      spyOn(latex, 'skimExecutableExists').andReturn(false)
-      const opener = latex.resolveOpenerImplementation('darwin')
-
-      expect(opener.name).toBe('PreviewOpener')
-    })
-
-    it('returns SumatraOpener when installed, and running on Windows', () => {
-      spyOn(latex, 'sumatraExecutableExists').andReturn(true)
-      const opener = latex.resolveOpenerImplementation('win32')
-
-      expect(opener.name).toBe('SumatraOpener')
-    })
-
-    it('returns AtomPdfOpener as a fallback, if the pdf-view package is installed', () => {
-      spyOn(latex, 'hasPdfViewerPackage').andReturn(true)
-      const opener = latex.resolveOpenerImplementation('foo')
-
-      expect(opener.name).toBe('AtomPdfOpener')
-    })
-
-    it('always returns AtomPdfOpener if alwaysOpenResultInAtom is enabled and pdf-view is installed', () => {
-      spyOn(latex, 'hasPdfViewerPackage').andReturn(true)
-      spyOn(latex, 'shouldOpenResultInAtom').andReturn(true)
-      spyOn(latex, 'skimExecutableExists').andCallThrough()
-
-      const opener = latex.resolveOpenerImplementation('darwin')
-
-      expect(opener.name).toBe('AtomPdfOpener')
-      expect(latex.skimExecutableExists).not.toHaveBeenCalled()
-    })
-
-    it('responds to changes in configuration', () => {
-      spyOn(latex, 'hasPdfViewerPackage').andReturn(true)
-      spyOn(latex, 'shouldOpenResultInAtom').andReturn(false)
-      spyOn(latex, 'skimExecutableExists').andReturn(true)
-
-      let opener = latex.resolveOpenerImplementation('darwin')
-      expect(opener.name).toBe('SkimOpener')
-
-      latex.shouldOpenResultInAtom.andReturn(true)
-      opener = latex.resolveOpenerImplementation('darwin')
-      expect(opener.name).toBe('AtomPdfOpener')
-
-      latex.shouldOpenResultInAtom.andReturn(false)
-      opener = latex.resolveOpenerImplementation('darwin')
-      expect(opener.name).toBe('SkimOpener')
-    })
-
-    it('returns OkularOpener when when installed and running on Linux', () => {
-      spyOn(latex, 'okularExecutableExists').andReturn(true)
-      spyOn(latex, 'evinceExecutableExists').andReturn(false)
-      const opener = latex.resolveOpenerImplementation('linux')
-
-      expect(opener.name).toBe('OkularOpener')
-    })
-
-    it('returns EvinceOpener when installed and running on Linux', () => {
-      spyOn(latex, 'okularExecutableExists').andReturn(false)
-      spyOn(latex, 'evinceExecutableExists').andReturn(true)
-      const opener = latex.resolveOpenerImplementation('linux')
-
-      expect(opener.name).toBe('EvinceOpener')
-    })
-
-    it('returns XdgOPener when Okular or Evince are not installed, and running on Linux', () => {
-      spyOn(latex, 'okularExecutableExists').andReturn(false)
-      spyOn(latex, 'evinceExecutableExists').andReturn(false)
-      const opener = latex.resolveOpenerImplementation('linux')
-
-      expect(opener.name).toBe('XdgOpener')
-    })
-
-    it('does not support unknown operating systems without pdf-view package', () => {
-      spyOn(latex, 'hasPdfViewerPackage').andReturn(false)
-      const opener = latex.resolveOpenerImplementation('foo')
-
-      expect(opener).toBeNull()
-    })
-
-    it('returns CustomOpener when custom viewer exists and alwaysOpenResultInAtom is disabled', () => {
-      spyOn(latex, 'viewerExecutableExists').andReturn(true)
-      spyOn(latex, 'shouldOpenResultInAtom').andReturn(false)
-      const opener = latex.resolveOpenerImplementation('foo')
-
-      expect(opener.name).toBe('CustomOpener')
     })
   })
 })

--- a/spec/latex-spec.js
+++ b/spec/latex-spec.js
@@ -1,19 +1,12 @@
 /** @babel */
 
-import './spec-helpers'
-import Latex from '../lib/latex'
+import helpers from './spec-helpers'
 
 describe('Latex', () => {
-  let latex, globalLatex
-
   beforeEach(() => {
-    globalLatex = global.latex
-    delete global.latex
-    latex = new Latex()
-  })
-
-  afterEach(() => {
-    global.latex = globalLatex
+    waitsForPromise(() => {
+      return helpers.activatePackages()
+    })
   })
 
   describe('initialize', () => {

--- a/spec/loggers/default-logger-spec.js
+++ b/spec/loggers/default-logger-spec.js
@@ -1,16 +1,17 @@
 /** @babel */
 
-import '../spec-bootstrap'
 import DefaultLogger from '../../lib/loggers/default-logger'
 import werkzeug from '../../lib/werkzeug'
-import Latex from '../../lib/latex'
+import helpers from '../spec-helpers'
 
 describe('DefaultLogger', () => {
   let logger
 
   beforeEach(() => {
+    waitsForPromise(() => {
+      return helpers.activatePackages()
+    })
     logger = new DefaultLogger()
-    global.latex = new Latex()
   })
 
   describe('showErrorMarkersInEditor', () => {

--- a/spec/master-tex-finder-spec.js
+++ b/spec/master-tex-finder-spec.js
@@ -1,13 +1,16 @@
 /** @babel */
 
-import './spec-bootstrap'
 import path from 'path'
+import helpers from './spec-helpers'
 import MasterTexFinder from '../lib/master-tex-finder'
 
 describe('MasterTexFinder', () => {
   let rootPath, fixturesPath
 
   beforeEach(() => {
+    waitsForPromise(() => {
+      return helpers.activatePackages()
+    })
     rootPath = atom.project.getPaths()[0]
     fixturesPath = path.join(rootPath, 'master-tex-finder', 'single-master')
 

--- a/spec/opener-registry-spec.js
+++ b/spec/opener-registry-spec.js
@@ -1,12 +1,10 @@
 /** @babel */
 
 import helpers from './spec-helpers'
-import OpenerRegistry from '../lib/opener-registry'
 
 describe('OpenerRegistry', () => {
   const filePath = 'wibble.pdf'
-  let registry
-  // The various viewer
+  // The various viewers
   let cannotOpen, canOpen, canOpenInBackground, canOpenWithSynctex
 
   beforeEach(() => {
@@ -20,12 +18,12 @@ describe('OpenerRegistry', () => {
     instance.canOpen.andReturn(canOpen)
     instance.hasSynctex.andReturn(hasSynctex)
     instance.canOpenInBackground.andReturn(canOpenInBackground)
-    registry.openers.set(name, instance)
+    latex.opener.openers.set(name, instance)
     return instance
   }
 
   beforeEach(() => {
-    registry = new OpenerRegistry()
+    latex.opener.openers.clear()
     // The opener names have to conform to latex.opener schema
     cannotOpen = createOpener('skim', false, true, true)
     canOpen = createOpener('xdg-open', true, false, false)
@@ -39,7 +37,7 @@ describe('OpenerRegistry', () => {
       atom.config.set('latex.openResultInBackground', true)
       atom.config.set('latex.opener', 'xdg-open')
 
-      registry.open(filePath)
+      latex.opener.open(filePath)
 
       expect(cannotOpen.open).not.toHaveBeenCalled()
       expect(canOpen.open).toHaveBeenCalled()
@@ -52,7 +50,7 @@ describe('OpenerRegistry', () => {
       atom.config.set('latex.openResultInBackground', true)
       atom.config.set('latex.opener', 'automatic')
 
-      registry.open(filePath)
+      latex.opener.open(filePath)
 
       expect(cannotOpen.open).not.toHaveBeenCalled()
       expect(canOpen.open).not.toHaveBeenCalled()
@@ -65,7 +63,7 @@ describe('OpenerRegistry', () => {
       atom.config.set('latex.openResultInBackground', true)
       atom.config.set('latex.opener', 'automatic')
 
-      registry.open(filePath)
+      latex.opener.open(filePath)
 
       expect(cannotOpen.open).not.toHaveBeenCalled()
       expect(canOpen.open).not.toHaveBeenCalled()

--- a/spec/opener-registry-spec.js
+++ b/spec/opener-registry-spec.js
@@ -1,0 +1,68 @@
+/** @babel */
+
+import OpenerRegistry from '../lib/opener-registry'
+
+describe('Latex', () => {
+  const filePath = 'wibble.pdf'
+  let registry
+  // The various viewer
+  let cannotOpen, canOpen, canOpenInBackground, canOpenWithSynctex
+
+  function createOpener (name, canOpen, hasSynctex, canOpenInBackground) {
+    const instance = jasmine.createSpyObj(name, ['canOpen', 'open', 'hasSynctex', 'canOpenInBackground'])
+    instance.canOpen.andReturn(canOpen)
+    instance.hasSynctex.andReturn(hasSynctex)
+    instance.canOpenInBackground.andReturn(canOpenInBackground)
+    registry.openers.set(name, instance)
+    return instance
+  }
+
+  beforeEach(() => {
+    registry = new OpenerRegistry()
+    cannotOpen = createOpener('cannot-open', false, true, true)
+    canOpen = createOpener('can-open', true, false, false)
+    canOpenInBackground = createOpener('can-open-in-background', true, false, true)
+    canOpenWithSynctex = createOpener('can-open-with-synctex', true, true, false)
+  })
+
+  describe('open', () => {
+    it('opens using preferred viewer even if it does not have requested features', () => {
+      atom.config.set('latex.enableSynctex', true)
+      atom.config.set('latex.openResultInBackground', true)
+      atom.config.set('latex.opener', 'can-open')
+
+      registry.open(filePath)
+
+      expect(cannotOpen.open).not.toHaveBeenCalled()
+      expect(canOpen.open).toHaveBeenCalled()
+      expect(canOpenInBackground.open).not.toHaveBeenCalled()
+      expect(canOpenWithSynctex.open).not.toHaveBeenCalled()
+    })
+
+    it('opens viewer that supports SyncTeX when enabled', () => {
+      atom.config.set('latex.enableSynctex', true)
+      atom.config.set('latex.openResultInBackground', true)
+      atom.config.set('latex.opener', 'automatic')
+
+      registry.open(filePath)
+
+      expect(cannotOpen.open).not.toHaveBeenCalled()
+      expect(canOpen.open).not.toHaveBeenCalled()
+      expect(canOpenInBackground.open).not.toHaveBeenCalled()
+      expect(canOpenWithSynctex.open).toHaveBeenCalled()
+    })
+
+    it('opens viewer that supports background opening when enabled', () => {
+      atom.config.set('latex.enableSynctex', false)
+      atom.config.set('latex.openResultInBackground', true)
+      atom.config.set('latex.opener', 'automatic')
+
+      registry.open(filePath)
+
+      expect(cannotOpen.open).not.toHaveBeenCalled()
+      expect(canOpen.open).not.toHaveBeenCalled()
+      expect(canOpenInBackground.open).toHaveBeenCalled()
+      expect(canOpenWithSynctex.open).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/spec/opener-registry-spec.js
+++ b/spec/opener-registry-spec.js
@@ -1,12 +1,19 @@
 /** @babel */
 
+import helpers from './spec-helpers'
 import OpenerRegistry from '../lib/opener-registry'
 
-describe('Latex', () => {
+describe('OpenerRegistry', () => {
   const filePath = 'wibble.pdf'
   let registry
   // The various viewer
   let cannotOpen, canOpen, canOpenInBackground, canOpenWithSynctex
+
+  beforeEach(() => {
+    waitsForPromise(() => {
+      return helpers.activatePackages()
+    })
+  })
 
   function createOpener (name, canOpen, hasSynctex, canOpenInBackground) {
     const instance = jasmine.createSpyObj(name, ['canOpen', 'open', 'hasSynctex', 'canOpenInBackground'])
@@ -19,17 +26,18 @@ describe('Latex', () => {
 
   beforeEach(() => {
     registry = new OpenerRegistry()
-    cannotOpen = createOpener('cannot-open', false, true, true)
-    canOpen = createOpener('can-open', true, false, false)
-    canOpenInBackground = createOpener('can-open-in-background', true, false, true)
-    canOpenWithSynctex = createOpener('can-open-with-synctex', true, true, false)
+    // The opener names have to conform to latex.opener schema
+    cannotOpen = createOpener('skim', false, true, true)
+    canOpen = createOpener('xdg-open', true, false, false)
+    canOpenInBackground = createOpener('okular', true, false, true)
+    canOpenWithSynctex = createOpener('evince', true, true, false)
   })
 
   describe('open', () => {
     it('opens using preferred viewer even if it does not have requested features', () => {
       atom.config.set('latex.enableSynctex', true)
       atom.config.set('latex.openResultInBackground', true)
-      atom.config.set('latex.opener', 'can-open')
+      atom.config.set('latex.opener', 'xdg-open')
 
       registry.open(filePath)
 

--- a/spec/process-manager-spec.js
+++ b/spec/process-manager-spec.js
@@ -22,7 +22,7 @@ describe('ProcessManager', () => {
     it('kills latexmk when given non-existant file', () => {
       let killed = false
 
-      processManager.executeChildProcess(constructCommand('foo.tex')).then(result => { killed = true })
+      processManager.executeChildProcess(constructCommand('foo.tex'), { allowKill: true }).then(result => { killed = true })
       processManager.killChildProcesses()
 
       waitsFor(() => killed, 5000)
@@ -32,9 +32,9 @@ describe('ProcessManager', () => {
       let oldKilled = false
       let newKilled = false
 
-      processManager.executeChildProcess(constructCommand('old.tex')).then(result => { oldKilled = true })
+      processManager.executeChildProcess(constructCommand('old.tex'), { allowKill: true }).then(result => { oldKilled = true })
       processManager.killChildProcesses()
-      processManager.executeChildProcess(constructCommand('new.tex')).then(result => { newKilled = true })
+      processManager.executeChildProcess(constructCommand('new.tex'), { allowKill: true }).then(result => { newKilled = true })
 
       waitsFor(() => oldKilled, 5000)
 

--- a/spec/spec-bootstrap.js
+++ b/spec/spec-bootstrap.js
@@ -1,7 +1,0 @@
-/** @babel */
-
-import Latex from '../lib/latex'
-import { NullLogger } from './stubs'
-
-global.latex = new Latex()
-latex.setLogger(new NullLogger())

--- a/spec/spec-helpers.js
+++ b/spec/spec-helpers.js
@@ -1,7 +1,5 @@
 /** @babel */
 
-import './spec-bootstrap'
-
 import fs from 'fs-plus'
 import temp from 'temp'
 import wrench from 'wrench'
@@ -27,5 +25,13 @@ export default {
     env.defaultTimeoutInterval = interval
 
     return originalInterval
+  },
+
+  activatePackages () {
+    const workspaceElement = atom.views.getView(atom.workspace)
+    const packages = ['language-latex', 'pdf-view', 'latex']
+    const activationPromise = Promise.all(packages.map(pkg => atom.packages.activatePackage(pkg)))
+    atom.commands.dispatch(workspaceElement, 'latex:sync')
+    return activationPromise
   }
 }


### PR DESCRIPTION
This is PR implements a simple opener registry which tries to pick an opener based on availability and features. The user can override the automatic selection via the `latex.opener` setting.

### Algorithm
1. If a specific opener has been set with `latex.opener` and that one can open the file then use it.
2. Filter out the openers that cannot open the requested file.
3. Abort and show a warning message if there no openers left after the filter.
4. Sort the openers in decreasing priority with SyncTeX capability ranked higher then "open in background" capability.
5. If `latex.enableSynctex` is enabled then use the viewer with the highest priority that supports SyncTeX if one is present. If there are openers that support both SyncTeX and "open in background" then these will be at the front of the list because of the priority sort.
6. If `latex.openResultInBackground` is enabled then use the viewer with the highest priority that supports opening in background if one is present.
7. If all else fails, just use the highest priority opener.

### Issues
- [x] Migrate `latex.alwaysOpenResultInAtom` setting to `latex.opener = 'pdf-view'` setting.
- [x] Simplify settings? Checking the existance of openers could be done with calls like `okular --version` if we replaced the `latex.texPath` with `latex.paths`. Would make all the opener path settings unneeded and make it possible to find 64bit SumatraPDF without user configuration. *Maybe later*
- [x] Refactor `EvinceOpener` to move methods into class.
- [x] Specs

Resolves #235 and resolves #85 and resolves #252.