### PR TITLE
Improve patch synctex

### DIFF
--- a/lib/builders/knitr.js
+++ b/lib/builders/knitr.js
@@ -58,9 +58,26 @@ export default class KnitrBuilder extends Builder {
 
     latex.log.info(`Rscript check succeeded. Found version ${version}.`)
 
-    const result = await this.execRscript('.', ['-e "library(knitr)"', '-e "library(patchSynctex)"'], 'warning')
+    const result = await this.execRscript('.', ['-e "installed.packages()"'], 'warning')
     if (result.statusCode === 0) {
-      latex.log.info('knitr and patchSynctex libraries found.')
+      this.checkRscriptPackageVersion(result.stdout, 'knitr')
+      this.checkRscriptPackageVersion(result.stdout, 'patchSynctex', '0.1-4')
+    }
+  }
+
+  checkRscriptPackageVersion (stdout, packageName, minimumVersion) {
+    const packagePattern = new RegExp(`^${packageName}\\s+"${packageName}"\\s+"[^"]*"\\s+"([^"]*)"`, 'm')
+    const match = stdout.match(packagePattern)
+    if (match) {
+      const version = match[1]
+      const message = `Rscript ${packageName} package check succeeded. Found version ${version}.`
+      if (minimumVersion && minimumVersion > version) {
+        latex.log.warning(`${message} Minimum version ${minimumVersion} needed.`)
+      } else {
+        latex.log.info(message)
+      }
+    } else {
+      latex.log.warning(`Rscript package ${packageName} was not found.`)
     }
   }
 

