### PR TITLE
Remove usage of the Shadow DOM

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     ]
   },
   "engines": {
-    "atom": ">=1.10.0 <2.0.0"
+    "atom": ">=1.13.0 <2.0.0"
   },
   "activationCommands": {
     "atom-workspace": [

--- a/styles/markers.atom-text-editor.less
+++ b/styles/markers.atom-text-editor.less
@@ -1,6 +1,6 @@
 @import "ui-variables";
 
-:host(:host) .gutter .line-number {
+atom-text-editor .gutter .line-number {
   &.latex-error {
     border-left: 2px solid @background-color-error;
     padding-left: ~"calc(0.5em - 2px)";


### PR DESCRIPTION
This PR rewrites deprecated Shadow DOM based selectors that will stop working in Atom v1.13.

Resolves #319