### PR TITLE
Check environment at startup

### DIFF
--- a/lib/builder-registry.js
+++ b/lib/builder-registry.js
@@ -1,6 +1,5 @@
 /** @babel */
 
-import _ from 'lodash'
 import fs from 'fs-plus'
 import path from 'path'
 import MagicParser from './parsers/magic-parser'
@@ -22,11 +21,11 @@ export default class BuilderRegistry {
     return (BuilderImpl != null) ? new BuilderImpl() : null
   }
 
-  async checkEnvironment () {
+  async checkRuntimeDependencies () {
     const builders = this.getAllBuilders()
     for (const BuilderImpl of builders) {
       const builder = new BuilderImpl()
-      await builder.checkEnvironment()
+      await builder.checkRuntimeDependencies()
     }
   }
 
@@ -50,7 +49,7 @@ export default class BuilderRegistry {
   resolveAmbiguousBuilders (builders, builderOverride) {
     function findBuilder (name) {
       const namePattern = new RegExp(`^${name}Builder$`, 'i')
-      return _.find(builders, builder => builder.name.match(namePattern))
+      return builders.find(builder => builder.name.match(namePattern))
     }
 
     let builder

--- a/lib/builder-registry.js
+++ b/lib/builder-registry.js
@@ -24,8 +24,10 @@ export default class BuilderRegistry {
 
   async checkEnvironment () {
     const builders = this.getAllBuilders()
-    const environmentChecks = builders.map(BuilderImpl => new BuilderImpl().checkEnvironment())
-    await Promise.all(environmentChecks)
+    for (const BuilderImpl of builders) {
+      const builder = new BuilderImpl()
+      await builder.checkEnvironment()
+    }
   }
 
   getBuilderFromMagic (filePath) {

--- a/lib/builder-registry.js
+++ b/lib/builder-registry.js
@@ -22,6 +22,12 @@ export default class BuilderRegistry {
     return (BuilderImpl != null) ? new BuilderImpl() : null
   }
 
+  async checkEnvironment () {
+    const builders = this.getAllBuilders()
+    const environmentChecks = builders.map(BuilderImpl => new BuilderImpl().checkEnvironment())
+    await Promise.all(environmentChecks)
+  }
+
   getBuilderFromMagic (filePath) {
     const magic = new MagicParser(filePath).parse()
     if (magic && magic.builder) {

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -11,9 +11,10 @@ import { heredoc, isPdfFile, isPsFile, isDviFile } from './werkzeug.js'
 export default class Builder {
   envPathKey = this.getEnvironmentPathKey(process.platform)
 
-  static canProcess (/* filePath */) {}
-  async run (/* filePath, jobname, shouldRebuild */) {}
-  constructArgs (/* filePath, jobname, shouldRebuild */) {}
+  static canProcess (filePath) {}
+  async run (filePath, jobname, shouldRebuild) {}
+  constructArgs (filePath, jobname, shouldRebuild) {}
+  async checkEnvironment () {}
 
   logStatusCode (statusCode) {
     switch (statusCode) {
@@ -46,7 +47,7 @@ export default class Builder {
     return new LogParser(logFilePath, texFilePath)
   }
 
-  constructChildProcessOptions (filePath, defaultEnv) {
+  constructChildProcessOptions (directoryPath, defaultEnv) {
     const env = _.assign(defaultEnv || {}, process.env)
     const childPath = this.constructPath()
     if (childPath) {
@@ -57,7 +58,7 @@ export default class Builder {
       allowKill: true,
       encoding: 'utf8',
       maxBuffer: 52428800, // Set process' max buffer size to 50 MB.
-      cwd: path.dirname(filePath), // Run process with sensible CWD.
+      cwd: directoryPath,  // Run process with sensible CWD.
       env
     }
   }

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -14,7 +14,7 @@ export default class Builder {
   static canProcess (filePath) {}
   async run (filePath, jobname, shouldRebuild) {}
   constructArgs (filePath, jobname, shouldRebuild) {}
-  async checkEnvironment () {}
+  async checkRuntimeDependencies () {}
 
   logStatusCode (statusCode) {
     switch (statusCode) {

--- a/lib/builders/knitr.js
+++ b/lib/builders/knitr.js
@@ -37,7 +37,7 @@ export default class KnitrBuilder extends Builder {
     return code
   }
 
-  async checkEnvironment () {
+  async checkRuntimeDependencies () {
     const { statusCode, stderr } = await this.execRscript('.', ['--version'], 'warning')
 
     if (statusCode !== 0) {

--- a/lib/builders/knitr.js
+++ b/lib/builders/knitr.js
@@ -5,6 +5,7 @@ import Builder from '../builder'
 
 const MISSING_PACKAGE_PATTERN = /there is no package called [‘']([^’']+)[’']/g
 const OUTPUT_PATH_PATTERN = /\[\d+\]\s+"(.*)"/
+const RSCRIPT_VERSION_PATTERN = /version\s+(\S+)/i
 
 export default class KnitrBuilder extends Builder {
   executable = 'Rscript'
@@ -15,7 +16,8 @@ export default class KnitrBuilder extends Builder {
 
   async run (filePath, jobname, shouldRebuild) {
     const args = this.constructArgs(filePath)
-    const { statusCode, stdout } = await this.execRscript(filePath, args, 'Error')
+    const directoryPath = path.dirname(filePath)
+    const { statusCode, stdout } = await this.execRscript(directoryPath, args, 'error')
     if (statusCode !== 0) return statusCode
 
     const texFilePath = this.resolveOutputPath(filePath, stdout)
@@ -26,7 +28,7 @@ export default class KnitrBuilder extends Builder {
       const outputDirectory = this.getOutputDirectory(filePath)
       if (outputDirectory) {
         const args = this.constructPatchSynctexArgs(texFilePath, jobname)
-        await this.execRscript(filePath, args, 'Warning')
+        await this.execRscript(directoryPath, args, 'warning')
       } else {
         latex.log.info('Using an output directory is not compatible with patchSynctex.')
       }
@@ -35,9 +37,34 @@ export default class KnitrBuilder extends Builder {
     return code
   }
 
-  async execRscript (filePath, args, type) {
+  async checkEnvironment () {
+    const { statusCode, stderr } = await this.execRscript('.', ['--version'], 'warning')
+
+    if (statusCode !== 0) {
+      latex.log.error(`Rscript check failed with code ${statusCode} and response of "${stderr}".`)
+      return
+    }
+
+    const match = stderr.match(RSCRIPT_VERSION_PATTERN)
+
+    if (!match) {
+      latex.log.warning(`Rscript check succeeded but with an unknown version response of "${stderr}".`)
+      return
+    }
+
+    const version = match[1]
+
+    latex.log.info(`Rscript check succeeded. Found version ${version}.`)
+
+    const result = await this.execRscript('.', ['-e "library(knitr)"', '-e "library(patchSynctex)"'], 'warning')
+    if (result.statusCode === 0) {
+      latex.log.info('knitr and patchSynctex libraries found.')
+    }
+  }
+
+  async execRscript (directoryPath, args, type) {
     const command = `${this.executable} ${args.join(' ')}`
-    const options = this.constructChildProcessOptions(filePath)
+    const options = this.constructChildProcessOptions(directoryPath)
 
     let { statusCode, stdout, stderr } = await latex.process.executeChildProcess(command, options)
 
@@ -51,7 +78,7 @@ export default class KnitrBuilder extends Builder {
       }
     }
 
-    return { statusCode, stdout }
+    return { statusCode, stdout, stderr }
   }
 
   constructArgs (filePath) {

--- a/lib/builders/knitr.js
+++ b/lib/builders/knitr.js
@@ -41,7 +41,7 @@ export default class KnitrBuilder extends Builder {
     const { statusCode, stderr } = await this.execRscript('.', ['--version'], 'warning')
 
     if (statusCode !== 0) {
-      latex.log.error(`Rscript check failed with code ${statusCode} and response of "${stderr}".`)
+      latex.log.warning(`Rscript check failed with code ${statusCode} and response of "${stderr}".`)
       return
     }
 

--- a/lib/builders/latexmk.js
+++ b/lib/builders/latexmk.js
@@ -5,7 +5,7 @@ import Builder from '../builder'
 
 const LATEX_PATTERN = /^latex|u?platex$/
 const LATEXMK_VERSION_PATTERN = /Version\s+(\S+)/i
-const LATEXMK_MINIMUM_VERSION = '4.47'
+const LATEXMK_MINIMUM_VERSION = '4.37'
 
 export default class LatexmkBuilder extends Builder {
   executable = 'latexmk'

--- a/lib/builders/latexmk.js
+++ b/lib/builders/latexmk.js
@@ -4,6 +4,8 @@ import path from 'path'
 import Builder from '../builder'
 
 const LATEX_PATTERN = /^latex|u?platex$/
+const LATEXMK_VERSION_PATTERN = /Version\s+(\S+)/i
+const LATEXMK_MINIMUM_VERSION = '4.47'
 
 export default class LatexmkBuilder extends Builder {
   executable = 'latexmk'
@@ -14,11 +16,43 @@ export default class LatexmkBuilder extends Builder {
 
   async run (filePath, jobname, shouldRebuild) {
     const args = this.constructArgs(filePath, jobname, shouldRebuild)
-    const command = `${this.executable} ${args.join(' ')}`
-    const options = this.constructChildProcessOptions(filePath, { max_print_line: 1000 })
+    const directoryPath = path.dirname(filePath)
 
-    const { statusCode } = await latex.process.executeChildProcess(command, options)
+    const { statusCode } = await this.execLatexmk(directoryPath, args, 'error')
+
     return statusCode
+  }
+
+  async execLatexmk (directoryPath, args, type) {
+    const command = `${this.executable} ${args.join(' ')}`
+    const options = this.constructChildProcessOptions(directoryPath, { max_print_line: 1000 })
+
+    return await latex.process.executeChildProcess(command, options)
+  }
+
+  async checkEnvironment () {
+    const { statusCode, stdout, stderr } = await this.execLatexmk('.', ['-v'], 'error')
+
+    if (statusCode !== 0) {
+      latex.log.error(`latexmk check failed with code ${statusCode} and response of "${stderr}".`)
+      return
+    }
+
+    const match = stdout.match(LATEXMK_VERSION_PATTERN)
+
+    if (!match) {
+      latex.log.warning(`latexmk check succeeded but with an unknown version response of "${stdout}".`)
+      return
+    }
+
+    const version = match[1]
+
+    if (version < LATEXMK_MINIMUM_VERSION) {
+      latex.log.warning(`latexmk check succeeded but with a version of ${version}". Minimum version required is ${LATEXMK_MINIMUM_VERSION}.`)
+      return
+    }
+
+    latex.log.info(`latexmk check succeeded. Found version ${version}.`)
   }
 
   logStatusCode (statusCode) {

--- a/lib/builders/latexmk.js
+++ b/lib/builders/latexmk.js
@@ -30,7 +30,7 @@ export default class LatexmkBuilder extends Builder {
     return await latex.process.executeChildProcess(command, options)
   }
 
-  async checkEnvironment () {
+  async checkRuntimeDependencies () {
     const { statusCode, stdout, stderr } = await this.execLatexmk('.', ['-v'], 'error')
 
     if (statusCode !== 0) {

--- a/lib/builders/texify.js
+++ b/lib/builders/texify.js
@@ -13,7 +13,8 @@ export default class TexifyBuilder extends Builder {
   async run (filePath, jobname) {
     const args = this.constructArgs(filePath, jobname)
     const command = `${this.executable} ${args.join(' ')}`
-    const options = this.constructChildProcessOptions(filePath, { BIBTEX: 'biber' })
+    const directoryPath = path.dirname(filePath)
+    const options = this.constructChildProcessOptions(directoryPath, { BIBTEX: 'biber' })
 
     const { statusCode } = await latex.process.executeChildProcess(command, options)
     return statusCode

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -17,7 +17,7 @@ export default class Composer extends Disposable {
     super(() => this.disposables.dispose())
     this.disposables.add(atom.config.onDidChange('latex', () => {
       this.rebuildCompleted = new Set()
-    })
+    }))
     if (!atom.inSpecMode()) {
       this.checkEnvironment()
     }

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -314,9 +314,20 @@ export default class Composer extends Disposable {
     // TODO: remove after grace period
     this.checkCleanExtensions()
     this.checkOpenerSetting()
+    this.checkMasterFileSearchSetting()
     await this.builderRegistry.checkRuntimeDependencies()
     latex.opener.checkRuntimeDependencies()
     latex.log.groupEnd()
+  }
+
+  checkMasterFileSearchSetting () {
+    if (!atom.config.get('latex.useMasterFileSearch')) return
+
+    const message = `LaTeX: The Master File Search setting has been deprecated`
+    const description = heredoc(`
+      Support for the Master File Search setting has been deprecated in favor of
+      \`%!TEX root\` magic comments, and will be removed soon.`)
+    atom.notifications.addInfo(message, { description })
   }
 
   checkCleanExtensions () {

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -18,7 +18,9 @@ export default class Composer extends Disposable {
     this.disposables.add(atom.config.onDidChange('latex', () => {
       this.rebuildCompleted = new Set()
     })
-    if (!atom.inSpecMode()) this.checkEnvironment()
+    if (!atom.inSpecMode()) {
+      this.checkEnvironment()
+    }
   }
 
   initializeBuild (filePath) {
@@ -209,7 +211,7 @@ export default class Composer extends Disposable {
     }
     const patterns = atom.config.get('latex.cleanPatterns')
 
-    return _.map(patterns, pattern => path.normalize(replacePropertiesInString(pattern, properties)))
+    return patterns.map(pattern => path.normalize(replacePropertiesInString(pattern, properties)))
   }
 
   getGeneratedFileList (builder, rootFilePath, jobname) {
@@ -312,8 +314,8 @@ export default class Composer extends Disposable {
     // TODO: remove after grace period
     this.checkCleanExtensions()
     this.checkOpenerSetting()
-    await this.builderRegistry.checkEnvironment()
-    latex.opener.checkEnvironment()
+    await this.builderRegistry.checkRuntimeDependencies()
+    latex.opener.checkRuntimeDependencies()
     latex.log.groupEnd()
   }
 

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -308,9 +308,12 @@ export default class Composer extends Disposable {
   shouldOpenResult () { return atom.config.get('latex.openResultAfterBuild') }
 
   async checkEnvironment () {
+    latex.log.group('LaTeX Check')
     // TODO: remove after grace period
     this.checkCleanExtensions()
     this.checkOpenerSetting()
+    await this.builderRegistry.checkEnvironment()
+    latex.log.groupEnd()
   }
 
   checkCleanExtensions () {

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -17,8 +17,8 @@ export default class Composer extends Disposable {
     super(() => this.disposables.dispose())
     this.disposables.add(atom.config.onDidChange('latex', () => {
       this.rebuildCompleted = new Set()
-    }))
-    this.checkEnvironment()
+    })
+    if (!atom.inSpecMode()) this.checkEnvironment()
   }
 
   initializeBuild (filePath) {

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -313,6 +313,7 @@ export default class Composer extends Disposable {
     this.checkCleanExtensions()
     this.checkOpenerSetting()
     await this.builderRegistry.checkEnvironment()
+    latex.opener.checkEnvironment()
     latex.log.groupEnd()
   }
 

--- a/lib/error-marker.js
+++ b/lib/error-marker.js
@@ -15,7 +15,7 @@ export default class ErrorMarker {
     this.markers = _.map(_.groupBy(this.messages, 'range'), messages => {
       const type = Logger.getMostSevereType(messages)
       const marker = this.editor.markBufferRange(messages[0].range, {invalidate: 'touch'})
-      this.editor.decorateMarker(marker, {type: 'line-number', class: `latex-${type.toLowerCase()}`})
+      this.editor.decorateMarker(marker, {type: 'line-number', class: `latex-${type}`})
       return marker
     })
   }

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -9,15 +9,15 @@ export default class Logger {
   }
 
   error (text, filePath, range, logPath, logRange) {
-    this.showMessage({ type: 'Error', text, filePath, range, logPath, logRange })
+    this.showMessage({ type: 'error', text, filePath, range, logPath, logRange })
   }
 
   warning (text, filePath, range, logPath, logRange) {
-    this.showMessage({ type: 'Warning', text, filePath, range, logPath, logRange })
+    this.showMessage({ type: 'warning', text, filePath, range, logPath, logRange })
   }
 
   info (text, filePath, range, logPath, logRange) {
-    this.showMessage({ type: 'Info', text, filePath, range, logPath, logRange })
+    this.showMessage({ type: 'info', text, filePath, range, logPath, logRange })
   }
 
   showMessage (message) {
@@ -47,7 +47,7 @@ export default class Logger {
     const showBuildWarning = loggingLevel !== 'error'
     const showBuildInfo = loggingLevel === 'info'
     const filteredMessages = _.filter(this.messages, (message) => {
-      return message.type === 'Error' || (showBuildWarning && message.type === 'Warning') || (showBuildInfo && message.type === 'Info')
+      return message.type === 'error' || (showBuildWarning && message.type === 'warning') || (showBuildInfo && message.type === 'info')
     })
 
     this.showMessages(this._label, filteredMessages)
@@ -55,9 +55,9 @@ export default class Logger {
 
   static getMostSevereType (messages) {
     return _.reduce(messages, (type, message) => {
-      if (type === 'Error' || message.type === 'Error') return 'Error'
-      if (type === 'Warning' || message.type === 'Warning') return 'Warning'
-      return 'Info'
+      if (type === 'error' || message.type === 'error') return 'error'
+      if (type === 'warning' || message.type === 'warning') return 'warning'
+      return 'info'
     }, undefined)
   }
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -21,6 +21,7 @@ export default class Logger {
   }
 
   showMessage (message) {
+    message.timestamp = Date.now()
     message = _.pickBy(message)
     if (this._group) {
       this._group.push(message)
@@ -37,7 +38,7 @@ export default class Logger {
   }
 
   groupEnd () {
-    this.messages = _.sortBy(this._group, 'filePath', message => { return message.range || [[-1, -1], [-1, -1]] }, 'type', 'text')
+    this.messages = _.sortBy(this._group, 'filePath', message => { return message.range || [[-1, -1], [-1, -1]] }, 'type', 'timestamp')
     this._group = null
     this.showFilteredMessages()
   }

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -21,8 +21,7 @@ export default class Logger {
   }
 
   showMessage (message) {
-    message.timestamp = Date.now()
-    message = _.pickBy(message)
+    message = _.assign({ timestamp: Date.now() }, _.pickBy(message))
     if (this._group) {
       this._group.push(message)
     } else {
@@ -51,7 +50,7 @@ export default class Logger {
       return message.type === 'error' || (showBuildWarning && message.type === 'warning') || (showBuildInfo && message.type === 'info')
     })
 
-    this.showMessages(this._label, filteredMessages)
+    this.showMessages(this._label, filteredMessages.map(message => _.omit(message, 'timestamp')))
   }
 
   static getMostSevereType (messages) {

--- a/lib/opener-registry.js
+++ b/lib/opener-registry.js
@@ -28,6 +28,29 @@ export default class OpenerRegistry extends Disposable {
     }
   }
 
+  checkEnvironment () {
+    const pdfOpeners = Array.from(this.getCandidateOpeners('foo.pdf').keys())
+    if (pdfOpeners.length) {
+      latex.log.info(`The following PDF capable openers were found: ${pdfOpeners.join(', ')}.`)
+    } else {
+      latex.log.error('No PDF capable openers were found.')
+    }
+
+    const psOpeners = Array.from(this.getCandidateOpeners('foo.ps').keys())
+    if (psOpeners.length) {
+      latex.log.info(`The following PS capable openers were found: ${psOpeners.join(', ')}.`)
+    } else {
+      latex.log.warning('No PS capable openers were found.')
+    }
+
+    const dviOpeners = Array.from(this.getCandidateOpeners('foo.dvi').keys())
+    if (dviOpeners.length) {
+      latex.log.info(`The following DVI capable openers were found: ${dviOpeners.join(', ')}.`)
+    } else {
+      latex.log.warning('No DVI capable openers were found.')
+    }
+  }
+
   async open (filePath, texPath, lineNumber) {
     const name = atom.config.get('latex.opener')
     let opener = this.openers.get(name)
@@ -43,10 +66,18 @@ export default class OpenerRegistry extends Disposable {
     }
   }
 
+  getCandidateOpeners (filePath) {
+    const candidates = new Map()
+    for (const [name, opener] of this.openers.entries()) {
+      if (opener.canOpen(filePath)) candidates.set(name, opener)
+    }
+    return candidates
+  }
+
   findOpener (filePath) {
     const openResultInBackground = atom.config.get('latex.openResultInBackground')
     const enableSynctex = atom.config.get('latex.enableSynctex')
-    const candidates = Array.from(this.openers.values()).filter(opener => opener.canOpen(filePath))
+    const candidates = Array.from(this.getCandidateOpeners(filePath).values())
 
     if (!candidates.length) return
 

--- a/lib/opener-registry.js
+++ b/lib/opener-registry.js
@@ -28,7 +28,7 @@ export default class OpenerRegistry extends Disposable {
     }
   }
 
-  checkEnvironment () {
+  checkRuntimeDependencies () {
     const pdfOpeners = Array.from(this.getCandidateOpeners('foo.pdf').keys())
     if (pdfOpeners.length) {
       latex.log.info(`The following PDF capable openers were found: ${pdfOpeners.join(', ')}.`)

--- a/lib/parsers/log-parser.js
+++ b/lib/parsers/log-parser.js
@@ -65,7 +65,7 @@ export default class LogParser extends Parser {
       if (match) {
         const lineNumber = match[2] ? parseInt(match[2], 10) : undefined
         result.messages.push({
-          type: 'Error',
+          type: 'error',
           text: (match[3] && match[3] !== 'LaTeX') ? match[3] + ': ' + match[4] : match[4],
           filePath: match[1] ? path.resolve(this.projectPath, match[1]) : this.texFilePath,
           range: lineNumber ? [[lineNumber - 1, 0], [lineNumber - 1, 65536]] : undefined,
@@ -78,7 +78,7 @@ export default class LogParser extends Parser {
       match = line.match(BOX_PATTERN)
       if (match) {
         result.messages.push({
-          type: 'Warning',
+          type: 'warning',
           text: match[1],
           filePath: this.texFilePath,
           range: [[parseInt(match[2], 10) - 1, 0], [parseInt(match[3], 10) - 1, 65536]],
@@ -92,7 +92,7 @@ export default class LogParser extends Parser {
       if (match) {
         const lineNumber = match[4] ? parseInt(match[4], 10) : undefined
         result.messages.push({
-          type: match[2],
+          type: match[2].toLowerCase(),
           text: ((match[1] !== 'LaTeX') ? match[1] + ': ' + match[3] : match[3]).replace(/\s+/g, ' '),
           filePath: this.texFilePath,
           range: lineNumber ? [[lineNumber - 1, 0], [lineNumber - 1, 65536]] : undefined,

--- a/lib/views/log-message.js
+++ b/lib/views/log-message.js
@@ -50,7 +50,7 @@ export default class LogMessage {
   }
 
   getClassNames (message) {
-    const className = `latex-${message.type.toLowerCase()}`
+    const className = `latex-${message.type}`
 
     const matchesFilePath = message.filePath && this.properties.filePath === message.filePath
     const containsPosition = message.range && this.properties.position && Range.fromObject(message.range).containsPoint(this.properties.position)

--- a/lib/views/status-label.js
+++ b/lib/views/status-label.js
@@ -24,7 +24,7 @@ export default class StatusLabel {
       'inline-block'
     ]
 
-    if (this.properties.type) classNames.push(`latex-${this.properties.type.toLowerCase()}`)
+    if (this.properties.type) classNames.push(`latex-${this.properties.type}`)
     if (this.properties.onClick) classNames.push('latex-status-link')
 
     let iconClassNames = [

--- a/spec/builders/knitr-spec.js
+++ b/spec/builders/knitr-spec.js
@@ -68,8 +68,9 @@ describe('KnitrBuilder', () => {
     })
 
     it('detects missing knitr library and logs an error', () => {
+      const directoryPath = path.dirname(filePath)
       const env = { 'R_LIBS_USER': '/dev/null', 'R_LIBS_SITE': '/dev/null' }
-      const options = _.merge(builder.constructChildProcessOptions(filePath), { env })
+      const options = _.merge(builder.constructChildProcessOptions(directoryPath), { env })
       spyOn(builder, 'constructChildProcessOptions').andReturn(options)
       spyOn(latex.log, 'showMessage').andCallThrough()
 
@@ -80,7 +81,7 @@ describe('KnitrBuilder', () => {
       runs(() => {
         expect(exitCode).toBe(-1)
         expect(latex.log.showMessage).toHaveBeenCalledWith({
-          type: 'Error',
+          type: 'error',
           text: 'The R package "knitr" could not be loaded.'
         })
       })

--- a/spec/builders/latexmk-spec.js
+++ b/spec/builders/latexmk-spec.js
@@ -174,20 +174,20 @@ describe('LatexmkBuilder', () => {
 
       runs(() => {
         const messages = [
-          { type: 'Error', text: 'There\'s no line here to end' },
-          { type: 'Error', text: 'Argument of \\@sect has an extra }' },
-          { type: 'Error', text: 'Paragraph ended before \\@sect was complete' },
-          { type: 'Error', text: 'Extra alignment tab has been changed to \\cr' },
-          { type: 'Warning', text: 'Reference `tab:snafu\' on page 1 undefined' },
-          { type: 'Error', text: 'Class foo: Significant class issue' },
-          { type: 'Warning', text: 'Class foo: Class issue' },
-          { type: 'Warning', text: 'Class foo: Nebulous class issue' },
-          { type: 'Info', text: 'Class foo: Insignificant class issue' },
-          { type: 'Error', text: 'Package bar: Significant package issue' },
-          { type: 'Warning', text: 'Package bar: Package issue' },
-          { type: 'Warning', text: 'Package bar: Nebulous package issue' },
-          { type: 'Info', text: 'Package bar: Insignificant package issue' },
-          { type: 'Warning', text: 'There were undefined references' }
+          { type: 'error', text: 'There\'s no line here to end' },
+          { type: 'error', text: 'Argument of \\@sect has an extra }' },
+          { type: 'error', text: 'Paragraph ended before \\@sect was complete' },
+          { type: 'error', text: 'Extra alignment tab has been changed to \\cr' },
+          { type: 'warning', text: 'Reference `tab:snafu\' on page 1 undefined' },
+          { type: 'error', text: 'Class foo: Significant class issue' },
+          { type: 'warning', text: 'Class foo: Class issue' },
+          { type: 'warning', text: 'Class foo: Nebulous class issue' },
+          { type: 'info', text: 'Class foo: Insignificant class issue' },
+          { type: 'error', text: 'Package bar: Significant package issue' },
+          { type: 'warning', text: 'Package bar: Package issue' },
+          { type: 'warning', text: 'Package bar: Nebulous package issue' },
+          { type: 'info', text: 'Package bar: Insignificant package issue' },
+          { type: 'warning', text: 'There were undefined references' }
         ]
 
         // Loop through the required messages and make sure that each one appears

--- a/spec/builders/texify-spec.js
+++ b/spec/builders/texify-spec.js
@@ -92,20 +92,20 @@ if (process.env.TEX_DIST === 'miktex') {
 
         runs(() => {
           const messages = [
-            { type: 'Error', text: 'There\'s no line here to end' },
-            { type: 'Error', text: 'Argument of \\@sect has an extra }' },
-            { type: 'Error', text: 'Paragraph ended before \\@sect was complete' },
-            { type: 'Error', text: 'Extra alignment tab has been changed to \\cr' },
-            { type: 'Warning', text: 'Reference `tab:snafu\' on page 1 undefined' },
-            { type: 'Error', text: 'Class foo: Significant class issue' },
-            { type: 'Warning', text: 'Class foo: Class issue' },
-            { type: 'Warning', text: 'Class foo: Nebulous class issue' },
-            { type: 'Info', text: 'Class foo: Insignificant class issue' },
-            { type: 'Error', text: 'Package bar: Significant package issue' },
-            { type: 'Warning', text: 'Package bar: Package issue' },
-            { type: 'Warning', text: 'Package bar: Nebulous package issue' },
-            { type: 'Info', text: 'Package bar: Insignificant package issue' },
-            { type: 'Warning', text: 'There were undefined references' }
+            { type: 'error', text: 'There\'s no line here to end' },
+            { type: 'error', text: 'Argument of \\@sect has an extra }' },
+            { type: 'error', text: 'Paragraph ended before \\@sect was complete' },
+            { type: 'error', text: 'Extra alignment tab has been changed to \\cr' },
+            { type: 'warning', text: 'Reference `tab:snafu\' on page 1 undefined' },
+            { type: 'error', text: 'Class foo: Significant class issue' },
+            { type: 'warning', text: 'Class foo: Class issue' },
+            { type: 'warning', text: 'Class foo: Nebulous class issue' },
+            { type: 'info', text: 'Class foo: Insignificant class issue' },
+            { type: 'error', text: 'Package bar: Significant package issue' },
+            { type: 'warning', text: 'Package bar: Package issue' },
+            { type: 'warning', text: 'Package bar: Nebulous package issue' },
+            { type: 'info', text: 'Package bar: Insignificant package issue' },
+            { type: 'warning', text: 'There were undefined references' }
           ]
 
           // Loop through the required messages and make sure that each one appears

--- a/spec/logger-spec.js
+++ b/spec/logger-spec.js
@@ -13,7 +13,7 @@ describe('Logger', () => {
   describe('showMessage', () => {
     it('verifies that calling directly without preceding call to group automatically calls groupEnd', () => {
       spyOn(logger, 'groupEnd').andReturn()
-      logger.showMessage({ type: 'Error' })
+      logger.showMessage({ type: 'error' })
 
       expect(logger.groupEnd).toHaveBeenCalled()
     })
@@ -32,33 +32,33 @@ describe('Logger', () => {
       atom.config.set('latex.loggingLevel', 'info')
       logger.groupEnd()
 
-      expect(logger.showMessages).toHaveBeenCalledWith('foo', [{ type: 'Error' }, { type: 'Info' }, { type: 'Warning' }])
+      expect(logger.showMessages).toHaveBeenCalledWith('foo', [{ type: 'error' }, { type: 'info' }, { type: 'warning' }])
     })
 
     it('verifies info messages filtered when logging level set to warning', () => {
       atom.config.set('latex.loggingLevel', 'warning')
       logger.groupEnd()
 
-      expect(logger.showMessages).toHaveBeenCalledWith('foo', [{ type: 'Error' }, { type: 'Warning' }])
+      expect(logger.showMessages).toHaveBeenCalledWith('foo', [{ type: 'error' }, { type: 'warning' }])
     })
 
     it('verifies warning and info messages filtered when logging level set to error', () => {
       atom.config.set('latex.loggingLevel', 'error')
       logger.groupEnd()
 
-      expect(logger.showMessages).toHaveBeenCalledWith('foo', [{ type: 'Error' }])
+      expect(logger.showMessages).toHaveBeenCalledWith('foo', [{ type: 'error' }])
     })
   })
 
   describe('getMostSevereType', () => {
     it('allows errors to override warnings and info messages', () => {
-      const mostSevereType = Logger.getMostSevereType([{ type: 'Info' }, { type: 'Warning' }, { type: 'Error' }])
-      expect(mostSevereType).toBe('Error')
+      const mostSevereType = Logger.getMostSevereType([{ type: 'info' }, { type: 'warning' }, { type: 'error' }])
+      expect(mostSevereType).toBe('error')
     })
 
     it('allows warnings to override info messages', () => {
-      const mostSevereType = Logger.getMostSevereType([{ type: 'Info' }, { type: 'Warning' }])
-      expect(mostSevereType).toBe('Warning')
+      const mostSevereType = Logger.getMostSevereType([{ type: 'info' }, { type: 'warning' }])
+      expect(mostSevereType).toBe('warning')
     })
   })
 })

--- a/spec/loggers/default-logger-spec.js
+++ b/spec/loggers/default-logger-spec.js
@@ -18,15 +18,15 @@ describe('DefaultLogger', () => {
     it('verifies that only messages that have a range and a matching file path are marked', () => {
       const editor = { getPath: () => 'foo.tex' }
       const messages = [{
-        type: 'Error',
+        type: 'error',
         range: [[0, 0], [0, 1]],
         filePath: 'foo.tex'
       }, {
-        type: 'Warning',
+        type: 'warning',
         range: [[0, 0], [0, 1]],
         filePath: 'bar.tex'
       }, {
-        type: 'Info',
+        type: 'info',
         filePath: 'foo.tex'
       }]
       spyOn(logger, 'addErrorMarker')

--- a/spec/parsers/log-parser-spec.js
+++ b/spec/parsers/log-parser-spec.js
@@ -48,7 +48,7 @@ describe('LogParser', () => {
       const texFile = path.join(fixturesPath, 'errors.tex')
       const parser = new LogParser(logFile, texFile)
       const result = parser.parse()
-      const error = _.find(result.messages, (message) => { return message.type === 'error' })
+      const error = result.messages.find(message => { return message.type === 'error' })
 
       expect(error).toEqual({
         type: 'error',

--- a/spec/parsers/log-parser-spec.js
+++ b/spec/parsers/log-parser-spec.js
@@ -40,7 +40,7 @@ describe('LogParser', () => {
       const parser = new LogParser(logFile, texFile)
       const result = parser.parse()
 
-      expect(_.countBy(result.messages, 'type').Error).toBe(3)
+      expect(_.countBy(result.messages, 'type').error).toBe(3)
     })
 
     it('associates an error with a file path, line number, and message', () => {
@@ -48,10 +48,10 @@ describe('LogParser', () => {
       const texFile = path.join(fixturesPath, 'errors.tex')
       const parser = new LogParser(logFile, texFile)
       const result = parser.parse()
-      const error = _.find(result.messages, (message) => { return message.type === 'Error' })
+      const error = _.find(result.messages, (message) => { return message.type === 'error' })
 
       expect(error).toEqual({
-        type: 'Error',
+        type: 'error',
         logRange: [[196, 0], [196, 84]],
         filePath: texFile,
         range: [[9, 0], [9, 65536]],


### PR DESCRIPTION
Expands the `checkEnvironment` function to do other checks besides deprecation notices and version migration. Since information checks are done also the messages are placed in the log versus using Atom notifications.

Current checks:
1. `latexmk` version check. Helps warn users about #243 situations. Also verifies that `latexmk` can be run outside of a build. [Error severity]
1. `Rscript` versions check. Mostly just to make sure `Rscript` can be run. [warning severity]
2. `knitr` and `patchSynctex` library check. [warning severity]
3. PDF capable viewer check. [error severity]
4. PS capable viewer check. [warning severity]
5. DVI capable viewer check. [warning severity]

Addresses some of #54 (does not automatically configure TeX path).

Resolves #62.