### PR TITLE
Improve SumatraPDF experience

### DIFF
--- a/lib/openers/sumatra-opener.js
+++ b/lib/openers/sumatra-opener.js
@@ -9,6 +9,7 @@ export default class SumatraOpener extends Opener {
     const sumatraPath = `"${atom.config.get('latex.sumatraPath')}"`
     const atomPath = `"${process.argv[0]}"`
     const args = [
+      '-reuse-instance',
       '-forward-search',
       `"${texPath}"`,
       lineNumber,
@@ -18,6 +19,8 @@ export default class SumatraOpener extends Opener {
     ]
 
     const command = `${sumatraPath} ${args.join(' ')}`
+
+    console.log(command)
 
     await latex.process.executeChildProcess(command)
   }

--- a/lib/openers/sumatra-opener.js
+++ b/lib/openers/sumatra-opener.js
@@ -7,7 +7,7 @@ import { isPdfFile } from '../werkzeug'
 export default class SumatraOpener extends Opener {
   async open (filePath, texPath, lineNumber) {
     const sumatraPath = `"${atom.config.get('latex.sumatraPath')}"`
-    const atomPath = `"${process.argv[0]}"`
+    const atomPath = process.argv[0]
     const args = [
       '-reuse-instance',
       '-forward-search',
@@ -19,8 +19,6 @@ export default class SumatraOpener extends Opener {
     ]
 
     const command = `${sumatraPath} ${args.join(' ')}`
-
-    console.log(command)
 
     await latex.process.executeChildProcess(command)
   }


### PR DESCRIPTION
Currently, the `-reuse-instance` flag appears to be needed when tabbed mode is off.

Fixes #347
Resolves #348