### PR TITLE
Add configuration check and migrator

### DIFF
--- a/lib/composer.js
+++ b/lib/composer.js
@@ -228,13 +228,6 @@ export default class Composer extends Disposable {
     return files
   }
 
-  async checkRuntime () {
-    latex.log.group('LaTeX Check')
-    await latex.builderRegistry.checkRuntimeDependencies()
-    latex.opener.checkRuntimeDependencies()
-    latex.log.groupEnd()
-  }
-
   moveResult (result, filePath) {
     const originalOutputFilePath = result.outputFilePath
     result.outputFilePath = this.alterParentPath(filePath, originalOutputFilePath)

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -228,6 +228,13 @@ export default class Composer extends Disposable {
     return files
   }
 
+  async checkRuntime () {
+    latex.log.group('LaTeX Check')
+    await latex.builderRegistry.checkRuntimeDependencies()
+    latex.opener.checkRuntimeDependencies()
+    latex.log.groupEnd()
+  }
+
   moveResult (result, filePath) {
     const originalOutputFilePath = result.outputFilePath
     result.outputFilePath = this.alterParentPath(filePath, originalOutputFilePath)

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -18,9 +18,6 @@ export default class Composer extends Disposable {
     this.disposables.add(atom.config.onDidChange('latex', () => {
       this.rebuildCompleted = new Set()
     }))
-    if (!atom.inSpecMode()) {
-      this.checkEnvironment()
-    }
   }
 
   initializeBuild (filePath) {
@@ -308,59 +305,4 @@ export default class Composer extends Disposable {
   }
 
   shouldOpenResult () { return atom.config.get('latex.openResultAfterBuild') }
-
-  async checkEnvironment () {
-    latex.log.group('LaTeX Check')
-    // TODO: remove after grace period
-    this.checkCleanExtensions()
-    this.checkOpenerSetting()
-    this.checkMasterFileSearchSetting()
-    await this.builderRegistry.checkRuntimeDependencies()
-    latex.opener.checkRuntimeDependencies()
-    latex.log.groupEnd()
-  }
-
-  checkMasterFileSearchSetting () {
-    if (!atom.config.get('latex.useMasterFileSearch')) return
-
-    const message = `LaTeX: The Master File Search setting has been deprecated`
-    const description = heredoc(`
-      Support for the Master File Search setting has been deprecated in favor of
-      \`%!TEX root\` magic comments, and will be removed soon.`)
-    atom.notifications.addInfo(message, { description })
-  }
-
-  checkCleanExtensions () {
-    const cleanExtensions = atom.config.get('latex.cleanExtensions')
-    if (!cleanExtensions) return
-
-    let cleanPatterns = atom.config.get('latex.cleanPatterns')
-    const defaultExtensions = [
-      '.aux', '.bbl', '.blg', '.fdb_latexmk', '.fls', '.lof', '.log',
-      '.lol', '.lot', '.nav', '.out', '.pdf', '.snm', '.synctex.gz', '.toc'
-    ]
-
-    atom.config.unset('latex.cleanExtensions')
-
-    const removedExtensions = _.difference(defaultExtensions, cleanExtensions)
-    cleanPatterns = _.difference(cleanPatterns, removedExtensions.map(extension => `**/*${extension}`))
-
-    const addedExtensions = _.difference(cleanExtensions, defaultExtensions)
-    cleanPatterns = _.union(cleanPatterns, addedExtensions.map(extension => `**/*${extension}`))
-
-    atom.config.set('latex.cleanPatterns', cleanPatterns)
-    const message = 'LaTeX: The "latex:clean" command has changed'
-    const description = heredoc(`
-      Your custom extensions in the \`Clean Extensions\` settings have
-      been migrated to the new setting \`Clean Patterns\`.`)
-    atom.notifications.addInfo(message, { description })
-  }
-
-  checkOpenerSetting () {
-    const alwaysOpenResultInAtom = atom.config.get('latex.alwaysOpenResultInAtom')
-    if (!alwaysOpenResultInAtom) return
-
-    atom.config.unset('latex.alwaysOpenResultInAtom')
-    atom.config.set('latex.opener', 'pdf-view')
-  }
 }

--- a/lib/config-migrator.js
+++ b/lib/config-migrator.js
@@ -3,59 +3,57 @@
 import _ from 'lodash'
 import { heredoc } from './werkzeug'
 
-export default class ConfigMigrator {
-  static async checkEnvironment () {
-    latex.log.group('LaTeX Check')
-    // TODO: remove after grace period
-    ConfigMigrator.checkCleanExtensions()
-    ConfigMigrator.checkOpenerSetting()
-    ConfigMigrator.checkMasterFileSearchSetting()
-    await latex.builderRegistry.checkRuntimeDependencies()
-    latex.opener.checkRuntimeDependencies()
-    latex.log.groupEnd()
-  }
+export default async function checkConfigAndMigrate () {
+  latex.log.group('LaTeX Check')
+  // TODO: remove after grace period
+  checkCleanExtensions()
+  checkOpenerSetting()
+  checkMasterFileSearchSetting()
+  await latex.builderRegistry.checkRuntimeDependencies()
+  latex.opener.checkRuntimeDependencies()
+  latex.log.groupEnd()
+}
 
-  static checkMasterFileSearchSetting () {
-    if (!atom.config.get('latex.useMasterFileSearch')) return
+function checkMasterFileSearchSetting () {
+  if (!atom.config.get('latex.useMasterFileSearch')) return
 
-    const message = `LaTeX: The Master File Search setting has been deprecated`
-    const description = heredoc(`
-      Support for the Master File Search setting has been deprecated in favor of
-      \`%!TEX root\` magic comments, and will be removed soon.`)
-    atom.notifications.addInfo(message, { description })
-  }
+  const message = `LaTeX: The Master File Search setting has been deprecated`
+  const description = heredoc(`
+    Support for the Master File Search setting has been deprecated in favor of
+    \`%!TEX root\` magic comments, and will be removed soon.`)
+  atom.notifications.addInfo(message, { description })
+}
 
-  static checkCleanExtensions () {
-    const cleanExtensions = atom.config.get('latex.cleanExtensions')
-    if (!cleanExtensions) return
+function checkCleanExtensions () {
+  const cleanExtensions = atom.config.get('latex.cleanExtensions')
+  if (!cleanExtensions) return
 
-    let cleanPatterns = atom.config.get('latex.cleanPatterns')
-    const defaultExtensions = [
-      '.aux', '.bbl', '.blg', '.fdb_latexmk', '.fls', '.lof', '.log',
-      '.lol', '.lot', '.nav', '.out', '.pdf', '.snm', '.synctex.gz', '.toc'
-    ]
+  let cleanPatterns = atom.config.get('latex.cleanPatterns')
+  const defaultExtensions = [
+    '.aux', '.bbl', '.blg', '.fdb_latexmk', '.fls', '.lof', '.log',
+    '.lol', '.lot', '.nav', '.out', '.pdf', '.snm', '.synctex.gz', '.toc'
+  ]
 
-    atom.config.unset('latex.cleanExtensions')
+  atom.config.unset('latex.cleanExtensions')
 
-    const removedExtensions = _.difference(defaultExtensions, cleanExtensions)
-    cleanPatterns = _.difference(cleanPatterns, removedExtensions.map(extension => `**/*${extension}`))
+  const removedExtensions = _.difference(defaultExtensions, cleanExtensions)
+  cleanPatterns = _.difference(cleanPatterns, removedExtensions.map(extension => `**/*${extension}`))
 
-    const addedExtensions = _.difference(cleanExtensions, defaultExtensions)
-    cleanPatterns = _.union(cleanPatterns, addedExtensions.map(extension => `**/*${extension}`))
+  const addedExtensions = _.difference(cleanExtensions, defaultExtensions)
+  cleanPatterns = _.union(cleanPatterns, addedExtensions.map(extension => `**/*${extension}`))
 
-    atom.config.set('latex.cleanPatterns', cleanPatterns)
-    const message = 'LaTeX: The "latex:clean" command has changed'
-    const description = heredoc(`
-      Your custom extensions in the \`Clean Extensions\` settings have
-      been migrated to the new setting \`Clean Patterns\`.`)
-    atom.notifications.addInfo(message, { description })
-  }
+  atom.config.set('latex.cleanPatterns', cleanPatterns)
+  const message = 'LaTeX: The "latex:clean" command has changed'
+  const description = heredoc(`
+    Your custom extensions in the \`Clean Extensions\` settings have
+    been migrated to the new setting \`Clean Patterns\`.`)
+  atom.notifications.addInfo(message, { description })
+}
 
-  static checkOpenerSetting () {
-    const alwaysOpenResultInAtom = atom.config.get('latex.alwaysOpenResultInAtom')
-    if (!alwaysOpenResultInAtom) return
+function checkOpenerSetting () {
+  const alwaysOpenResultInAtom = atom.config.get('latex.alwaysOpenResultInAtom')
+  if (!alwaysOpenResultInAtom) return
 
-    atom.config.unset('latex.alwaysOpenResultInAtom')
-    atom.config.set('latex.opener', 'pdf-view')
-  }
+  atom.config.unset('latex.alwaysOpenResultInAtom')
+  atom.config.set('latex.opener', 'pdf-view')
 }

--- a/lib/config-migrator.js
+++ b/lib/config-migrator.js
@@ -1,0 +1,61 @@
+/** @babel */
+
+import _ from 'lodash'
+import { heredoc } from './werkzeug'
+
+export default class ConfigMigrator {
+  static async checkEnvironment () {
+    latex.log.group('LaTeX Check')
+    // TODO: remove after grace period
+    ConfigMigrator.checkCleanExtensions()
+    ConfigMigrator.checkOpenerSetting()
+    ConfigMigrator.checkMasterFileSearchSetting()
+    await latex.builderRegistry.checkRuntimeDependencies()
+    latex.opener.checkRuntimeDependencies()
+    latex.log.groupEnd()
+  }
+
+  static checkMasterFileSearchSetting () {
+    if (!atom.config.get('latex.useMasterFileSearch')) return
+
+    const message = `LaTeX: The Master File Search setting has been deprecated`
+    const description = heredoc(`
+      Support for the Master File Search setting has been deprecated in favor of
+      \`%!TEX root\` magic comments, and will be removed soon.`)
+    atom.notifications.addInfo(message, { description })
+  }
+
+  static checkCleanExtensions () {
+    const cleanExtensions = atom.config.get('latex.cleanExtensions')
+    if (!cleanExtensions) return
+
+    let cleanPatterns = atom.config.get('latex.cleanPatterns')
+    const defaultExtensions = [
+      '.aux', '.bbl', '.blg', '.fdb_latexmk', '.fls', '.lof', '.log',
+      '.lol', '.lot', '.nav', '.out', '.pdf', '.snm', '.synctex.gz', '.toc'
+    ]
+
+    atom.config.unset('latex.cleanExtensions')
+
+    const removedExtensions = _.difference(defaultExtensions, cleanExtensions)
+    cleanPatterns = _.difference(cleanPatterns, removedExtensions.map(extension => `**/*${extension}`))
+
+    const addedExtensions = _.difference(cleanExtensions, defaultExtensions)
+    cleanPatterns = _.union(cleanPatterns, addedExtensions.map(extension => `**/*${extension}`))
+
+    atom.config.set('latex.cleanPatterns', cleanPatterns)
+    const message = 'LaTeX: The "latex:clean" command has changed'
+    const description = heredoc(`
+      Your custom extensions in the \`Clean Extensions\` settings have
+      been migrated to the new setting \`Clean Patterns\`.`)
+    atom.notifications.addInfo(message, { description })
+  }
+
+  static checkOpenerSetting () {
+    const alwaysOpenResultInAtom = atom.config.get('latex.alwaysOpenResultInAtom')
+    if (!alwaysOpenResultInAtom) return
+
+    atom.config.unset('latex.alwaysOpenResultInAtom')
+    atom.config.set('latex.opener', 'pdf-view')
+  }
+}

--- a/lib/config-migrator.js
+++ b/lib/config-migrator.js
@@ -3,15 +3,11 @@
 import _ from 'lodash'
 import { heredoc } from './werkzeug'
 
-export default async function checkConfigAndMigrate () {
-  latex.log.group('LaTeX Check')
+export default function checkConfigAndMigrate () {
   // TODO: remove after grace period
   checkCleanExtensions()
   checkOpenerSetting()
   checkMasterFileSearchSetting()
-  await latex.builderRegistry.checkRuntimeDependencies()
-  latex.opener.checkRuntimeDependencies()
-  latex.log.groupEnd()
 }
 
 function checkMasterFileSearchSetting () {

--- a/lib/main.js
+++ b/lib/main.js
@@ -3,9 +3,9 @@
 import { CompositeDisposable, Disposable } from 'atom'
 
 export default {
-  activate () {
+  async activate () {
     this.disposables = new CompositeDisposable()
-    this.bootstrap()
+    await this.bootstrap()
 
     this.disposables.add(atom.commands.add('atom-workspace', {
       'latex:build': () => latex.composer.build(false),
@@ -52,7 +52,7 @@ export default {
     })
   },
 
-  bootstrap () {
+  async bootstrap () {
     if (global.latex) { return }
 
     const Latex = require('./latex')
@@ -61,7 +61,7 @@ export default {
 
     if (!atom.inSpecMode()) {
       const checkConfigAndMigrate = require('./config-migrator')
-      checkConfigAndMigrate()
+      await checkConfigAndMigrate()
     }
   }
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -3,13 +3,14 @@
 import { CompositeDisposable, Disposable } from 'atom'
 
 export default {
-  async activate () {
+  activate () {
     this.disposables = new CompositeDisposable()
-    await this.bootstrap()
+    this.bootstrap()
 
     this.disposables.add(atom.commands.add('atom-workspace', {
       'latex:build': () => latex.composer.build(false),
       'latex:rebuild': () => latex.composer.build(true),
+      'latex:check-runtime': () => latex.composer.checkRuntime(),
       'latex:clean': () => latex.composer.clean(),
       'latex:sync': () => latex.composer.sync(),
       'latex:kill': () => latex.process.killChildProcesses(),
@@ -27,6 +28,11 @@ export default {
         }
       }))
     }))
+
+    if (!atom.inSpecMode()) {
+      const checkConfigAndMigrate = require('./config-migrator')
+      checkConfigAndMigrate()
+    }
   },
 
   deactivate () {
@@ -52,16 +58,11 @@ export default {
     })
   },
 
-  async bootstrap () {
+  bootstrap () {
     if (global.latex) { return }
 
     const Latex = require('./latex')
     global.latex = new Latex()
     this.disposables.add(global.latex)
-
-    if (!atom.inSpecMode()) {
-      const checkConfigAndMigrate = require('./config-migrator')
-      await checkConfigAndMigrate()
-    }
   }
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -10,7 +10,7 @@ export default {
     this.disposables.add(atom.commands.add('atom-workspace', {
       'latex:build': () => latex.composer.build(false),
       'latex:rebuild': () => latex.composer.build(true),
-      'latex:check-runtime': () => latex.composer.checkRuntime(),
+      'latex:check-runtime': () => this.checkRuntime(),
       'latex:clean': () => latex.composer.clean(),
       'latex:sync': () => latex.composer.sync(),
       'latex:kill': () => latex.process.killChildProcesses(),
@@ -64,5 +64,12 @@ export default {
     const Latex = require('./latex')
     global.latex = new Latex()
     this.disposables.add(global.latex)
+  },
+
+  async checkRuntime () {
+    latex.log.group('LaTeX Check')
+    await latex.builderRegistry.checkRuntimeDependencies()
+    latex.opener.checkRuntimeDependencies()
+    latex.log.groupEnd()
   }
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -58,5 +58,10 @@ export default {
     const Latex = require('./latex')
     global.latex = new Latex()
     this.disposables.add(global.latex)
+
+    if (!atom.inSpecMode()) {
+      const ConfigMigrator = require('./config-migrator')
+      ConfigMigrator.checkEnvironment()
+    }
   }
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -60,8 +60,8 @@ export default {
     this.disposables.add(global.latex)
 
     if (!atom.inSpecMode()) {
-      const ConfigMigrator = require('./config-migrator')
-      ConfigMigrator.checkEnvironment()
+      const checkConfigAndMigrate = require('./config-migrator')
+      checkConfigAndMigrate()
     }
   }
 }

--- a/menus/latex.json
+++ b/menus/latex.json
@@ -9,7 +9,8 @@
             { "label": "Build",   "command": "latex:build" },
             { "label": "Rebuild", "command": "latex:rebuild" },
             { "label": "Clean",   "command": "latex:clean" },
-            { "label": "Kill",   "command": "latex:kill" }
+            { "label": "Kill Build",   "command": "latex:kill" },
+            { "label": "Check Runtime",   "command": "latex:check-runtime" }
           ]
         }
       ]

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   "activationCommands": {
     "atom-workspace": [
       "latex:build",
+      "latex:check-runtime",
       "latex:clean",
       "latex:rebuild",
       "latex:sync",


### PR DESCRIPTION
Move checks that were happening in `Composer` into `ConfigMigrator` to avoid race condition in the creation of `latex`.