### PR TITLE
Use more ES6/7 features

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -48,7 +48,6 @@ export default class Builder {
 
   constructChildProcessOptions (directoryPath, defaultEnv) {
     const env = Object.assign(defaultEnv || {}, process.env)
-    console.log(env)
     const childPath = this.constructPath()
     if (childPath) {
       env[this.envPathKey] = childPath

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -1,6 +1,5 @@
 /** @babel */
 
-import _ from 'lodash'
 import fs from 'fs-plus'
 import path from 'path'
 import LogParser from './parsers/log-parser'
@@ -48,7 +47,8 @@ export default class Builder {
   }
 
   constructChildProcessOptions (directoryPath, defaultEnv) {
-    const env = _.assign(defaultEnv || {}, process.env)
+    const env = Object.assign(defaultEnv || {}, process.env)
+    console.log(env)
     const childPath = this.constructPath()
     if (childPath) {
       env[this.envPathKey] = childPath

--- a/lib/error-marker.js
+++ b/lib/error-marker.js
@@ -12,7 +12,7 @@ export default class ErrorMarker {
   }
 
   mark () {
-    this.markers = _.groupBy(this.messages, 'range').map(messages => {
+    this.markers = _.map(_.groupBy(this.messages, 'range'), messages => {
       const type = Logger.getMostSevereType(messages)
       const marker = this.editor.markBufferRange(messages[0].range, {invalidate: 'touch'})
       this.editor.decorateMarker(marker, {type: 'line-number', class: `latex-${type}`})

--- a/lib/error-marker.js
+++ b/lib/error-marker.js
@@ -12,7 +12,7 @@ export default class ErrorMarker {
   }
 
   mark () {
-    this.markers = _.map(_.groupBy(this.messages, 'range'), messages => {
+    this.markers = _.groupBy(this.messages, 'range').map(messages => {
       const type = Logger.getMostSevereType(messages)
       const marker = this.editor.markBufferRange(messages[0].range, {invalidate: 'touch'})
       this.editor.decorateMarker(marker, {type: 'line-number', class: `latex-${type}`})

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -21,7 +21,7 @@ export default class Logger {
   }
 
   showMessage (message) {
-    message = _.assign({ timestamp: Date.now() }, _.pickBy(message))
+    message = Object.assign({ timestamp: Date.now() }, _.pickBy(message))
     if (this._group) {
       this._group.push(message)
     } else {

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -46,7 +46,7 @@ export default class Logger {
     const loggingLevel = atom.config.get('latex.loggingLevel')
     const showBuildWarning = loggingLevel !== 'error'
     const showBuildInfo = loggingLevel === 'info'
-    const filteredMessages = _.filter(this.messages, (message) => {
+    const filteredMessages = this.messages.filter(message => {
       return message.type === 'error' || (showBuildWarning && message.type === 'warning') || (showBuildInfo && message.type === 'info')
     })
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -53,7 +53,7 @@ export default class Logger {
   }
 
   static getMostSevereType (messages) {
-    return _.reduce(messages, (type, message) => {
+    return messages.reduce((type, message) => {
       if (type === 'error' || message.type === 'error') return 'error'
       if (type === 'warning' || message.type === 'warning') return 'warning'
       return 'info'

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -46,9 +46,8 @@ export default class Logger {
     const loggingLevel = atom.config.get('latex.loggingLevel')
     const showBuildWarning = loggingLevel !== 'error'
     const showBuildInfo = loggingLevel === 'info'
-    const filteredMessages = this.messages.filter(message => {
-      return message.type === 'error' || (showBuildWarning && message.type === 'warning') || (showBuildInfo && message.type === 'info')
-    })
+    const filteredMessages = this.messages.filter(message =>
+      message.type === 'error' || (showBuildWarning && message.type === 'warning') || (showBuildInfo && message.type === 'info'))
 
     this.showMessages(this._label, filteredMessages.map(message => _.omit(message, 'timestamp')))
   }

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -49,7 +49,7 @@ export default class Logger {
     const filteredMessages = this.messages.filter(message =>
       message.type === 'error' || (showBuildWarning && message.type === 'warning') || (showBuildInfo && message.type === 'info'))
 
-    this.showMessages(this._label, filteredMessages.map(message => _.omit(message, 'timestamp')))
+    this.showMessages(this._label, filteredMessages)
   }
 
   static getMostSevereType (messages) {

--- a/lib/loggers/default-logger.js
+++ b/lib/loggers/default-logger.js
@@ -52,9 +52,9 @@ export default class DefaultLogger extends Logger {
   showErrorMarkersInEditor (editor, messages) {
     const filePath = editor.getPath()
     if (filePath) {
-      const m = messages.filter(message =>
+      const marker = messages.filter(message =>
         message.filePath && message.range && filePath.includes(message.filePath))
-      if (m.length) this.addErrorMarker(editor, m)
+      if (marker.length) this.addErrorMarker(editor, marker)
     }
   }
 

--- a/lib/loggers/default-logger.js
+++ b/lib/loggers/default-logger.js
@@ -52,9 +52,8 @@ export default class DefaultLogger extends Logger {
   showErrorMarkersInEditor (editor, messages) {
     const filePath = editor.getPath()
     if (filePath) {
-      const m = messages.filter(message => {
-        return message.filePath && message.range && filePath.includes(message.filePath)
-      })
+      const m = messages.filter(message =>
+        message.filePath && message.range && filePath.includes(message.filePath))
       if (m.length) this.addErrorMarker(editor, m)
     }
   }

--- a/lib/loggers/default-logger.js
+++ b/lib/loggers/default-logger.js
@@ -1,6 +1,5 @@
 /** @babel */
 
-import _ from 'lodash'
 import Logger from '../logger'
 import LogPanel from '../views/log-panel'
 import ErrorMarker from '../error-marker'
@@ -53,7 +52,7 @@ export default class DefaultLogger extends Logger {
   showErrorMarkersInEditor (editor, messages) {
     const filePath = editor.getPath()
     if (filePath) {
-      const m = _.filter(messages, message => {
+      const m = messages.filter(message => {
         return message.filePath && message.range && filePath.includes(message.filePath)
       })
       if (m.length) this.addErrorMarker(editor, m)

--- a/lib/parsers/log-parser.js
+++ b/lib/parsers/log-parser.js
@@ -1,6 +1,5 @@
 /** @babel */
 
-import _ from 'lodash'
 import Parser from '../parser.js'
 import path from 'path'
 
@@ -51,7 +50,7 @@ export default class LogParser extends Parser {
     }
 
     const lines = this.getLines()
-    _.forEach(lines, (line, index) => {
+    lines.forEach((line, index) => {
       // Simplest Thing That Works™ and KISS®
       const logRange = [[index, 0], [index, line.length]]
       let match = line.match(OUTPUT_PATTERN)

--- a/lib/process-manager.js
+++ b/lib/process-manager.js
@@ -2,7 +2,6 @@
 
 import childProcess from 'child_process'
 import kill from 'tree-kill'
-import _ from 'lodash'
 import { Disposable } from 'atom'
 
 export default class ProcessManager extends Disposable {
@@ -13,13 +12,12 @@ export default class ProcessManager extends Disposable {
   }
 
   executeChildProcess (command, options = {}) {
-    const { allowKill, showError } = options
-    options = _.omit(options, 'allowKill', 'showError')
-    return new Promise((resolve) => {
+    const { allowKill, showError, ...execOptions } = options
+    return new Promise(resolve => {
       // Windows does not like \$ appearing in command lines so only escape
       // if we need to.
       if (process.platform !== 'win32') command = command.replace('$', '\\$')
-      const { pid } = childProcess.exec(command, options, (error, stdout, stderr) => {
+      const { pid } = childProcess.exec(command, execOptions, (error, stdout, stderr) => {
         if (allowKill) {
           this.processes.delete(pid)
         }

--- a/spec/builders/knitr-spec.js
+++ b/spec/builders/knitr-spec.js
@@ -1,7 +1,6 @@
 /** @babel */
 
 import helpers from '../spec-helpers'
-import _ from 'lodash'
 import fs from 'fs-plus'
 import path from 'path'
 import KnitrBuilder from '../../lib/builders/knitr'
@@ -70,7 +69,8 @@ describe('KnitrBuilder', () => {
     it('detects missing knitr library and logs an error', () => {
       const directoryPath = path.dirname(filePath)
       const env = { 'R_LIBS_USER': '/dev/null', 'R_LIBS_SITE': '/dev/null' }
-      const options = _.merge(builder.constructChildProcessOptions(directoryPath), { env })
+      const options = builder.constructChildProcessOptions(directoryPath)
+      Object.assign(options.env, env)
       spyOn(builder, 'constructChildProcessOptions').andReturn(options)
       spyOn(latex.log, 'showMessage').andCallThrough()
 

--- a/spec/builders/knitr-spec.js
+++ b/spec/builders/knitr-spec.js
@@ -70,7 +70,7 @@ describe('KnitrBuilder', () => {
       const directoryPath = path.dirname(filePath)
       const env = { 'R_LIBS_USER': '/dev/null', 'R_LIBS_SITE': '/dev/null' }
       const options = builder.constructChildProcessOptions(directoryPath)
-      Object.assign(options.env, env)
+      options.env = Object.assign(env, options.env)
       spyOn(builder, 'constructChildProcessOptions').andReturn(options)
       spyOn(latex.log, 'showMessage').andCallThrough()
 

--- a/spec/builders/knitr-spec.js
+++ b/spec/builders/knitr-spec.js
@@ -70,7 +70,7 @@ describe('KnitrBuilder', () => {
       const directoryPath = path.dirname(filePath)
       const env = { 'R_LIBS_USER': '/dev/null', 'R_LIBS_SITE': '/dev/null' }
       const options = builder.constructChildProcessOptions(directoryPath)
-      options.env = Object.assign(env, options.env)
+      Object.assign(options.env, env)
       spyOn(builder, 'constructChildProcessOptions').andReturn(options)
       spyOn(latex.log, 'showMessage').andCallThrough()
 

--- a/spec/builders/latexmk-spec.js
+++ b/spec/builders/latexmk-spec.js
@@ -196,7 +196,7 @@ describe('LatexmkBuilder', () => {
         // which TeX distribution is being used or which fonts are currently
         // installed.
         for (const message of messages) {
-          expect(_.some(parsedLog.messages,
+          expect(parsedLog.messages.some(
             logMessage => message.type === logMessage.type && message.text === logMessage.text)).toBe(true, `Message = ${message.text}`)
         }
 

--- a/spec/builders/latexmk-spec.js
+++ b/spec/builders/latexmk-spec.js
@@ -3,7 +3,6 @@
 import helpers from '../spec-helpers'
 import path from 'path'
 import LatexmkBuilder from '../../lib/builders/latexmk'
-import _ from 'lodash'
 import fs from 'fs-plus'
 
 describe('LatexmkBuilder', () => {
@@ -200,7 +199,7 @@ describe('LatexmkBuilder', () => {
             logMessage => message.type === logMessage.type && message.text === logMessage.text)).toBe(true, `Message = ${message.text}`)
         }
 
-        expect(_.every(parsedLog.messages,
+        expect(parsedLog.messages.every(
           logMessage => !logMessage.filePath || logMessage.filePath === filePath || logMessage.filePath === subFilePath))
           .toBe(true, 'Incorrect file path resolution in log.')
 

--- a/spec/builders/texify-spec.js
+++ b/spec/builders/texify-spec.js
@@ -3,7 +3,6 @@
 import helpers from '../spec-helpers'
 import path from 'path'
 import TexifyBuilder from '../../lib/builders/texify'
-import _ from 'lodash'
 
 // This should probably try to detect texify
 if (process.env.TEX_DIST === 'miktex') {

--- a/spec/builders/texify-spec.js
+++ b/spec/builders/texify-spec.js
@@ -114,7 +114,7 @@ if (process.env.TEX_DIST === 'miktex') {
           // which TeX distribution is being used or which fonts are currently
           // installed.
           for (const message of messages) {
-            expect(_.some(parsedLog.messages,
+            expect(parsedLog.messages.some(
               logMessage => message.type === logMessage.type && message.text === logMessage.text)).toBe(true, `Message = ${message.text}`)
           }
 

--- a/spec/logger-spec.js
+++ b/spec/logger-spec.js
@@ -1,10 +1,11 @@
 /** @babel */
 
+import _ from 'lodash'
 import './spec-helpers'
 import Logger from '../lib/logger'
 
 describe('Logger', () => {
-  let logger
+  let logger, counts
 
   beforeEach(() => {
     logger = new Logger()
@@ -21,7 +22,9 @@ describe('Logger', () => {
 
   describe('showFilteredMessages', () => {
     beforeEach(() => {
-      spyOn(logger, 'showMessages').andReturn()
+      spyOn(logger, 'showMessages').andCallFake((label, messages) => {
+        counts = _.countBy(messages, 'type')
+      })
       logger.group('foo')
       logger.info()
       logger.warning()
@@ -32,21 +35,27 @@ describe('Logger', () => {
       atom.config.set('latex.loggingLevel', 'info')
       logger.groupEnd()
 
-      expect(logger.showMessages).toHaveBeenCalledWith('foo', [{ type: 'error' }, { type: 'info' }, { type: 'warning' }])
+      expect(counts.error).toBeDefined()
+      expect(counts.warning).toBeDefined()
+      expect(counts.info).toBe(1)
     })
 
     it('verifies info messages filtered when logging level set to warning', () => {
       atom.config.set('latex.loggingLevel', 'warning')
       logger.groupEnd()
 
-      expect(logger.showMessages).toHaveBeenCalledWith('foo', [{ type: 'error' }, { type: 'warning' }])
+      expect(counts.error).toBeDefined()
+      expect(counts.warning).toBeDefined()
+      expect(counts.info).toBeUndefined()
     })
 
     it('verifies warning and info messages filtered when logging level set to error', () => {
       atom.config.set('latex.loggingLevel', 'error')
       logger.groupEnd()
 
-      expect(logger.showMessages).toHaveBeenCalledWith('foo', [{ type: 'error' }])
+      expect(counts.error).toBeDefined()
+      expect(counts.warning).toBeUndefined()
+      expect(counts.info).toBeUndefined()
     })
   })
 


### PR DESCRIPTION
Decrease dependence on lodash by using more ES6/7 features

- [x] `Array.filter`
- [x] `Array.find`
- [x] `Array.forEach`
- [x] `Array.includes`
- [x] `Array.map`
- [x] `Array.reduce`
- [x] `Array.some`
- [x] `Object.assign`
- [x] More use of object destructuring including rest