--- a/lib/builders/knitr.js
+++ b/lib/builders/knitr.js
@@ -6,6 +6,7 @@ import Builder from '../builder'
 const MISSING_PACKAGE_PATTERN = /there is no package called [‘']([^’']+)[’']/g
 const OUTPUT_PATH_PATTERN = /\[\d+]\s+"(.*)"/
 const RSCRIPT_VERSION_PATTERN = /version\s+(\S+)/i
+const PACKAGE_VERSION_PATTERN = /^\[1] "([^"]*)"/
 
 function escapePath (filePath) {
   return filePath.replace(/\\/g, '\\\\')
@@ -58,27 +59,28 @@ export default class KnitrBuilder extends Builder {
 
     latex.log.info(`Rscript check succeeded. Found version ${version}.`)
 
-    const result = await this.execRscript('.', ['-e "installed.packages()"'], 'warning')
-    if (result.statusCode === 0) {
-      this.checkRscriptPackageVersion(result.stdout, 'knitr')
-      this.checkRscriptPackageVersion(result.stdout, 'patchSynctex', '0.1-4')
-    }
+    await this.checkRscriptPackageVersion('knitr')
+    await this.checkRscriptPackageVersion('patchSynctex', '0.1-4')
   }
 
-  checkRscriptPackageVersion (stdout, packageName, minimumVersion) {
-    const packagePattern = new RegExp(`^${packageName}\\s+"${packageName}"\\s+"[^"]*"\\s+"([^"]*)"`, 'm')
-    const match = stdout.match(packagePattern)
-    if (match) {
-      const version = match[1]
-      const message = `Rscript ${packageName} package check succeeded. Found version ${version}.`
-      if (minimumVersion && minimumVersion > version) {
-        latex.log.warning(`${message} Minimum version ${minimumVersion} needed.`)
-      } else {
-        latex.log.info(message)
+  async checkRscriptPackageVersion (packageName, minimumVersion) {
+    const result = await this.execRscript('.', [`-e "installed.packages()['${packageName}','Version']"`], 'warning')
+
+    if (result.statusCode === 0) {
+      const match = result.stdout.match(PACKAGE_VERSION_PATTERN)
+      if (match) {
+        const version = match[1]
+        const message = `Rscript ${packageName} package check succeeded. Found version ${version}.`
+        if (minimumVersion && minimumVersion > version) {
+          latex.log.warning(`${message} Minimum version ${minimumVersion} needed.`)
+        } else {
+          latex.log.info(message)
+        }
+        return
       }
-    } else {
-      latex.log.warning(`Rscript package ${packageName} was not found.`)
     }
+
+    latex.log.warning(`Rscript package ${packageName} was not found.`)
   }
 
   async execRscript (directoryPath, args, type) {

--- a/lib/builders/knitr.js
+++ b/lib/builders/knitr.js
@@ -7,6 +7,10 @@ const MISSING_PACKAGE_PATTERN = /there is no package called [‘']([^’']+)[’
 const OUTPUT_PATH_PATTERN = /\[\d+]\s+"(.*)"/
 const RSCRIPT_VERSION_PATTERN = /version\s+(\S+)/i
 
+function escapePath (filePath) {
+  return filePath.replace(/\\/g, '\\\\')
+}
+
 export default class KnitrBuilder extends Builder {
   executable = 'Rscript'
 
@@ -28,14 +32,8 @@ export default class KnitrBuilder extends Builder {
     const code = await builder.run(jobState)
 
     if (code === 0 && jobState.getEnableSynctex()) {
-      if (jobState.getOutputDirectory()) {
-        latex.log.info('Using an output directory is not compatible with patchSynctex.')
-      } else if (jobState.getJobName()) {
-        latex.log.info('Using a jobname is not compatible with patchSynctex.')
-      } else {
-        const args = this.constructPatchSynctexArgs(jobState)
-        await this.execRscript(jobState.getProjectPath(), args, 'warning')
-      }
+      const args = this.constructPatchSynctexArgs(jobState)
+      await this.execRscript(jobState.getProjectPath(), args, 'warning')
     }
 
     return code
@@ -89,16 +87,18 @@ export default class KnitrBuilder extends Builder {
     const args = [
       '-e "library(knitr)"',
       '-e "opts_knit$set(concordance = TRUE)"',
-      `-e "knit('${jobState.getKnitrFilePath().replace(/\\/g, '\\\\')}')"`
+      `-e "knit('${escapePath(jobState.getKnitrFilePath())}')"`
     ]
 
     return args
   }
 
   constructPatchSynctexArgs (jobState) {
+    let synctexPath = this.resolveOutputFilePath(jobState, '')
+
     const args = [
       '-e "library(patchSynctex)"',
-      `-e "patchSynctex('${jobState.getKnitrFilePath().replace(/\\/g, '\\\\')}')"`
+      `-e "patchSynctex('${escapePath(jobState.getKnitrFilePath())}',syncfile='${escapePath(synctexPath)}')"`
     ]
 
     return args

--- a/spec/builders/knitr-spec.js
+++ b/spec/builders/knitr-spec.js
@@ -41,6 +41,20 @@ describe('KnitrBuilder', () => {
     })
   })
 
+  describe('constructPatchSynctexArgs', () => {
+    it('produces default arguments containing expected file path', () => {
+      const escapedFilePath = filePath.replace(/\\/g, '\\\\')
+      const escapedSynctexPath = escapedFilePath.replace(/\.[^.]+$/, '')
+      const expectedArgs = [
+        '-e "library(patchSynctex)"',
+        `-e "patchSynctex('${escapedFilePath}',syncfile='${escapedSynctexPath}')"`
+      ]
+
+      const args = builder.constructPatchSynctexArgs(filePath)
+      expect(args).toEqual(expectedArgs)
+    })
+  })
+
   describe('run', () => {
     let exitCode
 

--- a/spec/builders/knitr-spec.js
+++ b/spec/builders/knitr-spec.js
@@ -50,7 +50,7 @@ describe('KnitrBuilder', () => {
         `-e "patchSynctex('${escapedFilePath}',syncfile='${escapedSynctexPath}')"`
       ]
 
-      const args = builder.constructPatchSynctexArgs(filePath)
+      const args = builder.constructPatchSynctexArgs(jobState)
       expect(args).toEqual(expectedArgs)
     })
   })


### PR DESCRIPTION
Use `syncfile` parameter added by EmmanuelCharpentier/patchSynctex#4 to enable SyncTex patching when using an output directory or a jobname.