### PR TITLE
Fix relative/absolute output path in build and clean

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -102,7 +102,7 @@ export default class Builder {
     const currentDirectory = path.dirname(texFilePath)
     const fileName = jobname ? jobname + extension : path.basename(texFilePath).replace(/\.\w+$/, extension)
 
-    return path.join(currentDirectory, outputDirectory, fileName)
+    return path.resolve(currentDirectory, outputDirectory, fileName)
   }
 
   resolveLogFilePath (texFilePath, jobname) {

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -216,7 +216,7 @@ export default class Composer extends Disposable {
     const fdb = builder.parseFdbFile(rootFilePath, jobname)
 
     const outputDirectory = builder.getOutputDirectory()
-    const pattern = path.join(dir, outputDirectory, `${jobname || name}*`)
+    const pattern = path.resolve(dir, outputDirectory, `${jobname || name}*`)
     const files = new Set(glob.sync(pattern))
 
     if (fdb) {


### PR DESCRIPTION
Extend relative/absolute functionality to build, etc. Fixes #290.