### PR TITLE
Add checks for logStatusCode

### DIFF
--- a/lib/builders/knitr.js
+++ b/lib/builders/knitr.js
@@ -18,8 +18,10 @@ export default class KnitrBuilder extends Builder {
     const args = this.constructArgs(filePath)
     const directoryPath = path.dirname(filePath)
     const { statusCode, stdout, stderr } = await this.execRscript(directoryPath, args, 'error')
-    this.logStatusCode(statusCode, stderr)
-    if (statusCode !== 0) return statusCode
+    if (statusCode !== 0) {
+      this.logStatusCode(statusCode, stderr)
+      return statusCode
+    }
 
     const texFilePath = this.resolveOutputPath(filePath, stdout)
     const builder = latex.builderRegistry.getBuilder(texFilePath)

--- a/lib/builders/latexmk.js
+++ b/lib/builders/latexmk.js
@@ -20,7 +20,9 @@ export default class LatexmkBuilder extends Builder {
     const directoryPath = path.dirname(filePath)
 
     const { statusCode, stderr } = await this.execLatexmk(directoryPath, args, 'error')
-    this.logStatusCode(statusCode, stderr)
+    if (statusCode !== 0) {
+      this.logStatusCode(statusCode, stderr)
+    }
 
     return statusCode
   }

--- a/lib/builders/texify.js
+++ b/lib/builders/texify.js
@@ -17,7 +17,10 @@ export default class TexifyBuilder extends Builder {
     const options = this.constructChildProcessOptions(directoryPath, { BIBTEX: 'biber' })
 
     const { statusCode, stderr } = await latex.process.executeChildProcess(command, options)
-    this.logStatusCode(statusCode, stderr)
+    if (statusCode !== 0) {
+      this.logStatusCode(statusCode, stderr)
+    }
+
     return statusCode
   }
 

--- a/spec/builders/knitr-spec.js
+++ b/spec/builders/knitr-spec.js
@@ -17,6 +17,7 @@ describe('KnitrBuilder', () => {
       return helpers.activatePackages()
     })
     builder = new KnitrBuilder()
+    spyOn(builder, 'logStatusCode')
     fixturesPath = helpers.cloneFixtures()
     filePath = path.join(fixturesPath, 'knitr', 'file.Rnw')
   })
@@ -50,6 +51,7 @@ describe('KnitrBuilder', () => {
         const outputFilePath = path.join(fixturesPath, 'knitr', 'file.tex')
 
         expect(exitCode).toBe(0)
+        expect(builder.logStatusCode).not.toHaveBeenCalled()
         expect(getRawFile(outputFilePath)).toContain('$\\tau \\approx 6.2831853$')
       })
     })
@@ -63,6 +65,7 @@ describe('KnitrBuilder', () => {
 
       runs(() => {
         expect(exitCode).toBe(1)
+        expect(builder.logStatusCode).toHaveBeenCalled()
       })
     })
 
@@ -80,6 +83,7 @@ describe('KnitrBuilder', () => {
 
       runs(() => {
         expect(exitCode).toBe(-1)
+        expect(builder.logStatusCode).toHaveBeenCalled()
         expect(latex.log.showMessage).toHaveBeenCalledWith({
           type: 'error',
           text: 'The R package "knitr" could not be loaded.'

--- a/spec/builders/latexmk-spec.js
+++ b/spec/builders/latexmk-spec.js
@@ -13,6 +13,7 @@ describe('LatexmkBuilder', () => {
       return helpers.activatePackages()
     })
     builder = new LatexmkBuilder()
+    spyOn(builder, 'logStatusCode')
     fixturesPath = helpers.cloneFixtures()
     filePath = path.join(fixturesPath, 'file.tex')
   })
@@ -148,6 +149,7 @@ describe('LatexmkBuilder', () => {
       })
 
       runs(() => {
+        expect(builder.logStatusCode).not.toHaveBeenCalled()
         expect(exitCode).toBe(0)
       })
     })
@@ -160,6 +162,7 @@ describe('LatexmkBuilder', () => {
       })
 
       runs(() => {
+        expect(builder.logStatusCode).not.toHaveBeenCalled()
         expect(exitCode).toBe(0)
       })
     })
@@ -207,6 +210,7 @@ describe('LatexmkBuilder', () => {
           logMessage => !logMessage.filePath || logMessage.filePath === filePath || logMessage.filePath === subFilePath))
           .toBe(true, 'Incorrect file path resolution in log.')
 
+        expect(builder.logStatusCode).toHaveBeenCalled()
         expect(exitCode).toBe(12)
       })
     })
@@ -220,6 +224,7 @@ describe('LatexmkBuilder', () => {
 
       runs(() => {
         expect(exitCode).toBe(10)
+        expect(builder.logStatusCode).toHaveBeenCalled()
       })
     })
 
@@ -239,6 +244,7 @@ describe('LatexmkBuilder', () => {
 
       runs(() => {
         expect(exitCode).toBe(11)
+        expect(builder.logStatusCode).toHaveBeenCalled()
       })
     })
 
