### PR TITLE
Use file protocol in Okular

### DIFF
--- a/lib/openers/okular-opener.js
+++ b/lib/openers/okular-opener.js
@@ -1,14 +1,21 @@
 /** @babel */
 
 import fs from 'fs-plus'
+import url from 'url'
 import Opener from '../opener'
 
 export default class OkularOpener extends Opener {
   async open (filePath, texPath, lineNumber) {
     const okularPath = atom.config.get('latex.okularPath')
+    const uri = url.format({
+      protocol: 'file:',
+      slashes: true,
+      pathname: encodeURI(filePath),
+      hash: encodeURI(`src:${lineNumber} ${texPath}`)
+    })
     const args = [
       '--unique',
-      `"${filePath}#src:${lineNumber} ${texPath}"`
+      `"${uri}"`
     ]
     if (this.shouldOpenInBackground()) args.unshift('--noraise')
 


### PR DESCRIPTION
Okular seems to want a url with a proper file protocol portion or it tries to escape the hash preceding the fragment.

Fixes #332.