### PR TITLE
Add support for Evince forks

### DIFF
--- a/lib/openers/atril-opener.js
+++ b/lib/openers/atril-opener.js
@@ -17,4 +17,8 @@ export default class AtrilOpener extends EvinceOpener {
   constructor () {
     super(DBUS_NAMES)
   }
+
+  canOpenInBackground () {
+    return false
+  }
 }

--- a/lib/openers/atril-opener.js
+++ b/lib/openers/atril-opener.js
@@ -15,7 +15,7 @@ const DBUS_NAMES = {
 
 export default class AtrilOpener extends EvinceOpener {
   constructor () {
-    super(DBUS_NAMES)
+    super('Atril', DBUS_NAMES)
   }
 
   canOpenInBackground () {

--- a/lib/openers/atril-opener.js
+++ b/lib/openers/atril-opener.js
@@ -1,0 +1,20 @@
+/** @babel */
+
+import EvinceOpener from './evince-opener'
+
+const DBUS_NAMES = {
+  applicationObject: '/org/mate/atril/Atril',
+  applicationInterface: 'org.mate.atril.Application',
+
+  daemonService: 'org.mate.atril.Daemon',
+  daemonObject: '/org/mate/atril/Daemon',
+  daemonInterface: 'org.mate.atril.Daemon',
+
+  windowInterface: 'org.mate.atril.Window'
+}
+
+export default class AtrilOpener extends EvinceOpener {
+  constructor () {
+    super(DBUS_NAMES)
+  }
+}

--- a/lib/openers/evince-opener.js
+++ b/lib/openers/evince-opener.js
@@ -25,12 +25,13 @@ function syncSource (uri, point) {
 export default class EvinceOpener extends Opener {
   windows = new Map()
 
-  constructor (dbusNames = DBUS_NAMES) {
+  constructor (name = 'Evince', dbusNames = DBUS_NAMES) {
     super(() => {
       for (const texPath of Array.from(this.windows.keys())) {
         this.disposeWindow(texPath)
       }
     })
+    this.name = name
     this.dbusNames = dbusNames
     this.initialize()
   }
@@ -100,7 +101,7 @@ export default class EvinceOpener extends Opener {
 
       return true
     } catch (error) {
-      latex.log.error('An error occured while trying to run Evince opener')
+      latex.log.error(`An error occured while trying to run ${this.name} opener`)
       return false
     }
   }

--- a/lib/openers/evince-opener.js
+++ b/lib/openers/evince-opener.js
@@ -3,17 +3,19 @@
 import Opener from '../opener'
 import url from 'url'
 
-const EVINCE_OBJECT = '/org/gnome/evince/Evince'
-const EVINCE_APPLICATION_INTERFACE = 'org.gnome.evince.Application'
+const DBUS_NAMES = {
+  applicationObject: '/org/gnome/evince/Evince',
+  applicationInterface: 'org.gnome.evince.Application',
 
-const DAEMON_SERVICE = 'org.gnome.evince.Daemon'
-const DAEMON_OBJECT = '/org/gnome/evince/Daemon'
-const DAEMON_INTERFACE = 'org.gnome.evince.Daemon'
+  daemonService: 'org.gnome.evince.Daemon',
+  daemonObject: '/org/gnome/evince/Daemon',
+  daemonInterface: 'org.gnome.evince.Daemon',
 
-const WINDOW_INTERFACE = 'org.gnome.evince.Window'
+  windowInterface: 'org.gnome.evince.Window',
 
-const GTK_APPLICATION_OBJECT = '/org/gtk/Application/anonymous'
-const GTK_APPLICATION_INTERFACE = 'org.freedesktop.Application'
+  fdApplicationObject: '/org/gtk/Application/anonymous',
+  fdApplicationInterface: 'org.freedesktop.Application'
+}
 
 function syncSource (uri, point) {
   const filePath = decodeURI(url.parse(uri).pathname)
@@ -23,12 +25,13 @@ function syncSource (uri, point) {
 export default class EvinceOpener extends Opener {
   windows = new Map()
 
-  constructor () {
+  constructor (dbusNames = DBUS_NAMES) {
     super(() => {
       for (const texPath of Array.from(this.windows.keys())) {
         this.disposeWindow(texPath)
       }
     })
+    this.dbusNames = dbusNames
     this.initialize()
   }
 
@@ -37,7 +40,7 @@ export default class EvinceOpener extends Opener {
       if (process.platform === 'linux') {
         const dbus = require('dbus-native')
         this.bus = dbus.sessionBus()
-        this.daemon = await this.getInterface(DAEMON_SERVICE, DAEMON_OBJECT, DAEMON_INTERFACE)
+        this.daemon = await this.getInterface(this.dbusNames.daemonService, this.dbusNames.daemonObject, this.dbusNames.daemonInterface)
       }
     } catch (e) {}
   }
@@ -51,16 +54,19 @@ export default class EvinceOpener extends Opener {
     const documentName = await this.findDocument(filePath)
 
     // Get the application interface and get the window list of the application
-    const evinceApplication = await this.getInterface(documentName, EVINCE_OBJECT, EVINCE_APPLICATION_INTERFACE)
+    const evinceApplication = await this.getInterface(documentName, this.dbusNames.applicationObject, this.dbusNames.applicationInterface)
     const windowNames = await this.getWindowList(evinceApplication)
 
-    // Get the window interface of the of the first (only) window and get the
-    // GTK/FreeDesktop application interface so we can activate the window
+    // Get the window interface of the of the first (only) window
     const onClosed = () => this.disposeWindow(texPath)
     const windowInstance = {
-      evinceWindow: await this.getInterface(documentName, windowNames[0], WINDOW_INTERFACE),
-      gtkApplication: await this.getInterface(documentName, GTK_APPLICATION_OBJECT, GTK_APPLICATION_INTERFACE),
+      evinceWindow: await this.getInterface(documentName, windowNames[0], this.dbusNames.windowInterface),
       onClosed
+    }
+
+    if (this.dbusNames.fdApplicationObject) {
+      // Get the GTK/FreeDesktop application interface so we can activate the window
+      windowInstance.fdApplication = await this.getInterface(documentName, this.dbusNames.fdApplicationObject, this.dbusNames.fdApplicationInterface)
     }
 
     windowInstance.evinceWindow.on('SyncSource', syncSource)
@@ -85,8 +91,8 @@ export default class EvinceOpener extends Opener {
   async open (filePath, texPath, lineNumber) {
     try {
       const windowInstance = await this.getWindow(filePath, texPath)
-      if (!this.shouldOpenInBackground()) {
-        windowInstance.gtkApplication.Activate({})
+      if (!this.shouldOpenInBackground() && windowInstance.fdApplication) {
+        windowInstance.fdApplication.Activate({})
       }
 
       // SyncView seems to want to activate the window sometimes

--- a/lib/openers/x-reader-opener.js
+++ b/lib/openers/x-reader-opener.js
@@ -15,7 +15,7 @@ const DBUS_NAMES = {
 
 export default class XReaderOpener extends EvinceOpener {
   constructor () {
-    super(DBUS_NAMES)
+    super('Xreader', DBUS_NAMES)
   }
 
   canOpenInBackground () {

--- a/lib/openers/x-reader-opener.js
+++ b/lib/openers/x-reader-opener.js
@@ -1,0 +1,20 @@
+/** @babel */
+
+import EvinceOpener from './evince-opener'
+
+const DBUS_NAMES = {
+  applicationObject: '/org/x/reader/Xreader',
+  applicationInterface: 'org.x.reader.Application',
+
+  daemonService: 'org.x.reader.Daemon',
+  daemonObject: '/org/x/reader/Daemon',
+  daemonInterface: 'org.x.reader.Daemon',
+
+  windowInterface: 'org.x.reader.Window'
+}
+
+export default class XReaderOpener extends EvinceOpener {
+  constructor () {
+    super(DBUS_NAMES)
+  }
+}

--- a/lib/openers/x-reader-opener.js
+++ b/lib/openers/x-reader-opener.js
@@ -17,4 +17,8 @@ export default class XReaderOpener extends EvinceOpener {
   constructor () {
     super(DBUS_NAMES)
   }
+
+  canOpenInBackground () {
+    return false
+  }
 }

--- a/package.json
+++ b/package.json
@@ -233,6 +233,7 @@
       "type": "string",
       "enum": [
         "automatic",
+        "atril",
         "evince",
         "okular",
         "pdf-view",
@@ -240,6 +241,7 @@
         "skim",
         "sumatra",
         "xdg-open",
+        "x-reader",
         "custom"
       ],
       "default": "automatic",


### PR DESCRIPTION
Add support for MATE's [Atril](https://github.com/mate-desktop/atril) and Cinnamon's [Xreader](https://github.com/linuxmint/xreader) forks of Evince. Since these forks use the same opening and SyncTeX logic just with different D-Bus names support is accomplished by sub-classing `EvinceOpener`. They do not support the `org.freedesktop.Application` interface used to activate the application, so open in background is probably not possible.