@@ -252,6 +258,7 @@ describe('LatexmkBuilder', () => {
 
       runs(() => {
         expect(exitCode).toBe(0)
+        expect(builder.logStatusCode).not.toHaveBeenCalled()
         expectExistenceOfExtendedOutputs()
       })
     })
@@ -267,6 +274,7 @@ describe('LatexmkBuilder', () => {
 
       runs(() => {
         expect(exitCode).toBe(0)
+        expect(builder.logStatusCode).not.toHaveBeenCalled()
         expectExistenceOfExtendedOutputs()
       })
     })
@@ -281,6 +289,7 @@ describe('LatexmkBuilder', () => {
 
       runs(() => {
         expect(exitCode).toBe(0)
+        expect(builder.logStatusCode).not.toHaveBeenCalled()
         expectExistenceOfExtendedOutputs()
       })
     })
@@ -296,6 +305,7 @@ describe('LatexmkBuilder', () => {
 
       runs(() => {
         expect(exitCode).toBe(0)
+        expect(builder.logStatusCode).not.toHaveBeenCalled()
         expectExistenceOfExtendedOutputs()
       })
     })
@@ -310,6 +320,7 @@ describe('LatexmkBuilder', () => {
 
       runs(() => {
         expect(exitCode).toBe(0)
+        expect(builder.logStatusCode).not.toHaveBeenCalled()
         expectExistenceOfExtendedOutputs()
       })
     })
@@ -325,6 +336,7 @@ describe('LatexmkBuilder', () => {
 
       runs(() => {
         expect(exitCode).toBe(0)
+        expect(builder.logStatusCode).not.toHaveBeenCalled()
         expectExistenceOfExtendedOutputs()
       })
     })
@@ -339,6 +351,7 @@ describe('LatexmkBuilder', () => {
 
       runs(() => {
         expect(exitCode).toBe(0)
+        expect(builder.logStatusCode).not.toHaveBeenCalled()
         expectExistenceOfExtendedOutputs()
       })
     })
@@ -354,6 +367,7 @@ describe('LatexmkBuilder', () => {
 
       runs(() => {
         expect(exitCode).toBe(0)
+        expect(builder.logStatusCode).not.toHaveBeenCalled()
         expectExistenceOfExtendedOutputs()
       })
     })
@@ -368,6 +382,7 @@ describe('LatexmkBuilder', () => {
 
       runs(() => {
         expect(exitCode).toBe(0)
+        expect(builder.logStatusCode).not.toHaveBeenCalled()
         expectExistenceOfExtendedOutputs()
       })
     })
@@ -383,6 +398,7 @@ describe('LatexmkBuilder', () => {
 
       runs(() => {
         expect(exitCode).toBe(0)
+        expect(builder.logStatusCode).not.toHaveBeenCalled()
         expectExistenceOfExtendedOutputs()
       })
     })
@@ -401,6 +417,7 @@ describe('LatexmkBuilder', () => {
 
       runs(() => {
         expect(exitCode).toBe(0)
+        expect(builder.logStatusCode).not.toHaveBeenCalled()
         expectExistenceOfExtendedOutputs()
       })
     })
@@ -416,6 +433,7 @@ describe('LatexmkBuilder', () => {
 
       runs(() => {
         expect(exitCode).toBe(0)
+        expect(builder.logStatusCode).not.toHaveBeenCalled()
         expectExistenceOfExtendedOutputs()
       })
     })

--- a/spec/builders/texify-spec.js
+++ b/spec/builders/texify-spec.js
@@ -14,6 +14,7 @@ if (process.env.TEX_DIST === 'miktex') {
         return helpers.activatePackages()
       })
       builder = new TexifyBuilder()
+      spyOn(builder, 'logStatusCode')
       fixturesPath = helpers.cloneFixtures()
       filePath = path.join(fixturesPath, 'file.tex')
     })
@@ -64,6 +65,7 @@ if (process.env.TEX_DIST === 'miktex') {
 
         runs(() => {
           expect(exitCode).toBe(0)
+          expect(builder.logStatusCode).not.toHaveBeenCalled()
         })
       })
 
@@ -76,6 +78,7 @@ if (process.env.TEX_DIST === 'miktex') {
 
         runs(() => {
           expect(exitCode).toBe(0)
+          expect(builder.logStatusCode).not.toHaveBeenCalled()
         })
       })
 
@@ -118,6 +121,7 @@ if (process.env.TEX_DIST === 'miktex') {
           }
 
           expect(exitCode).toBe(1)
+          expect(builder.logStatusCode).toHaveBeenCalled()
         })
       })
 
@@ -130,6 +134,7 @@ if (process.env.TEX_DIST === 'miktex') {
 
         runs(() => {
           expect(exitCode).toBe(1)
+          expect(builder.logStatusCode).toHaveBeenCalled()
         })
       })
 
@@ -145,6 +150,7 @@ if (process.env.TEX_DIST === 'miktex') {
 
         runs(() => {
           expect(exitCode).toBe(1)
+          expect(builder.logStatusCode).toHaveBeenCalled()
         })
       })
     })


### PR DESCRIPTION
Make sure `logStatusCode` gets called for failed builds.