### PR TITLE
Add logStatusCode calls

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -15,7 +15,7 @@ export default class Builder {
   constructArgs (filePath, jobname, shouldRebuild) {}
   async checkRuntimeDependencies () {}
 
-  logStatusCode (statusCode) {
+  logStatusCode (statusCode, stderr) {
     switch (statusCode) {
       case 127:
         latex.log.error(heredoc(`
@@ -30,7 +30,8 @@ export default class Builder {
       case 0:
         break
       default:
-        latex.log.error(`TeXification failed with status code ${statusCode}`)
+        const errorOutput = stderr ? ` and output of "${stderr}"` : ''
+        latex.log.error(`TeXification failed with status code ${statusCode}${errorOutput}`)
     }
   }
 

--- a/lib/builders/knitr.js
+++ b/lib/builders/knitr.js
@@ -17,7 +17,8 @@ export default class KnitrBuilder extends Builder {
   async run (filePath, jobname, shouldRebuild) {
     const args = this.constructArgs(filePath)
     const directoryPath = path.dirname(filePath)
-    const { statusCode, stdout } = await this.execRscript(directoryPath, args, 'error')
+    const { statusCode, stdout, stderr } = await this.execRscript(directoryPath, args, 'error')
+    this.logStatusCode(statusCode, stderr)
     if (statusCode !== 0) return statusCode
 
     const texFilePath = this.resolveOutputPath(filePath, stdout)

--- a/lib/builders/latexmk.js
+++ b/lib/builders/latexmk.js
@@ -19,7 +19,8 @@ export default class LatexmkBuilder extends Builder {
     const args = this.constructArgs(filePath, jobname, shouldRebuild)
     const directoryPath = path.dirname(filePath)
 
-    const { statusCode } = await this.execLatexmk(directoryPath, args, 'error')
+    const { statusCode, stderr } = await this.execLatexmk(directoryPath, args, 'error')
+    this.logStatusCode(statusCode, stderr)
 
     return statusCode
   }
@@ -56,7 +57,7 @@ export default class LatexmkBuilder extends Builder {
     latex.log.info(`latexmk check succeeded. Found version ${version}.`)
   }
 
-  logStatusCode (statusCode) {
+  logStatusCode (statusCode, stderr) {
     switch (statusCode) {
       case 10:
         latex.log.error('latexmk: Bad command line arguments.')
@@ -74,7 +75,7 @@ export default class LatexmkBuilder extends Builder {
         latex.log.error('latexmk: probable bug or retcode from called program.')
         break
       default:
-        super.logStatusCode(statusCode)
+        super.logStatusCode(statusCode, stderr)
     }
   }
 

--- a/lib/builders/texify.js
+++ b/lib/builders/texify.js
@@ -16,7 +16,8 @@ export default class TexifyBuilder extends Builder {
     const directoryPath = path.dirname(filePath)
     const options = this.constructChildProcessOptions(directoryPath, { BIBTEX: 'biber' })
 
-    const { statusCode } = await latex.process.executeChildProcess(command, options)
+    const { statusCode, stderr } = await latex.process.executeChildProcess(command, options)
+    this.logStatusCode(statusCode, stderr)
     return statusCode
   }
 


### PR DESCRIPTION
The call to `logStatusCode` got removed in v0.38.0. Moved it into the builders since `KnitrBuilder` doesn't know about status codes of `latexmk`.