### PR TITLE
Add xdvipdfmx section to FDB parse

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -147,7 +147,7 @@ export default class Builder {
 
     const fdb = jobState.getFileDatabase()
     if (fdb) {
-      const sections = ['ps2pdf', 'xdvipdfmx', 'dvipdf', 'dvips', 'latex', 'pdflatex']
+      const sections = ['ps2pdf', 'xdvipdfmx', 'dvipdf', 'dvips', 'latex', 'pdflatex', 'lualatex', 'xelatex']
       let output
 
       for (const section of sections) {

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -147,7 +147,7 @@ export default class Builder {
 
     const fdb = jobState.getFileDatabase()
     if (fdb) {
-      const sections = ['ps2pdf', 'dvipdf', 'dvips', 'latex', 'pdflatex']
+      const sections = ['ps2pdf', 'xdvipdfmx', 'dvipdf', 'dvips', 'latex', 'pdflatex']
       let output
 
       for (const section of sections) {


### PR DESCRIPTION
`latexmk` now runs xdvipdfmx separately so we need to look at the `xdvipdfmx` section in the FDB.

Fixes #339