### PR TITLE
Fix Evince jobname support

### DIFF
--- a/lib/openers/evince-opener.js
+++ b/lib/openers/evince-opener.js
@@ -47,8 +47,8 @@ export default class EvinceOpener extends Opener {
   }
 
   async getWindow (filePath, texPath) {
-    if (this.windows.has(texPath)) {
-      return this.windows.get(texPath)
+    if (this.windows.has(filePath)) {
+      return this.windows.get(filePath)
     }
 
     // First find the internal document name
@@ -72,10 +72,10 @@ export default class EvinceOpener extends Opener {
 
     windowInstance.evinceWindow.on('SyncSource', syncSource)
     windowInstance.evinceWindow.on('Closed', windowInstance.onClosed)
-    this.windows.set(texPath, windowInstance)
+    this.windows.set(filePath, windowInstance)
 
     // This seems to help with future syncs
-    windowInstance.evinceWindow.SyncView(texPath, [0, 0], 0)
+    await this.syncView(windowInstance.evinceWindow, texPath, [0, 0], 0)
 
     return windowInstance
   }
@@ -97,7 +97,7 @@ export default class EvinceOpener extends Opener {
       }
 
       // SyncView seems to want to activate the window sometimes
-      windowInstance.evinceWindow.SyncView(texPath, [lineNumber, 0], 0)
+      await this.syncView(windowInstance.evinceWindow, texPath, [lineNumber, 0], 0)
 
       return true
     } catch (error) {
@@ -137,6 +137,19 @@ export default class EvinceOpener extends Opener {
           reject(error)
         } else {
           resolve(windowNames)
+        }
+      })
+    })
+  }
+
+  syncView (evinceWindow, source, point, timestamp) {
+    return new Promise((resolve, reject) => {
+      evinceWindow.SyncView(source, point, timestamp, (error) => {
+        console.log(`${source} ${error}`)
+        if (error) {
+          reject(error)
+        } else {
+          resolve()
         }
       })
     })


### PR DESCRIPTION
Evince indexed the window based on the TeX path when it should be the output
path.