### PR TITLE
Fix latex reference in ProcessManager

### DIFF
--- a/lib/process-manager.js
+++ b/lib/process-manager.js
@@ -21,7 +21,7 @@ export default class ProcessManager extends Disposable {
         if (allowKill) {
           this.processes.delete(pid)
         }
-        if (error && showError) {
+        if (error && showError && latex && latex.log) {
           latex.log.error(`An error occurred while trying to run "${command}" (${error.code}).`)
         }
         resolve({


### PR DESCRIPTION
Add guard to process error log in case process is still running when package is disabled. Fixes #330.