### PR TITLE
Add qpdfview, Zathura and Windows shell open

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -69,7 +69,7 @@ export default {
   async checkRuntime () {
     latex.log.group('LaTeX Check')
     await latex.builderRegistry.checkRuntimeDependencies()
-    latex.opener.checkRuntimeDependencies()
+    await latex.opener.checkRuntimeDependencies()
     latex.log.groupEnd()
   }
 }

--- a/lib/opener-registry.js
+++ b/lib/opener-registry.js
@@ -28,24 +28,24 @@ export default class OpenerRegistry extends Disposable {
     }
   }
 
-  checkRuntimeDependencies () {
-    const pdfOpeners = Array.from(this.getCandidateOpeners('foo.pdf').keys())
-    if (pdfOpeners.length) {
-      latex.log.info(`The following PDF capable openers were found: ${pdfOpeners.join(', ')}.`)
+  async checkRuntimeDependencies () {
+    const pdfOpeners = await this.getCandidateOpeners('foo.pdf')
+    if (pdfOpeners.size) {
+      latex.log.info(`The following PDF capable openers were found: ${Array.from(pdfOpeners.keys()).join(', ')}.`)
     } else {
       latex.log.error('No PDF capable openers were found.')
     }
 
-    const psOpeners = Array.from(this.getCandidateOpeners('foo.ps').keys())
-    if (psOpeners.length) {
-      latex.log.info(`The following PS capable openers were found: ${psOpeners.join(', ')}.`)
+    const psOpeners = await this.getCandidateOpeners('foo.ps')
+    if (psOpeners.size) {
+      latex.log.info(`The following PS capable openers were found: ${Array.from(psOpeners.keys()).join(', ')}.`)
     } else {
       latex.log.warning('No PS capable openers were found.')
     }
 
-    const dviOpeners = Array.from(this.getCandidateOpeners('foo.dvi').keys())
-    if (dviOpeners.length) {
-      latex.log.info(`The following DVI capable openers were found: ${dviOpeners.join(', ')}.`)
+    const dviOpeners = await this.getCandidateOpeners('foo.dvi')
+    if (dviOpeners.size) {
+      latex.log.info(`The following DVI capable openers were found: ${Array.from(dviOpeners.keys()).join(', ')}.`)
     } else {
       latex.log.warning('No DVI capable openers were found.')
     }
@@ -55,8 +55,8 @@ export default class OpenerRegistry extends Disposable {
     const name = atom.config.get('latex.opener')
     let opener = this.openers.get(name)
 
-    if (!opener || !opener.canOpen(filePath)) {
-      opener = this.findOpener(filePath)
+    if (!opener || !await opener.canOpen(filePath)) {
+      opener = await this.findOpener(filePath)
     }
 
     if (opener) {
@@ -66,22 +66,22 @@ export default class OpenerRegistry extends Disposable {
     }
   }
 
-  getCandidateOpeners (filePath) {
+  async getCandidateOpeners (filePath) {
     const candidates = new Map()
     for (const [name, opener] of this.openers.entries()) {
-      if (opener.canOpen(filePath)) candidates.set(name, opener)
+      if (await opener.canOpen(filePath)) candidates.set(name, opener)
     }
     return candidates
   }
 
-  findOpener (filePath) {
+  async findOpener (filePath) {
     const openResultInBackground = atom.config.get('latex.openResultInBackground')
     const enableSynctex = atom.config.get('latex.enableSynctex')
-    const candidates = Array.from(this.getCandidateOpeners(filePath).values())
+    const candidates = await this.getCandidateOpeners(filePath)
 
-    if (!candidates.length) return
+    if (!candidates.size) return
 
-    const rankedCandidates = _.orderBy(candidates,
+    const rankedCandidates = _.orderBy(Array.from(candidates.values()),
       [opener => opener.hasSynctex(), opener => opener.canOpenInBackground()],
       ['desc', 'desc'])
 

--- a/lib/openers/custom-opener.js
+++ b/lib/openers/custom-opener.js
@@ -12,7 +12,7 @@ export default class CustomOpener extends Opener {
     await latex.process.executeChildProcess(command, { showError: true })
   }
 
-  canOpen (filePath) {
+  async canOpen (filePath) {
     return isPdfFile(filePath) && fs.existsSync(atom.config.get('latex.viewerPath'))
   }
 }

--- a/lib/openers/evince-opener.js
+++ b/lib/openers/evince-opener.js
@@ -99,7 +99,7 @@ export default class EvinceOpener extends Opener {
     }
   }
 
-  canOpen (filePath) {
+  async canOpen (filePath) {
     return !!this.daemon
   }
 

--- a/lib/openers/okular-opener.js
+++ b/lib/openers/okular-opener.js
@@ -17,7 +17,7 @@ export default class OkularOpener extends Opener {
     await latex.process.executeChildProcess(command, { showError: true })
   }
 
-  canOpen (filePath) {
+  async canOpen (filePath) {
     return process.platform === 'linux' && fs.existsSync(atom.config.get('latex.okularPath'))
   }
 

--- a/lib/openers/pdf-view-opener.js
+++ b/lib/openers/pdf-view-opener.js
@@ -25,7 +25,7 @@ export default class PdfViewOpener extends Opener {
     return true
   }
 
-  canOpen (filePath) {
+  async canOpen (filePath) {
     return isPdfFile(filePath) && atom.packages.isPackageActive('pdf-view')
   }
 }

--- a/lib/openers/preview-opener.js
+++ b/lib/openers/preview-opener.js
@@ -13,7 +13,7 @@ export default class PreviewOpener extends Opener {
     await latex.process.executeChildProcess(command, { showError: true })
   }
 
-  canOpen (filePath) {
+  async canOpen (filePath) {
     return process.platform === 'darwin' && (isPdfFile(filePath) || isPsFile(filePath))
   }
 

--- a/lib/openers/qpdfview-opener.js
+++ b/lib/openers/qpdfview-opener.js
@@ -18,13 +18,7 @@ export default class QPdfViewOpener extends Opener {
   }
 
   async open (filePath, texPath, lineNumber) {
-    const args = [
-      '--unique',
-      `"${filePath}#src:${texPath}:${lineNumber}:0"`
-    ]
-
-    const command = `${this.executable} ${args.join(' ')}`
-
+    const command = `${this.executable} --unique "${filePath}#src:${texPath}:${lineNumber}:0"`
     await latex.process.executeChildProcess(command, { showError: true })
   }
 

--- a/lib/openers/qpdfview-opener.js
+++ b/lib/openers/qpdfview-opener.js
@@ -1,6 +1,5 @@
 /** @babel */
 
-import _ from 'lodash'
 import Opener from '../opener'
 import { isPdfFile, isPsFile } from '../werkzeug'
 
@@ -23,7 +22,7 @@ export default class QPdfViewOpener extends Opener {
   }
 
   async canOpen (filePath) {
-    if (_.isUndefined(this.exists)) {
+    if (this.exists === undefined) {
       await this.initialize()
     }
     return this.exists && (isPdfFile(filePath) || isPsFile(filePath))

--- a/lib/openers/qpdfview-opener.js
+++ b/lib/openers/qpdfview-opener.js
@@ -1,0 +1,41 @@
+/** @babel */
+
+import _ from 'lodash'
+import Opener from '../opener'
+import { isPdfFile, isPsFile } from '../werkzeug'
+
+export default class QPdfViewOpener extends Opener {
+  executable = 'qpdfview'
+
+  async initialize () {
+    this.exists = false
+    try {
+      if (process.platform === 'linux') {
+        const { statusCode } = await latex.process.executeChildProcess(`${this.executable} --help`)
+        this.exists = statusCode === 0
+      }
+    } catch (e) {}
+  }
+
+  async open (filePath, texPath, lineNumber) {
+    const args = [
+      '--unique',
+      `"${filePath}#src:${texPath}:${lineNumber}:0"`
+    ]
+
+    const command = `${this.executable} ${args.join(' ')}`
+
+    await latex.process.executeChildProcess(command, { showError: true })
+  }
+
+  async canOpen (filePath) {
+    if (_.isUndefined(this.exists)) {
+      await this.initialize()
+    }
+    return this.exists && (isPdfFile(filePath) || isPsFile(filePath))
+  }
+
+  hasSynctex () {
+    return true
+  }
+}

--- a/lib/openers/shell-open-opener.js
+++ b/lib/openers/shell-open-opener.js
@@ -1,0 +1,16 @@
+/** @babel */
+
+import Opener from '../opener'
+
+export default class ShellOpenOpener extends Opener {
+  // shell open does not support texPath and lineNumber.
+  async open (filePath, texPath, lineNumber) {
+    const command = `"${filePath}"`
+
+    await latex.process.executeChildProcess(command, { showError: true })
+  }
+
+  async canOpen (filePath) {
+    return process.platform === 'win32'
+  }
+}

--- a/lib/openers/skim-opener.js
+++ b/lib/openers/skim-opener.js
@@ -30,7 +30,7 @@ export default class SkimOpener extends Opener {
     await latex.process.executeChildProcess(command, { showError: true })
   }
 
-  canOpen (filePath) {
+  async canOpen (filePath) {
     return process.platform === 'darwin' && fs.existsSync(atom.config.get('latex.skimPath'))
   }
 

--- a/lib/openers/sumatra-opener.js
+++ b/lib/openers/sumatra-opener.js
@@ -22,7 +22,7 @@ export default class SumatraOpener extends Opener {
     await latex.process.executeChildProcess(command)
   }
 
-  canOpen (filePath) {
+  async canOpen (filePath) {
     return process.platform === 'win32' && isPdfFile(filePath) &&
       fs.existsSync(atom.config.get('latex.sumatraPath'))
   }

--- a/lib/openers/xdg-open-opener.js
+++ b/lib/openers/xdg-open-opener.js
@@ -10,7 +10,7 @@ export default class XdgOpenOpener extends Opener {
     await latex.process.executeChildProcess(command, { showError: true })
   }
 
-  canOpen (filePath) {
+  async canOpen (filePath) {
     return process.platform === 'linux'
   }
 }

--- a/lib/openers/zathura-opener.js
+++ b/lib/openers/zathura-opener.js
@@ -1,0 +1,41 @@
+/** @babel */
+
+import _ from 'lodash'
+import Opener from '../opener'
+import { isPdfFile, isPsFile } from '../werkzeug'
+
+export default class ZathuraOpener extends Opener {
+  executable = 'zathura'
+
+  async initialize () {
+    this.exists = false
+    try {
+      if (process.platform === 'linux') {
+        const { statusCode } = await latex.process.executeChildProcess(`${this.executable} -v`)
+        this.exists = statusCode === 0
+      }
+    } catch (e) {}
+  }
+
+  async open (filePath, texPath, lineNumber) {
+    const atomPath = process.argv[0]
+    const args = [
+      `--synctex-editor-command="\\"${atomPath}\\" \\"%{input}:%{line}\\""`,
+      `--synctex-forward="${lineNumber}:1:${texPath}"`,
+      `"${filePath}"`
+    ]
+    const command = `${this.executable} ${args.join(' ')}`
+    await latex.process.executeChildProcess(command, { showError: true })
+  }
+
+  async canOpen (filePath) {
+    if (_.isUndefined(this.exists)) {
+      await this.initialize()
+    }
+    return this.exists && (isPdfFile(filePath) || isPsFile(filePath))
+  }
+
+  hasSynctex () {
+    return true
+  }
+}

--- a/package.json
+++ b/package.json
@@ -230,7 +230,7 @@
       "order": 16
     },
     "opener": {
-      "Description": "Default opener to use when viewing PDF, PS or DVI files. `automatic` will try to find the viewer best suited to the file type and your current settings."
+      "Description": "Default opener to use when viewing PDF, PS or DVI files. `automatic` will try to find the viewer best suited to the file type and your current settings.",
       "type": "string",
       "enum": [
         "automatic",

--- a/package.json
+++ b/package.json
@@ -237,6 +237,7 @@
         "okular",
         "pdf-view",
         "preview",
+        "qpdfview",
         "skim",
         "sumatra",
         "xdg-open",

--- a/package.json
+++ b/package.json
@@ -230,6 +230,7 @@
       "order": 16
     },
     "opener": {
+      "Description": "Default opener to use when viewing PDF, PS or DVI files. `automatic` will try to find the viewer best suited to the file type and your current settings."
       "type": "string",
       "enum": [
         "automatic",
@@ -239,6 +240,7 @@
         "preview",
         "qpdfview",
         "skim",
+        "shell-open",
         "sumatra",
         "xdg-open",
         "zathura",

--- a/package.json
+++ b/package.json
@@ -230,7 +230,7 @@
       "order": 16
     },
     "opener": {
-      "Description": "Default opener to use when viewing PDF, PS or DVI files. `automatic` will try to find the viewer best suited to the file type and your current settings.",
+      "description": "Default opener to use when viewing PDF, PS or DVI files. `automatic` will try to find the viewer best suited to the file type and your current settings.",
       "type": "string",
       "enum": [
         "automatic",

--- a/package.json
+++ b/package.json
@@ -241,6 +241,7 @@
         "skim",
         "sumatra",
         "xdg-open",
+        "zathura",
         "custom"
       ],
       "default": "automatic",

--- a/spec/opener-registry-spec.js
+++ b/spec/opener-registry-spec.js
@@ -15,7 +15,7 @@ describe('OpenerRegistry', () => {
 
   function createOpener (name, canOpen, hasSynctex, canOpenInBackground) {
     const instance = jasmine.createSpyObj(name, ['canOpen', 'open', 'hasSynctex', 'canOpenInBackground'])
-    instance.canOpen.andReturn(canOpen)
+    instance.canOpen.andReturn(Promise.resolve(canOpen))
     instance.hasSynctex.andReturn(hasSynctex)
     instance.canOpenInBackground.andReturn(canOpenInBackground)
     latex.opener.openers.set(name, instance)
@@ -37,12 +37,14 @@ describe('OpenerRegistry', () => {
       atom.config.set('latex.openResultInBackground', true)
       atom.config.set('latex.opener', 'xdg-open')
 
-      latex.opener.open(filePath)
+      waitsForPromise(() => latex.opener.open(filePath))
 
-      expect(cannotOpen.open).not.toHaveBeenCalled()
-      expect(canOpen.open).toHaveBeenCalled()
-      expect(canOpenInBackground.open).not.toHaveBeenCalled()
-      expect(canOpenWithSynctex.open).not.toHaveBeenCalled()
+      runs(() => {
+        expect(cannotOpen.open).not.toHaveBeenCalled()
+        expect(canOpen.open).toHaveBeenCalled()
+        expect(canOpenInBackground.open).not.toHaveBeenCalled()
+        expect(canOpenWithSynctex.open).not.toHaveBeenCalled()
+      })
     })
 
     it('opens viewer that supports SyncTeX when enabled', () => {
@@ -50,12 +52,14 @@ describe('OpenerRegistry', () => {
       atom.config.set('latex.openResultInBackground', true)
       atom.config.set('latex.opener', 'automatic')
 
-      latex.opener.open(filePath)
+      waitsForPromise(() => latex.opener.open(filePath))
 
-      expect(cannotOpen.open).not.toHaveBeenCalled()
-      expect(canOpen.open).not.toHaveBeenCalled()
-      expect(canOpenInBackground.open).not.toHaveBeenCalled()
-      expect(canOpenWithSynctex.open).toHaveBeenCalled()
+      runs(() => {
+        expect(cannotOpen.open).not.toHaveBeenCalled()
+        expect(canOpen.open).not.toHaveBeenCalled()
+        expect(canOpenInBackground.open).not.toHaveBeenCalled()
+        expect(canOpenWithSynctex.open).toHaveBeenCalled()
+      })
     })
 
     it('opens viewer that supports background opening when enabled', () => {
@@ -63,12 +67,14 @@ describe('OpenerRegistry', () => {
       atom.config.set('latex.openResultInBackground', true)
       atom.config.set('latex.opener', 'automatic')
 
-      latex.opener.open(filePath)
+      waitsForPromise(() => latex.opener.open(filePath))
 
-      expect(cannotOpen.open).not.toHaveBeenCalled()
-      expect(canOpen.open).not.toHaveBeenCalled()
-      expect(canOpenInBackground.open).toHaveBeenCalled()
-      expect(canOpenWithSynctex.open).not.toHaveBeenCalled()
+      runs(() => {
+        expect(cannotOpen.open).not.toHaveBeenCalled()
+        expect(canOpen.open).not.toHaveBeenCalled()
+        expect(canOpenInBackground.open).toHaveBeenCalled()
+        expect(canOpenWithSynctex.open).not.toHaveBeenCalled()
+      })
     })
   })
 })


### PR DESCRIPTION
Add support for qpdfview and Zathura. Does not look for existence of the executable, instead it just tries to execute `qpdfview --help` or `zathura -v` since they should be in the path. This method could be used to make the `latex.okularPath` setting unneeded.

Add Windows shell open which functions the same as `xdg-open`, i.e. as a final fallback,