### PR TITLE
Fix incorrect path resolution in LogParser

### DIFF
--- a/lib/parsers/log-parser.js
+++ b/lib/parsers/log-parser.js
@@ -65,9 +65,6 @@ export default class LogParser extends Parser {
       match = line.match(ERROR_PATTERN)
       if (match) {
         const lineNumber = match[2] ? parseInt(match[2], 10) : undefined
-        if (match[1]) {
-          console.log(`${match[1]} -> ${path.resolve(this.projectPath, match[1])}`)
-        }
         result.messages.push({
           type: 'Error',
           text: (match[3] && match[3] !== 'LaTeX') ? match[3] + ': ' + match[4] : match[4],

--- a/lib/parsers/log-parser.js
+++ b/lib/parsers/log-parser.js
@@ -41,7 +41,6 @@ export default class LogParser extends Parser {
     super(filePath)
     this.texFilePath = texFilePath
     this.projectPath = path.dirname(texFilePath)
-    this.outputPath = path.dirname(filePath)
   }
 
   parse () {
@@ -58,7 +57,7 @@ export default class LogParser extends Parser {
       let match = line.match(OUTPUT_PATTERN)
       if (match) {
         const filePath = match[1].replace(/"/g, '') // TODO: Fix with improved regex.
-        result.outputFilePath = path.resolve(this.outputPath, filePath)
+        result.outputFilePath = path.resolve(this.projectPath, filePath)
         return
       }
 

--- a/lib/parsers/log-parser.js
+++ b/lib/parsers/log-parser.js
@@ -12,9 +12,9 @@ const OUTPUT_PATTERN = new RegExp('' +
 
 // Error pattern
 const ERROR_PATTERN = new RegExp('' +
-  '^(?:(?:\\.\\/)?(.*):(\\d+):|!)' + // File path and line number ignoring leading './'
-  '(?: (.+) Error:)? ' +             // Error type
-  '(.+?)\\.?$'                       // Message text, the ending period is optional for MiKTeX
+  '^(?:(.*):(\\d+):|!)' + // File path and line number
+  '(?: (.+) Error:)? ' +  // Error type
+  '(.+?)\\.?$'           // Message text, the ending period is optional for MiKTeX
 )
 
 // Pattern for overfull/underfull boxes
@@ -40,7 +40,8 @@ export default class LogParser extends Parser {
   constructor (filePath, texFilePath) {
     super(filePath)
     this.texFilePath = texFilePath
-    this.projectPath = path.dirname(filePath)
+    this.projectPath = path.dirname(texFilePath)
+    this.outputPath = path.dirname(filePath)
   }
 
   parse () {
@@ -57,17 +58,20 @@ export default class LogParser extends Parser {
       let match = line.match(OUTPUT_PATTERN)
       if (match) {
         const filePath = match[1].replace(/"/g, '') // TODO: Fix with improved regex.
-        result.outputFilePath = path.resolve(this.projectPath, filePath)
+        result.outputFilePath = path.resolve(this.outputPath, filePath)
         return
       }
 
       match = line.match(ERROR_PATTERN)
       if (match) {
         const lineNumber = match[2] ? parseInt(match[2], 10) : undefined
+        if (match[1]) {
+          console.log(`${match[1]} -> ${path.resolve(this.projectPath, match[1])}`)
+        }
         result.messages.push({
           type: 'Error',
           text: (match[3] && match[3] !== 'LaTeX') ? match[3] + ': ' + match[4] : match[4],
-          filePath: match[1] ? this.alterParentPath(this.texFilePath, match[1]) : this.texFilePath,
+          filePath: match[1] ? path.resolve(this.projectPath, match[1]) : this.texFilePath,
           range: lineNumber ? [[lineNumber - 1, 0], [lineNumber - 1, 65536]] : undefined,
           logPath: this.filePath,
           logRange: logRange
@@ -103,10 +107,5 @@ export default class LogParser extends Parser {
       } })
 
     return result
-  }
-
-  alterParentPath (targetPath, originalPath) {
-    const targetDir = path.dirname(targetPath)
-    return path.join(targetDir, path.basename(originalPath))
   }
 }

--- a/spec/builders/latexmk-spec.js
+++ b/spec/builders/latexmk-spec.js
@@ -139,6 +139,7 @@ describe('LatexmkBuilder', () => {
 
     it('fails with code 12 and various errors, warnings and info messages are produced in log file', () => {
       filePath = path.join(fixturesPath, 'error-warning.tex')
+      const subFilePath = path.join(fixturesPath, 'sub', 'wibble.tex')
 
       waitsForPromise(() => {
         return builder.run(filePath).then(code => {
@@ -174,6 +175,10 @@ describe('LatexmkBuilder', () => {
           expect(_.some(parsedLog.messages,
             logMessage => message.type === logMessage.type && message.text === logMessage.text)).toBe(true, `Message = ${message.text}`)
         }
+
+        expect(_.every(parsedLog.messages,
+          logMessage => !logMessage.filePath || logMessage.filePath === filePath || logMessage.filePath === subFilePath))
+          .toBe(true, 'Incorrect file path resolution in log.')
 
         expect(exitCode).toBe(12)
       })

--- a/spec/fixtures/error-warning.tex
+++ b/spec/fixtures/error-warning.tex
@@ -25,9 +25,6 @@
     Foo & Bar & Snafu \\
   \end{tabular}
 
-  % Undefined references
-  \ref{tab:snafu}
-
   % Class errors, warnings, etc.
   \ClassError{foo}{Significant class issue}{RTFM!}
   \ClassWarning{foo}{Class issue}
@@ -39,5 +36,8 @@
   \PackageWarning{bar}{Package issue}
   \PackageWarningNoLine{bar}{Nebulous package issue}
   \PackageInfo{bar}{Insignificant package issue}
+
+  % Generate an error in a subfile located in another directory
+  \input{sub/wibble}
 
 \end{document}

--- a/spec/fixtures/sub/wibble.tex
+++ b/spec/fixtures/sub/wibble.tex
@@ -1,0 +1,2 @@
+% Undefined references
+\ref{tab:snafu}


### PR DESCRIPTION
Current path resolution for error messages only works if the source file generating the error is in the same directory. It fails if the file is in a sub-directory or if the path contains a parent reference like `../foo`