### PR TITLE
Add basic support for DiCy builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Dependency Status][dependency svg]][dependency]
 [![devDependency Status][devDependency svg]][devDependency]
 
-Compile LaTeX or [knitr] documents from within Atom.
+Compile LaTeX or [knitr][] documents from within Atom.
 
 ## Installing
 Use the Atom package manager and search for "latex", or run `apm install latex`
@@ -12,10 +12,10 @@ from the command line.
 
 ## Prerequisites
 ### TeX distribution
-Since this package relies upon `latexmk`, a reasonably up-to-date and working
-TeX distribution is required. The only officially supported distributions are
-[TeX Live], and [MiKTeX]. Although, the latter is not as well tested and
-supported as TeX Live, hence using TeX Live is highly recommended.
+A reasonably up-to-date and working TeX distribution is required. The only
+officially supported distributions are [TeX Live][], and [MiKTeX][]. Although,
+the latter is not as well tested and supported as TeX Live, hence using TeX Live
+is highly recommended.
 
 You need to ensure that the package can find your TeX distribution's binaries;
 by default the package uses your `PATH` environment variable, as well as the
@@ -36,16 +36,22 @@ If your TeX distribution's binaries are not installed in one of those locations
 or discoverable via the `PATH` environment variable, you will need to help the
 package find the binaries. This can be done by setting the *TeX Path*
 configuration option to point to the folder containing the binaries, either in
-the settings view, or directly in your `config.cson` file. See [Configuration]
+the settings view, or directly in your `config.cson` file. See [Configuration][]
 for further details regarding the settings of this package.
 
-#### TeX Live
-If you're using TeX Live and have installed to the default location then no
-further action should be required.
+### Builder Selection
+The `latex` package provides access to two automatic builders for LaTeX and
+knitr documents. By default the package will use `latexmk` for LaTeX documents
+and an included builder to prepare knitr documents for `latexmk`. In this case
+an up to date installation of `latexmk` is required. If you're using TeX Live
+then you need only insure that `latexmk` is installed and up to date using the
+appropriate package manager.  If you're using MikTeX then see how to [use
+`latexmk` with MiKTeX][latexmk with MiKTeX].
 
-#### MiKTeX
-If you're using MikTeX and have not installed the required `latexmk` package,
-learn how to [use `latexmk` with MiKTeX][latexmk with MiKTeX].
+The JavaScript based [DiCy][] builder may also be used for all documents by
+selecting the `Use DiCy` option in the settings page. [DiCy][] will be installed
+automatically and so no further action is required for either TeX Live or
+MiKTeX.
 
 ## Usage
 The `latex:build` command can be invoked from the LaTex menu or by pressing the
@@ -69,11 +75,11 @@ The `latex` package supports other commands as detailed in the table below.
 Many of the build settings in the settings page of the `latex` package can be
 overridden on a per file basis. One way to override specific build settings is
 to use "magic" TeX comments in the form of `% !TEX <name> = <value>`. Another
-way is to use a [YAML] formatted file with the same name as your root LaTeX
+way is to use a [YAML][] formatted file with the same name as your root LaTeX
 file, but with an extension of `.yaml`. The settings and values that can
 overridden via either method are listed in the table below. If multiple setting
 names are listed then the first is preferred and following names are available
-for compatibility. More details can found at [Overridding Build Settings].
+for compatibility. More details can found at [Overridding Build Settings][].
 
 | Name                                    | Value                                          | Use                                                                                       |
 |:----------------------------------------|:-----------------------------------------------|:------------------------------------------------------------------------------------------|
@@ -90,11 +96,11 @@ for compatibility. More details can found at [Overridding Build Settings].
 | `root`                                  | file path, e.g. `../file.tex`                  | Specify the root file that should be built. Only available via "magic" TeX comments.      |
 
 ### PDF/DVI/PS Viewers
-The `latex` package currently supports [Atril], [Evince], [Okular], [pdf-view],
-[Preview], [Skim], [Sumatra PDF], Windows shell open, [xdg-open], [Xreader] and
-[Zathura] as PDF/DVI/PS viewers. This includes support for cursor
-synchronization via SyncTeX if possible. Specific features of each of the
-viewers is detailed at [Supported Viewers].
+The `latex` package currently supports [Atril][], [Evince][], [Okular][],
+[pdf-view][], [Preview][], [Skim][], [Sumatra PDF][], Windows shell open,
+[xdg-open][], [Xreader][] and [Zathura][] as PDF/DVI/PS viewers. This includes
+support for cursor synchronization via SyncTeX if possible. Specific features of
+each of the viewers is detailed at [Supported Viewers][].
 
 ## Development status
 Please note that this package is in a **beta** state. It is stable, but lacks
@@ -107,6 +113,7 @@ Any and all help is greatly appreciated!
 [appveyor]: https://ci.appveyor.com/project/thomasjo/atom-latex/branch/master
 [Atril]: http://mate-desktop.com/#atril
 [Configuration]: https://github.com/thomasjo/atom-latex/wiki/Configuration
+[DiCy]: https://yitzchak.github.io/dicy/
 [dependency svg]: https://david-dm.org/thomasjo/atom-latex.svg
 [dependency]: https://david-dm.org/thomasjo/atom-latex
 [devDependency svg]: https://david-dm.org/thomasjo/atom-latex/dev-status.svg

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -3,7 +3,8 @@
 import _ from 'lodash'
 import fs from 'fs-plus'
 import path from 'path'
-import { getEditorDetails, replacePropertiesInString } from './werkzeug'
+import { Dicy } from '@dicy/core'
+import { getEditorDetails, isDviFile, isPdfFile, isPsFile, replacePropertiesInString } from './werkzeug'
 import minimatch from 'minimatch'
 import glob from 'glob'
 import yaml from 'js-yaml'
@@ -14,11 +15,16 @@ import MagicParser from './parsers/magic-parser'
 export default class Composer extends Disposable {
   disposables = new CompositeDisposable()
   cachedBuildStates = new Map()
+  cachedDicy = new Map()
 
   constructor () {
     super(() => this.disposables.dispose())
     this.disposables.add(atom.config.onDidChange('latex', () => {
       this.rebuildCompleted = new Set()
+      const dicy = this.cachedDicy.values().next().value
+      if (dicy) {
+        dicy.updateOptions(this.getDicyOptions(), true)
+      }
     }))
   }
 
@@ -162,6 +168,102 @@ export default class Composer extends Disposable {
     }
   }
 
+  async getDicy (filePath, options = {}) {
+    const magic = new MagicParser(filePath).parse()
+    if (magic.root) {
+      filePath = path.resolve(path.dirname(filePath), magic.root)
+    }
+
+    let dicy
+
+    if (!options.ignoreCache) {
+      dicy = this.cachedDicy.get(filePath)
+      if (dicy) return dicy
+    }
+
+    dicy = await Dicy.create(filePath, options)
+    if (this.cachedDicy.size === 0) {
+      // This is the first Dicy builder so make sure the user options
+      // are synchronized.
+      dicy.updateOptions(this.getDicyOptions(), true)
+    }
+    this.cachedDicy.set(filePath, dicy)
+
+    dicy.on('log', event => {
+      const nameText = event.name ? `[${event.name}] ` : ''
+      const typeText = event.category ? `${event.category}: ` : ''
+      const message = {
+        type: event.severity,
+        text: `${nameText}${typeText}${event.text.replace('\n', ' ')}`
+      }
+
+      if (event.source) {
+        message.filePath = path.resolve(dicy.rootPath, event.source.file)
+        if (event.source.start) {
+          message.range = [[event.source.start - 1, 0], [(event.source.end || event.source.start) - 1, 65535]]
+        }
+      }
+
+      if (event.log) {
+        message.logPath = path.resolve(dicy.rootPath, event.log.file)
+        if (event.log.start) {
+          message.logRange = [[event.log.start - 1, 0], [(event.log.end || event.log.start) - 1, 65535]]
+        }
+      }
+
+      latex.log.showMessage(message)
+    })
+    .on('command', event => {
+      latex.log.info(`[${event.rule}] Executing \`${event.command}\``)
+    })
+    .on('fileDeleted', event => {
+      latex.log.info(`Deleting \`${event.file}\``)
+    })
+
+    return dicy
+  }
+
+  getDicyOptions () {
+    return _.pick(atom.config.get('latex'), [
+      'customEngine',
+      'engine',
+      'enableShellEscape',
+      'enableSynctex',
+      'loggingLevel',
+      'cleanPatterns',
+      'outputDirectory',
+      'outputFormat',
+      'producer',
+      'moveResultToSourceDirectory'
+    ])
+  }
+
+  async runDicy (commands, options = {}, openResults = true, label = null) {
+    const { filePath, lineNumber } = getEditorDetails()
+    const dicy = await this.getDicy(filePath, options)
+
+    if (label) {
+      latex.status.show(label, 'highlight', 'sync', true, 'Click to kill LaTeX build.', () => dicy.killChildProcesses())
+      latex.log.group(label)
+    }
+
+    const success = await dicy.run(...commands)
+
+    if (openResults && success) {
+      const targets = await dicy.getTargetPaths(true)
+      for (const outputFilePath of targets) {
+        // SyncTeX files are considered targets also, so do a positive file type check.
+        if (isDviFile(outputFilePath) || isPdfFile(outputFilePath) || isPsFile(outputFilePath)) {
+          await latex.opener.open(path.resolve(dicy.rootPath, outputFilePath), filePath, lineNumber)
+        }
+      }
+    }
+
+    if (label) {
+      latex.log.groupEnd()
+    }
+  }
+
   async build (shouldRebuild) {
     latex.process.killChildProcesses()
 
@@ -174,6 +276,11 @@ export default class Composer extends Disposable {
 
     if (editor.isModified()) {
       editor.save() // TODO: Make this configurable?
+    }
+
+    if (this.shouldUseDicy()) {
+      return this.runDicy(['load', 'build', 'log', 'save'], { ignoreCache: shouldRebuild },
+        this.shouldOpenResult(), 'LaTeX Build')
     }
 
     const { builder, state } = this.initializeBuild(filePath)
@@ -224,6 +331,10 @@ export default class Composer extends Disposable {
       return
     }
 
+    if (this.shouldUseDicy()) {
+      return this.runDicy(['load'])
+    }
+
     const { builder, state } = this.initializeBuild(filePath, true)
     if (!builder) return false
 
@@ -246,6 +357,10 @@ export default class Composer extends Disposable {
     const { filePath } = getEditorDetails()
     if (!filePath || !this.isTexFile(filePath)) {
       return false
+    }
+
+    if (this.shouldUseDicy()) {
+      return this.runDicy(['load', 'clean', 'save'], {}, false, 'LaTeX Clean')
     }
 
     const { builder, state } = this.initializeBuild(filePath, true)
@@ -394,6 +509,8 @@ export default class Composer extends Disposable {
   shouldMoveResult (jobState) {
     return jobState.getMoveResultToSourceDirectory() && jobState.getOutputDirectory().length > 0
   }
+
+  shouldUseDicy () { return atom.config.get('latex.enableDicy') }
 
   shouldOpenResult () { return atom.config.get('latex.openResultAfterBuild') }
 }

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -280,7 +280,7 @@ export default class Composer extends Disposable {
   }
 
   async build (shouldRebuild) {
-    this.kill()
+    await this.kill()
 
     const { editor, filePath } = getEditorDetails()
 
@@ -343,9 +343,9 @@ export default class Composer extends Disposable {
   kill () {
     latex.process.killChildProcesses()
 
-    for (const dicy of this.cachedDiCy.values()) {
-      dicy.killChildProcesses()
-    }
+    const killJobs = Array.from(this.cachedDiCy.values()).map(dicy => dicy.kill())
+
+    return Promise.all(killJobs)
   }
 
   async sync () {

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -265,9 +265,9 @@ export default class Composer extends Disposable {
     switch (platform) {
       case 'win32':
         return [
+          '%SystemDrive%\\texlive\\2017\\bin\\win32',
           '%SystemDrive%\\texlive\\2016\\bin\\win32',
           '%SystemDrive%\\texlive\\2015\\bin\\win32',
-          '%SystemDrive%\\texlive\\2014\\bin\\win32',
           '%ProgramFiles%\\MiKTeX 2.9\\miktex\\bin\\x64',
           '%ProgramFiles(x86)%\\MiKTeX 2.9\\miktex\\bin',
           '$PATH'

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -185,9 +185,16 @@ export default class Composer extends Disposable {
 
     let dicy
 
+    // logging severity level is set to info so we receive all messages and
+    // do our own filtering.
+    options.severity = 'info'
+
     if (!options.ignoreCache) {
       dicy = this.cachedDicy.get(filePath)
-      if (dicy) return dicy
+      if (dicy) {
+        // dicy.setInstanceOptions(options)
+        return dicy
+      }
     }
 
     dicy = await Dicy.create(filePath, options)
@@ -233,6 +240,8 @@ export default class Composer extends Disposable {
   }
 
   getDicyOptions () {
+    // loggingLevel is sent even though it is set to info in getDicy so that
+    // any command line versions of Dicy have the same error reporting level.
     return _.pick(atom.config.get('latex'), [
       'cleanPatterns',
       'customEngine',
@@ -248,14 +257,12 @@ export default class Composer extends Disposable {
     ])
   }
 
-  async runDicy (commands, options = {}, openResults = true, label = null) {
+  async runDicy (commands, options = {}, openResults = true, clearLog = false) {
     const { filePath, lineNumber } = getEditorDetails()
     const dicy = await this.getDicy(filePath, options)
 
-    if (label) {
-      latex.status.show(label, 'highlight', 'sync', true, 'Click to kill LaTeX build.', () => dicy.killChildProcesses())
-      latex.log.group(label)
-    }
+    if (clearLog) latex.log.clear()
+    latex.status.setBusy()
 
     const success = await dicy.run(...commands)
 
@@ -269,9 +276,7 @@ export default class Composer extends Disposable {
       }
     }
 
-    if (label) {
-      latex.log.groupEnd()
-    }
+    latex.status.setIdle()
   }
 
   async build (shouldRebuild) {
@@ -290,7 +295,7 @@ export default class Composer extends Disposable {
 
     if (this.shouldUseDicy()) {
       return this.runDicy(['load', 'build', 'log', 'save'], { ignoreCache: shouldRebuild },
-        this.shouldOpenResult(), 'LaTeX Build')
+        this.shouldOpenResult(), true)
     }
 
     const { builder, state } = this.initializeBuild(filePath)
@@ -378,7 +383,7 @@ export default class Composer extends Disposable {
     }
 
     if (this.shouldUseDicy()) {
-      return this.runDicy(['load', 'clean', 'save'], {}, false, 'LaTeX Clean')
+      return this.runDicy(['load', 'clean', 'save'], {}, false, true)
     }
 
     const { builder, state } = this.initializeBuild(filePath, true)

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -566,7 +566,7 @@ export default class Composer extends Disposable {
     return jobState.getMoveResultToSourceDirectory() && jobState.getOutputDirectory().length > 0
   }
 
-  shouldUseDiCy () { return atom.config.get('latex.builder') === 'dicy' }
+  shouldUseDiCy () { return atom.config.get('latex.useDicy') }
 
   shouldOpenResult () { return atom.config.get('latex.openResultAfterBuild') }
 }

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -242,7 +242,7 @@ export default class Composer extends Disposable {
   getDiCyOptions () {
     // loggingLevel is sent even though it is set to info in getDiCy so that
     // any command line versions of DiCy have the same error reporting level.
-    return _.pick(atom.config.get('latex'), [
+    const options = _.pick(atom.config.get('latex'), [
       'cleanPatterns',
       'customEngine',
       'enableShellEscape',
@@ -252,9 +252,33 @@ export default class Composer extends Disposable {
       'moveResultToSourceDirectory',
       'outputDirectory',
       'outputFormat',
-      'producer',
-      'texPath'
+      'producer'
     ])
+
+    const PATH = atom.config.get('latex.texPath').trim() || this.defaultTexPath(process.platform)
+    if (PATH) options['$PATH'] = PATH
+
+    return options
+  }
+
+  defaultTexPath (platform) {
+    switch (platform) {
+      case 'win32':
+        return [
+          '%SystemDrive%\\texlive\\2016\\bin\\win32',
+          '%SystemDrive%\\texlive\\2015\\bin\\win32',
+          '%SystemDrive%\\texlive\\2014\\bin\\win32',
+          '%ProgramFiles%\\MiKTeX 2.9\\miktex\\bin\\x64',
+          '%ProgramFiles(x86)%\\MiKTeX 2.9\\miktex\\bin',
+          '$PATH'
+        ].join(path.delimiter)
+      case 'darwin':
+        return [
+          '/usr/texbin',
+          '/Library/TeX/texbin',
+          '$PATH'
+        ].join(path.delimiter)
+    }
   }
 
   async runDiCy (commands, options = {}, openResults = true, clearLog = false) {

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -19,13 +19,22 @@ export default class Composer extends Disposable {
 
   constructor () {
     super(() => this.disposables.dispose())
-    this.disposables.add(atom.config.onDidChange('latex', () => {
-      this.rebuildCompleted = new Set()
-      const dicy = this.cachedDicy.values().next().value
-      if (dicy) {
-        dicy.updateOptions(this.getDicyOptions(), true)
-      }
-    }))
+    this.disposables.add(atom.config.onDidChange('latex', () => this.updateConfiguration()))
+  }
+
+  updateConfiguration () {
+    // Setting rebuildCompleted to empty set will force rebuild to happen at the
+    // next build.
+    this.rebuildCompleted = new Set()
+
+    // Get the first cached Dicy builder
+    const dicy = this.cachedDicy.values().next().value
+    if (dicy) {
+      // Update the options on the first builder. This will set the options in
+      // the user's config file. All other builders will then reread the config
+      // file on their next build.
+      dicy.updateOptions(this.getDicyOptions(), true)
+    }
   }
 
   initializeBuild (filePath, allowCached = false) {

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -210,7 +210,7 @@ export default class Composer extends Disposable {
       const typeText = event.category ? `${event.category}: ` : ''
       const message = {
         type: event.severity,
-        text: `${nameText}${typeText}${event.text.replace('\n', ' ')}`
+        text: `${nameText}${typeText}${event.text}`
       }
 
       if (event.source) {

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -234,16 +234,17 @@ export default class Composer extends Disposable {
 
   getDicyOptions () {
     return _.pick(atom.config.get('latex'), [
+      'cleanPatterns',
       'customEngine',
-      'engine',
       'enableShellEscape',
       'enableSynctex',
+      'engine',
       'loggingLevel',
-      'cleanPatterns',
+      'moveResultToSourceDirectory',
       'outputDirectory',
       'outputFormat',
       'producer',
-      'moveResultToSourceDirectory'
+      'texPath'
     ])
   }
 

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -243,7 +243,6 @@ export default class Composer extends Disposable {
     // loggingLevel is sent even though it is set to info in getDiCy so that
     // any command line versions of DiCy have the same error reporting level.
     const options = _.pick(atom.config.get('latex'), [
-      'cleanPatterns',
       'customEngine',
       'enableShellEscape',
       'enableSynctex',
@@ -254,6 +253,16 @@ export default class Composer extends Disposable {
       'outputFormat',
       'producer'
     ])
+    const properties = {
+      output_dir: `\${OUTDIR}`,
+      jobname: `\${JOB}`,
+      name: `\${NAME}`,
+      ext: `\${OUTEXT}`
+    }
+    const cleanPatterns = atom.config.get('latex.cleanPatterns')
+
+    // Convert property expansion to DiCy's conventions
+    options.cleanPatterns = cleanPatterns.map(pattern => replacePropertiesInString(pattern, properties))
 
     const PATH = atom.config.get('latex.texPath').trim() || this.defaultTexPath(process.platform)
     if (PATH) options['$PATH'] = PATH

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -200,14 +200,14 @@ export default class Composer extends Disposable {
       if (event.source) {
         message.filePath = path.resolve(dicy.rootPath, event.source.file)
         if (event.source.start) {
-          message.range = [[event.source.start - 1, 0], [(event.source.end || event.source.start) - 1, 65535]]
+          message.range = [[event.source.start - 1, 0], [(event.source.end || event.source.start) - 1, Number.MAX_SAFE_INTEGER]]
         }
       }
 
       if (event.log) {
         message.logPath = path.resolve(dicy.rootPath, event.log.file)
         if (event.log.start) {
-          message.logRange = [[event.log.start - 1, 0], [(event.log.end || event.log.start) - 1, 65535]]
+          message.logRange = [[event.log.start - 1, 0], [(event.log.end || event.log.start) - 1, Number.MAX_SAFE_INTEGER]]
         }
       }
 

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -566,7 +566,7 @@ export default class Composer extends Disposable {
     return jobState.getMoveResultToSourceDirectory() && jobState.getOutputDirectory().length > 0
   }
 
-  shouldUseDiCy () { return atom.config.get('latex.enableDicy') }
+  shouldUseDiCy () { return atom.config.get('latex.builder') === 'dicy' }
 
   shouldOpenResult () { return atom.config.get('latex.openResultAfterBuild') }
 }

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -215,15 +215,15 @@ export default class Composer extends Disposable {
 
       if (event.source) {
         message.filePath = path.resolve(dicy.rootPath, event.source.file)
-        if (event.source.start) {
-          message.range = [[event.source.start - 1, 0], [(event.source.end || event.source.start) - 1, Number.MAX_SAFE_INTEGER]]
+        if (event.source.range) {
+          message.range = [[event.source.range.start - 1, 0], [event.source.range.end - 1, Number.MAX_SAFE_INTEGER]]
         }
       }
 
       if (event.log) {
         message.logPath = path.resolve(dicy.rootPath, event.log.file)
-        if (event.log.start) {
-          message.logRange = [[event.log.start - 1, 0], [(event.log.end || event.log.start) - 1, Number.MAX_SAFE_INTEGER]]
+        if (event.log.range) {
+          message.logRange = [[event.log.range.start - 1, 0], [event.log.range.end - 1, Number.MAX_SAFE_INTEGER]]
         }
       }
 

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -233,7 +233,9 @@ export default class Composer extends Disposable {
       latex.log.info(`[${event.rule}] Executing \`${event.command}\``)
     })
     .on('fileDeleted', event => {
-      latex.log.info(`Deleting \`${event.file}\``)
+      if (!event.virtual) {
+        latex.log.info(`Deleting \`${event.file}\``)
+      }
     })
 
     return dicy
@@ -250,8 +252,7 @@ export default class Composer extends Disposable {
       'loggingLevel',
       'moveResultToSourceDirectory',
       'outputDirectory',
-      'outputFormat',
-      'producer'
+      'outputFormat'
     ])
     const properties = {
       output_dir: `\${OUTDIR}`,
@@ -263,6 +264,11 @@ export default class Composer extends Disposable {
 
     // Convert property expansion to DiCy's conventions
     options.cleanPatterns = cleanPatterns.map(pattern => replacePropertiesInString(pattern, properties))
+
+    // DiCy manages intermediate PostScript production itself, without the
+    // wrapper dvipdf since it is not available on Windows.
+    const producer = atom.config.get('latex.producer')
+    options.intermediatePostScript = producer === 'dvipdf' || producer === 'ps2pdf'
 
     const PATH = atom.config.get('latex.texPath').trim() || this.defaultTexPath(process.platform)
     if (PATH) options['$PATH'] = PATH

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -3,7 +3,7 @@
 import _ from 'lodash'
 import fs from 'fs-plus'
 import path from 'path'
-import { Dicy } from '@dicy/core'
+import { DiCy } from '@dicy/core'
 import { getEditorDetails, isDviFile, isPdfFile, isPsFile, replacePropertiesInString } from './werkzeug'
 import minimatch from 'minimatch'
 import glob from 'glob'
@@ -15,7 +15,7 @@ import MagicParser from './parsers/magic-parser'
 export default class Composer extends Disposable {
   disposables = new CompositeDisposable()
   cachedBuildStates = new Map()
-  cachedDicy = new Map()
+  cachedDiCy = new Map()
 
   constructor () {
     super(() => this.disposables.dispose())
@@ -27,13 +27,13 @@ export default class Composer extends Disposable {
     // next build.
     this.rebuildCompleted = new Set()
 
-    // Get the first cached Dicy builder
-    const dicy = this.cachedDicy.values().next().value
+    // Get the first cached DiCy builder
+    const dicy = this.cachedDiCy.values().next().value
     if (dicy) {
       // Update the options on the first builder. This will set the options in
       // the user's config file. All other builders will then reread the config
       // file on their next build.
-      dicy.updateOptions(this.getDicyOptions(), true)
+      dicy.updateOptions(this.getDiCyOptions(), true)
     }
   }
 
@@ -177,7 +177,7 @@ export default class Composer extends Disposable {
     }
   }
 
-  async getDicy (filePath, options = {}) {
+  async getDiCy (filePath, options = {}) {
     const magic = new MagicParser(filePath).parse()
     if (magic.root) {
       filePath = path.resolve(path.dirname(filePath), magic.root)
@@ -190,20 +190,20 @@ export default class Composer extends Disposable {
     options.severity = 'info'
 
     if (!options.ignoreCache) {
-      dicy = this.cachedDicy.get(filePath)
+      dicy = this.cachedDiCy.get(filePath)
       if (dicy) {
         // dicy.setInstanceOptions(options)
         return dicy
       }
     }
 
-    dicy = await Dicy.create(filePath, options)
-    if (this.cachedDicy.size === 0) {
-      // This is the first Dicy builder so make sure the user options
+    dicy = await DiCy.create(filePath, options)
+    if (this.cachedDiCy.size === 0) {
+      // This is the first DiCy builder so make sure the user options
       // are synchronized.
-      dicy.updateOptions(this.getDicyOptions(), true)
+      dicy.updateOptions(this.getDiCyOptions(), true)
     }
-    this.cachedDicy.set(filePath, dicy)
+    this.cachedDiCy.set(filePath, dicy)
 
     dicy.on('log', event => {
       const nameText = event.name ? `[${event.name}] ` : ''
@@ -239,9 +239,9 @@ export default class Composer extends Disposable {
     return dicy
   }
 
-  getDicyOptions () {
-    // loggingLevel is sent even though it is set to info in getDicy so that
-    // any command line versions of Dicy have the same error reporting level.
+  getDiCyOptions () {
+    // loggingLevel is sent even though it is set to info in getDiCy so that
+    // any command line versions of DiCy have the same error reporting level.
     return _.pick(atom.config.get('latex'), [
       'cleanPatterns',
       'customEngine',
@@ -257,9 +257,9 @@ export default class Composer extends Disposable {
     ])
   }
 
-  async runDicy (commands, options = {}, openResults = true, clearLog = false) {
+  async runDiCy (commands, options = {}, openResults = true, clearLog = false) {
     const { filePath, lineNumber } = getEditorDetails()
-    const dicy = await this.getDicy(filePath, options)
+    const dicy = await this.getDiCy(filePath, options)
 
     if (clearLog) latex.log.clear()
     latex.status.setBusy()
@@ -293,8 +293,8 @@ export default class Composer extends Disposable {
       editor.save() // TODO: Make this configurable?
     }
 
-    if (this.shouldUseDicy()) {
-      return this.runDicy(['load', 'build', 'log', 'save'], { ignoreCache: shouldRebuild },
+    if (this.shouldUseDiCy()) {
+      return this.runDiCy(['load', 'build', 'log', 'save'], { ignoreCache: shouldRebuild },
         this.shouldOpenResult(), true)
     }
 
@@ -343,7 +343,7 @@ export default class Composer extends Disposable {
   kill () {
     latex.process.killChildProcesses()
 
-    for (const dicy of this.cachedDicy.values()) {
+    for (const dicy of this.cachedDiCy.values()) {
       dicy.killChildProcesses()
     }
   }
@@ -354,8 +354,8 @@ export default class Composer extends Disposable {
       return
     }
 
-    if (this.shouldUseDicy()) {
-      return this.runDicy(['load'])
+    if (this.shouldUseDiCy()) {
+      return this.runDiCy(['load'])
     }
 
     const { builder, state } = this.initializeBuild(filePath, true)
@@ -382,8 +382,8 @@ export default class Composer extends Disposable {
       return false
     }
 
-    if (this.shouldUseDicy()) {
-      return this.runDicy(['load', 'clean', 'save'], {}, false, true)
+    if (this.shouldUseDiCy()) {
+      return this.runDiCy(['load', 'clean', 'save'], {}, false, true)
     }
 
     const { builder, state } = this.initializeBuild(filePath, true)
@@ -533,7 +533,7 @@ export default class Composer extends Disposable {
     return jobState.getMoveResultToSourceDirectory() && jobState.getOutputDirectory().length > 0
   }
 
-  shouldUseDicy () { return atom.config.get('latex.enableDicy') }
+  shouldUseDiCy () { return atom.config.get('latex.enableDicy') }
 
   shouldOpenResult () { return atom.config.get('latex.openResultAfterBuild') }
 }

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -274,7 +274,7 @@ export default class Composer extends Disposable {
   }
 
   async build (shouldRebuild) {
-    latex.process.killChildProcesses()
+    this.kill()
 
     const { editor, filePath } = getEditorDetails()
 
@@ -331,6 +331,14 @@ export default class Composer extends Disposable {
       }
     } catch (error) {
       latex.log.error(error.message)
+    }
+  }
+
+  kill () {
+    latex.process.killChildProcesses()
+
+    for (const dicy of this.cachedDicy.values()) {
+      dicy.killChildProcesses()
     }
   }
 

--- a/lib/config-migrator.js
+++ b/lib/config-migrator.js
@@ -14,9 +14,10 @@ export default function checkConfigAndMigrate () {
 
 function checkBuilder () {
   const builder = atom.config.get('latex.builder')
-  if (builder !== 'texify') return
+  if (!builder) return
 
-  atom.config.set('latex.builder', 'latexmk')
+  atom.config.unset('latex.builder')
+  if (builder !== 'texify') return
 
   // --------------------------------------------------
   // TODO: Remove this whole block after a grace period

--- a/lib/config-migrator.js
+++ b/lib/config-migrator.js
@@ -14,10 +14,9 @@ export default function checkConfigAndMigrate () {
 
 function checkBuilder () {
   const builder = atom.config.get('latex.builder')
-  if (!builder) return
-
-  atom.config.unset('latex.builder')
   if (builder !== 'texify') return
+
+  atom.config.set('latex.builder', 'latexmk')
 
   // --------------------------------------------------
   // TODO: Remove this whole block after a grace period

--- a/lib/main.js
+++ b/lib/main.js
@@ -16,7 +16,7 @@ export default {
       'latex:clean': () => latex.composer.clean(),
       'latex:clear-log': () => latex.log.clear(),
       'latex:hide-log': () => latex.log.hide(),
-      'latex:kill': () => latex.process.killChildProcesses(),
+      'latex:kill': () => latex.composer.kill(),
       'latex:rebuild': () => latex.composer.build(true),
       'latex:show-log': () => latex.log.show(),
       'latex:sync-log': () => latex.log.sync(),

--- a/lib/parsers/log-parser.js
+++ b/lib/parsers/log-parser.js
@@ -67,7 +67,7 @@ export default class LogParser extends Parser {
           type: 'error',
           text: (match[3] && match[3] !== 'LaTeX') ? match[3] + ': ' + match[4] : match[4],
           filePath: match[1] ? path.resolve(this.projectPath, match[1]) : this.texFilePath,
-          range: lineNumber ? [[lineNumber - 1, 0], [lineNumber - 1, 65536]] : undefined,
+          range: lineNumber ? [[lineNumber - 1, 0], [lineNumber - 1, Number.MAX_SAFE_INTEGER]] : undefined,
           logPath: this.filePath,
           logRange: logRange
         })
@@ -80,7 +80,7 @@ export default class LogParser extends Parser {
           type: 'warning',
           text: match[1],
           filePath: this.texFilePath,
-          range: [[parseInt(match[2], 10) - 1, 0], [parseInt(match[3], 10) - 1, 65536]],
+          range: [[parseInt(match[2], 10) - 1, 0], [parseInt(match[3], 10) - 1, Number.MAX_SAFE_INTEGER]],
           logPath: this.filePath,
           logRange: logRange
         })
@@ -94,7 +94,7 @@ export default class LogParser extends Parser {
           type: match[2].toLowerCase(),
           text: ((match[1] !== 'LaTeX') ? match[1] + ': ' + match[3] : match[3]).replace(/\s+/g, ' '),
           filePath: this.texFilePath,
-          range: lineNumber ? [[lineNumber - 1, 0], [lineNumber - 1, 65536]] : undefined,
+          range: lineNumber ? [[lineNumber - 1, 0], [lineNumber - 1, Number.MAX_SAFE_INTEGER]] : undefined,
           logPath: this.filePath,
           logRange: logRange
         })

--- a/lib/views/log-message.js
+++ b/lib/views/log-message.js
@@ -18,11 +18,13 @@ export default class LogMessage {
 
   render () {
     const message = this.properties.message
+    console.log(message.text)
+    const lines = message.text.split('\n').map(line => (<div>{line}</div>))
 
     return (
       <tr className={this.getClassNames(message)}>
         <td><MessageIcon type={message.type} /></td>
-        <td>{message.text}</td>
+        <td>{lines}</td>
         <td><FileReference file={message.filePath} range={message.range} /></td>
         <td><FileReference file={message.logPath} range={message.logRange} /></td>
       </tr>

--- a/lib/views/log-message.js
+++ b/lib/views/log-message.js
@@ -18,7 +18,6 @@ export default class LogMessage {
 
   render () {
     const message = this.properties.message
-    console.log(message.text)
     const lines = message.text.split('\n').map(line => (<div>{line}</div>))
 
     return (

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "main": "./lib/main",
   "repository": "https://github.com/thomasjo/atom-latex",
   "dependencies": {
-    "@dicy/core": "^0.2.0",
+    "@dicy/core": "^0.3.0",
     "dbus-native": "^0.2.1",
     "etch": "0.12.4",
     "fs-plus": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "main": "./lib/main",
   "repository": "https://github.com/thomasjo/atom-latex",
   "dependencies": {
-    "@dicy/core": "^0.6.0",
+    "@dicy/core": "^0.7.0",
     "dbus-native": "^0.2.1",
     "etch": "0.12.4",
     "fs-plus": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "main": "./lib/main",
   "repository": "https://github.com/thomasjo/atom-latex",
   "dependencies": {
-    "@dicy/core": "^0.4.0",
+    "@dicy/core": "^0.5.0",
     "dbus-native": "^0.2.1",
     "etch": "0.12.4",
     "fs-plus": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
       "order": 5
     },
     "useDicy": {
+      "title": "Use DiCy",
       "description": "Use the experimental javascript based builder [`DiCy`](https://yitzchak.github.io/dicy/) instead of `latexmk`. [`DiCy`](https://yitzchak.github.io/dicy/) is included with this package so no further configuration or installation is required.",
       "type": "boolean",
       "default": "false",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "main": "./lib/main",
   "repository": "https://github.com/thomasjo/atom-latex",
   "dependencies": {
-    "@dicy/core": "^0.3.0",
+    "@dicy/core": "^0.3.1",
     "dbus-native": "^0.2.1",
     "etch": "0.12.4",
     "fs-plus": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -117,10 +117,14 @@
       "default": true,
       "order": 5
     },
-    "enableDicy": {
-      "description": "Enable the usage of the [DiCy](https://yitzchak.github.io/dicy/) builder instead of `latexmk`.",
-      "type": "boolean",
-      "default": "false",
+    "builder": {
+      "description": "Program to use for building LaTeX documents. Permitted builders include [latexmk](http://personal.psu.edu/jcc8/latexmk/) or [DiCy](https://yitzchak.github.io/dicy/).",
+      "type": "string",
+      "enum": [
+        "latexmk",
+        "dicy"
+      ],
+      "default": "latexmk",
       "order": 6
     },
     "enableExtendedBuildMode": {

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
       "order": 5
     },
     "enableDicy": {
-      "description": "Enable the usage of the experimental [Dicy](https://yitzchak.github.io/dicy/) builder instead of `latexmk`.",
+      "description": "Enable the usage of the [DiCy](https://yitzchak.github.io/dicy/) builder instead of `latexmk`.",
       "type": "boolean",
       "default": "false",
       "order": 6

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "main": "./lib/main",
   "repository": "https://github.com/thomasjo/atom-latex",
   "dependencies": {
+    "@dicy/core": "^0.1.0",
     "dbus-native": "^0.2.1",
     "etch": "0.12.4",
     "fs-plus": "^3.0.0",
@@ -116,11 +117,17 @@
       "default": true,
       "order": 5
     },
+    "enableDicy": {
+      "description": "Enable the usage of the experimental [Dicy](https://yitzchak.github.io/dicy/) builder instead of `latexmk`.",
+      "type": "boolean",
+      "default": "false",
+      "order": 6
+    },
     "enableExtendedBuildMode": {
       "description": "Enable extended build mode using `latexmk` rules for custom files types. Currently includes support for Asymptote, the `glossaries` package, the `index` package, MetaPost, the `nomencl` package and SageTeX. Please note that these rules are loaded after all other `latexmkrc` files are loaded, and therefore may overwrite custom rules defined by the user.",
       "type": "boolean",
       "default": true,
-      "order": 6
+      "order": 7
     },
     "loggingLevel": {
       "description": "The minimum level of message severity to output in the logger. A logging level of `error` shows only messages indicating catastrophic issues such as undefined symbols, `warning` shows error messages and messages indicating unintended consequences such as bad boxes, and `info` shows all messages including purely informational messages such a font loading.",
@@ -131,7 +138,7 @@
         "info"
       ],
       "default": "warning",
-      "order": 7
+      "order": 8
     },
     "cleanPatterns": {
       "description": "The files and directories to remove during a LaTeX clean. Basic glob patterns are understood and named properties such as {jobname} are replaced with the current build properties. Patterns that start with `/` or `\\` are matched against any file in the same directory as the source file. All other patterns are matched against generated files in the output directory. More information can be found on the Atom LaTeX wiki.",
@@ -169,13 +176,13 @@
         "/texput.log",
         "/texput.aux"
       ],
-      "order": 8
+      "order": 9
     },
     "outputDirectory": {
       "description": "All files generated during a build will be redirected here. Leave blank if you want the build output to be stored in the same directory as the TeX document.",
       "type": "string",
       "default": "",
-      "order": 9
+      "order": 10
     },
     "outputFormat": {
       "description": "Output file format. DVI and PS currently only supported for latexmk.",
@@ -186,7 +193,7 @@
         "ps"
       ],
       "default": "pdf",
-      "order": 10
+      "order": 11
     },
     "producer": {
       "title": "PDF Producer",
@@ -199,33 +206,33 @@
         "ps2pdf"
       ],
       "default": "dvipdfmx",
-      "order": 11
+      "order": 12
     },
     "moveResultToSourceDirectory": {
       "title": "Move Result to Source Directory",
       "description": "Ensures that the output file produced by a successful build is stored together with the TeX document that produced it.",
       "type": "boolean",
       "default": true,
-      "order": 12
+      "order": 13
     },
     "buildOnSave": {
       "title": "Build on Save",
       "description": "Automatically run builds when files are saved.",
       "type": "boolean",
       "default": false,
-      "order": 13
+      "order": 14
     },
     "openResultAfterBuild": {
       "title": "Open Result after Successful Build",
       "type": "boolean",
       "default": true,
-      "order": 14
+      "order": 15
     },
     "openResultInBackground": {
       "title": "Open Result in Background",
       "type": "boolean",
       "default": true,
-      "order": 15
+      "order": 16
     },
     "opener": {
       "type": "string",
@@ -245,39 +252,39 @@
         "custom"
       ],
       "default": "automatic",
-      "order": 16
+      "order": 17
     },
     "skimPath": {
       "description": "Full application path to Skim (macOS).",
       "type": "string",
       "default": "/Applications/Skim.app",
-      "order": 17
+      "order": 18
     },
     "sumatraPath": {
       "title": "SumatraPDF Path",
       "description": "Full application path to SumatraPDF (Windows).",
       "type": "string",
       "default": "C:\\Program Files (x86)\\SumatraPDF\\SumatraPDF.exe",
-      "order": 18
+      "order": 19
     },
     "okularPath": {
       "description": "Full application path to Okular (*nix).",
       "type": "string",
       "default": "/usr/bin/okular",
-      "order": 19
+      "order": 20
     },
     "zathuraPath": {
       "description": "Full application path to Zathura (*nix).",
       "type": "string",
       "default": "/usr/bin/zathura",
-      "order": 20
+      "order": 21
     },
     "viewerPath": {
       "title": "Custom PDF Viewer Path",
       "description": "Full application path to your PDF viewer. Overrides Skim and SumatraPDF options.",
       "type": "string",
       "default": "",
-      "order": 21
+      "order": 22
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -117,14 +117,10 @@
       "default": true,
       "order": 5
     },
-    "builder": {
-      "description": "Program to use for building LaTeX documents. Permitted builders include [latexmk](http://personal.psu.edu/jcc8/latexmk/) or [DiCy](https://yitzchak.github.io/dicy/).",
-      "type": "string",
-      "enum": [
-        "latexmk",
-        "dicy"
-      ],
-      "default": "latexmk",
+    "useDicy": {
+      "description": "Use the experimental javascript based builder [`DiCy`](https://yitzchak.github.io/dicy/) instead of `latexmk`. [`DiCy`](https://yitzchak.github.io/dicy/) is included with this package so no further configuration or installation is required.",
+      "type": "boolean",
+      "default": "false",
       "order": 6
     },
     "enableExtendedBuildMode": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "main": "./lib/main",
   "repository": "https://github.com/thomasjo/atom-latex",
   "dependencies": {
-    "@dicy/core": "^0.3.1",
+    "@dicy/core": "^0.4.0",
     "dbus-native": "^0.2.1",
     "etch": "0.12.4",
     "fs-plus": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "main": "./lib/main",
   "repository": "https://github.com/thomasjo/atom-latex",
   "dependencies": {
-    "@dicy/core": "^0.5.0",
+    "@dicy/core": "^0.6.0",
     "dbus-native": "^0.2.1",
     "etch": "0.12.4",
     "fs-plus": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "main": "./lib/main",
   "repository": "https://github.com/thomasjo/atom-latex",
   "dependencies": {
-    "@dicy/core": "^0.1.0",
+    "@dicy/core": "^0.2.0",
     "dbus-native": "^0.2.1",
     "etch": "0.12.4",
     "fs-plus": "^3.0.0",

--- a/script/install-knitr
+++ b/script/install-knitr
@@ -29,7 +29,7 @@ install_knitr() {
     [[ ! -d "${R_LIBS_USER}" ]] && mkdir -p "${R_LIBS_USER}"
 
     echo "Installing knitr..."
-    Rscript -e "install.packages('knitr', 'patchSynctex', repos = 'http://cran.r-project.org')"
+    Rscript -e "install.packages(c('knitr', 'patchSynctex'), repos = 'http://cran.r-project.org')"
   else
     echo "Using cached installation of knitr"
   fi

--- a/script/install-knitr
+++ b/script/install-knitr
@@ -24,12 +24,12 @@ install_knitr() {
   ensure_r_installed
 
   # Check if we need to install Knitr.
-  if ! Rscript -e "library(knitr)" &> /dev/null; then
+  if ! Rscript -e "library(knitr); library(patchSynctex)" &> /dev/null; then
     # Make sure the R_LIBS_USER directory exists to make R happy.
     [[ ! -d "${R_LIBS_USER}" ]] && mkdir -p "${R_LIBS_USER}"
 
     echo "Installing knitr..."
-    Rscript -e "install.packages('knitr', repos = 'http://cran.r-project.org')"
+    Rscript -e "install.packages('knitr', 'patchSynctex', repos = 'http://cran.r-project.org')"
   else
     echo "Using cached installation of knitr"
   fi

--- a/spec/composer-spec.js
+++ b/spec/composer-spec.js
@@ -34,7 +34,6 @@ describe('Composer', () => {
 
       spyOn(composer, 'runDicy').andCallThrough()
       spyOn(latex.opener, 'open')
-      spyOn(latex.log, 'showMessage')
     }
 
     beforeEach(() => {
@@ -182,7 +181,7 @@ describe('Composer', () => {
       runs(() => {
         expect(composer.runDicy).toHaveBeenCalled()
         expect(latex.opener.open).toHaveBeenCalledWith(targetPath, filePath, 1)
-        expect(latex.log.showMessage).not.toHaveBeenCalled()
+        expect(latex.log.getMessages().length).toBe(0)
       })
     })
 
@@ -200,7 +199,7 @@ describe('Composer', () => {
       runs(() => {
         expect(composer.runDicy).toHaveBeenCalled()
         expect(latex.opener.open).toHaveBeenCalledWith(targetPath, filePath, 1)
-        expect(latex.log.showMessage).not.toHaveBeenCalled()
+        expect(latex.log.getMessages().length).toBe(0)
       })
     })
 
@@ -217,7 +216,7 @@ describe('Composer', () => {
       runs(() => {
         expect(composer.runDicy).toHaveBeenCalled()
         expect(latex.opener.open).not.toHaveBeenCalled()
-        expect(latex.log.showMessage).toHaveBeenCalled()
+        expect(latex.log.getMessages().length).not.toBe(0)
       })
     })
   })

--- a/spec/composer-spec.js
+++ b/spec/composer-spec.js
@@ -737,7 +737,7 @@ describe('Composer', () => {
       let result
 
       waitsForPromise(() =>
-        composer.getDicy(rootFilePath)
+        composer.getDicy(subFilePath)
           .then(dicy => { result = dicy })
       )
 

--- a/spec/composer-spec.js
+++ b/spec/composer-spec.js
@@ -219,6 +219,24 @@ describe('Composer', () => {
         expect(latex.log.getMessages().length).not.toBe(0)
       })
     })
+
+    it('successfully builds knitr file using DiCy', () => {
+      const filePath = path.join(fixturesPath, 'knitr', 'file.Rnw')
+      const targetPath = path.join(fixturesPath, 'knitr', 'file.pdf')
+
+      initializeSpies(filePath)
+      atom.config.set('latex.enableDicy', true)
+
+      waitsForPromise(() => {
+        return composer.build().catch(r => r)
+      })
+
+      runs(() => {
+        expect(composer.runDiCy).toHaveBeenCalled()
+        expect(latex.opener.open).toHaveBeenCalledWith(targetPath, filePath, 1)
+        expect(latex.log.getMessages()).toEqual([])
+      })
+    })
   })
 
   describe('clean', () => {

--- a/spec/composer-spec.js
+++ b/spec/composer-spec.js
@@ -32,7 +32,7 @@ describe('Composer', () => {
       })
       spyOn(latex.builderRegistry, 'getBuilder').andReturn(builder)
 
-      spyOn(composer, 'runDicy').andCallThrough()
+      spyOn(composer, 'runDiCy').andCallThrough()
       spyOn(latex.opener, 'open')
     }
 
@@ -167,7 +167,7 @@ describe('Composer', () => {
       })
     })
 
-    it('successfully builds LaTeX file using Dicy', () => {
+    it('successfully builds LaTeX file using DiCy', () => {
       const filePath = path.join(fixturesPath, 'file.tex')
       const targetPath = path.join(fixturesPath, 'file.pdf')
 
@@ -179,13 +179,13 @@ describe('Composer', () => {
       })
 
       runs(() => {
-        expect(composer.runDicy).toHaveBeenCalled()
+        expect(composer.runDiCy).toHaveBeenCalled()
         expect(latex.opener.open).toHaveBeenCalledWith(targetPath, filePath, 1)
         expect(latex.log.getMessages().length).toBe(0)
       })
     })
 
-    it('successfully executes Dicy when given a file path containing spaces', () => {
+    it('successfully executes DiCy when given a file path containing spaces', () => {
       const filePath = path.join(fixturesPath, 'filename with spaces.tex')
       const targetPath = path.join(fixturesPath, 'filename with spaces.pdf')
 
@@ -197,13 +197,13 @@ describe('Composer', () => {
       })
 
       runs(() => {
-        expect(composer.runDicy).toHaveBeenCalled()
+        expect(composer.runDiCy).toHaveBeenCalled()
         expect(latex.opener.open).toHaveBeenCalledWith(targetPath, filePath, 1)
         expect(latex.log.getMessages().length).toBe(0)
       })
     })
 
-    it('fails to produce target when error messages are generated using Dicy', () => {
+    it('fails to produce target when error messages are generated using DiCy', () => {
       const filePath = path.join(fixturesPath, 'error-warning.tex')
 
       initializeSpies(filePath)
@@ -214,7 +214,7 @@ describe('Composer', () => {
       })
 
       runs(() => {
-        expect(composer.runDicy).toHaveBeenCalled()
+        expect(composer.runDiCy).toHaveBeenCalled()
         expect(latex.opener.open).not.toHaveBeenCalled()
         expect(latex.log.getMessages().length).not.toBe(0)
       })
@@ -763,12 +763,12 @@ describe('Composer', () => {
     })
   })
 
-  describe('getDicy', () => {
+  describe('getDiCy', () => {
     let composer, fixturesPath, rootBaseName, subFileBaseName, rootFilePath, subFilePath
 
     beforeEach(() => {
       composer = new Composer()
-      spyOn(composer, 'shouldUseDicy').andReturn(true)
+      spyOn(composer, 'shouldUseDiCy').andReturn(true)
       fixturesPath = path.join(__dirname, 'fixtures')
       rootBaseName = 'file.tex'
       rootFilePath = path.join(fixturesPath, rootBaseName)
@@ -776,11 +776,11 @@ describe('Composer', () => {
       subFilePath = path.join(fixturesPath, 'magic-comments', subFileBaseName)
     })
 
-    it('verifies that Dicy builder is created for a simple file', () => {
+    it('verifies that DiCy builder is created for a simple file', () => {
       let result
 
       waitsForPromise(() =>
-        composer.getDicy(rootFilePath)
+        composer.getDiCy(rootFilePath)
           .then(dicy => { result = dicy })
       )
 
@@ -794,7 +794,7 @@ describe('Composer', () => {
       let result
 
       waitsForPromise(() =>
-        composer.getDicy(subFilePath)
+        composer.getDiCy(subFilePath)
           .then(dicy => { result = dicy })
       )
 
@@ -803,13 +803,13 @@ describe('Composer', () => {
       })
     })
 
-    it('verifies that Dicy builder is cached', () => {
+    it('verifies that DiCy builder is cached', () => {
       let firstResult, secondResult
 
       waitsForPromise(() =>
-        composer.getDicy(rootFilePath)
+        composer.getDiCy(rootFilePath)
           .then(dicy => { firstResult = dicy })
-          .then(() => composer.getDicy(rootFilePath))
+          .then(() => composer.getDiCy(rootFilePath))
           .then(dicy => { secondResult = dicy })
       )
 
@@ -819,13 +819,13 @@ describe('Composer', () => {
       })
     })
 
-    it('verifies that Dicy builder is not cached if ignoreCache is enabled', () => {
+    it('verifies that DiCy builder is not cached if ignoreCache is enabled', () => {
       let firstResult, secondResult
 
       waitsForPromise(() =>
-        composer.getDicy(rootFilePath)
+        composer.getDiCy(rootFilePath)
           .then(dicy => { firstResult = dicy })
-          .then(() => composer.getDicy(rootFilePath, { ignoreCache: true }))
+          .then(() => composer.getDiCy(rootFilePath, { ignoreCache: true }))
           .then(dicy => { secondResult = dicy })
       )
 
@@ -837,7 +837,7 @@ describe('Composer', () => {
     })
   })
 
-  describe('runDicy', () => {
+  describe('runDiCy', () => {
     const sourceBaseName = 'file.tex'
     const outputBaseName = 'file.pdf'
     const synctexBaseName = 'file.synctex.gz'
@@ -850,14 +850,14 @@ describe('Composer', () => {
     })
 
     function initializeSpies (result = true) {
-      dicy = jasmine.createSpyObj('MockDicy', ['run', 'getTargetPaths'])
+      dicy = jasmine.createSpyObj('MockDiCy', ['run', 'getTargetPaths'])
       dicy.run.andCallFake(() => Promise.resolve(result))
       dicy.getTargetPaths.andCallFake(() => Promise.resolve([outputBaseName, synctexBaseName]))
       dicy.rootPath = fixturesPath
       sourcePath = path.join(fixturesPath, sourceBaseName)
       outputPath = path.join(fixturesPath, outputBaseName)
       synctexPath = path.join(fixturesPath, synctexBaseName)
-      spyOn(composer, 'getDicy').andCallFake(() => Promise.resolve(dicy))
+      spyOn(composer, 'getDiCy').andCallFake(() => Promise.resolve(dicy))
       spyOn(werkzeug, 'getEditorDetails').andReturn({ filePath: sourcePath, lineNumber: 1 })
       spyOn(latex.opener, 'open').andCallFake(() => Promise.resolve(true))
     }
@@ -865,7 +865,7 @@ describe('Composer', () => {
     it('opens PDF after successful build, but does open SyncTeX file', () => {
       initializeSpies()
 
-      waitsForPromise(() => composer.runDicy(['build']))
+      waitsForPromise(() => composer.runDiCy(['build']))
 
       runs(() => {
         expect(latex.opener.open).toHaveBeenCalledWith(outputPath, sourcePath, 1)
@@ -876,7 +876,7 @@ describe('Composer', () => {
     it('does not open targets after unsuccessful build', () => {
       initializeSpies(false)
 
-      waitsForPromise(() => composer.runDicy(['build']))
+      waitsForPromise(() => composer.runDiCy(['build']))
 
       runs(() => {
         expect(latex.opener.open).not.toHaveBeenCalled()
@@ -886,7 +886,7 @@ describe('Composer', () => {
     it('does not open targets after successful build if open is not requested', () => {
       initializeSpies(true)
 
-      waitsForPromise(() => composer.runDicy(['build'], {}, false))
+      waitsForPromise(() => composer.runDiCy(['build'], {}, false))
 
       runs(() => {
         expect(latex.opener.open).not.toHaveBeenCalled()

--- a/spec/composer-spec.js
+++ b/spec/composer-spec.js
@@ -181,7 +181,7 @@ describe('Composer', () => {
       runs(() => {
         expect(composer.runDiCy).toHaveBeenCalled()
         expect(latex.opener.open).toHaveBeenCalledWith(targetPath, filePath, 1)
-        expect(latex.log.getMessages().length).toBe(0)
+        expect(latex.log.getMessages()).toEqual([])
       })
     })
 
@@ -199,7 +199,7 @@ describe('Composer', () => {
       runs(() => {
         expect(composer.runDiCy).toHaveBeenCalled()
         expect(latex.opener.open).toHaveBeenCalledWith(targetPath, filePath, 1)
-        expect(latex.log.getMessages().length).toBe(0)
+        expect(latex.log.getMessages()).toEqual([])
       })
     })
 

--- a/spec/composer-spec.js
+++ b/spec/composer-spec.js
@@ -173,7 +173,7 @@ describe('Composer', () => {
       const targetPath = path.join(fixturesPath, 'file.pdf')
 
       initializeSpies(filePath)
-      atom.config.set('latex.enableDicy', true)
+      atom.config.set('latex.builder', 'dicy')
 
       waitsForPromise(() => {
         return composer.build().catch(r => r)
@@ -191,7 +191,7 @@ describe('Composer', () => {
       const targetPath = path.join(fixturesPath, 'filename with spaces.pdf')
 
       initializeSpies(filePath)
-      atom.config.set('latex.enableDicy', true)
+      atom.config.set('latex.builder', 'dicy')
 
       waitsForPromise(() => {
         return composer.build().catch(r => r)
@@ -208,7 +208,7 @@ describe('Composer', () => {
       const filePath = path.join(fixturesPath, 'error-warning.tex')
 
       initializeSpies(filePath)
-      atom.config.set('latex.enableDicy', true)
+      atom.config.set('latex.builder', 'dicy')
 
       waitsForPromise(() => {
         return composer.build().catch(r => r)
@@ -226,7 +226,7 @@ describe('Composer', () => {
       const targetPath = path.join(fixturesPath, 'knitr', 'file.pdf')
 
       initializeSpies(filePath)
-      atom.config.set('latex.enableDicy', true)
+      atom.config.set('latex.builder', 'dicy')
 
       waitsForPromise(() => {
         return composer.build().catch(r => r)

--- a/spec/composer-spec.js
+++ b/spec/composer-spec.js
@@ -705,4 +705,78 @@ describe('Composer', () => {
       expect(composer.resolveOutputFilePath(builder, jobState)).toEqual(outputFilePath)
     })
   })
+
+  describe('getDicy', () => {
+    let composer, fixturesPath, rootBaseName, subFileBaseName, rootFilePath, subFilePath
+
+    beforeEach(() => {
+      composer = new Composer()
+      spyOn(composer, 'shouldUseDicy').andReturn(true)
+      fixturesPath = path.join(__dirname, 'fixtures')
+      rootBaseName = 'file.tex'
+      rootFilePath = path.join(fixturesPath, rootBaseName)
+      subFileBaseName = 'root-comment.tex'
+      subFilePath = path.join(fixturesPath, 'magic-comments', subFileBaseName)
+    })
+
+    it('verifies that Dicy builder is created for a simple file', () => {
+      let result
+
+      waitsForPromise(() =>
+        composer.getDicy(rootFilePath)
+          .then(dicy => { result = dicy })
+      )
+
+      runs(() => {
+        expect(result).toBeDefined()
+        expect(result.filePath).toEqual(rootBaseName)
+      })
+    })
+
+    it('verifies that root magic comment is detected', () => {
+      let result
+
+      waitsForPromise(() =>
+        composer.getDicy(rootFilePath)
+          .then(dicy => { result = dicy })
+      )
+
+      runs(() => {
+        expect(result).toBeDefined()
+      })
+    })
+
+    it('verifies that Dicy builder is cached', () => {
+      let firstResult, secondResult
+
+      waitsForPromise(() =>
+        composer.getDicy(rootFilePath)
+          .then(dicy => { firstResult = dicy })
+          .then(() => composer.getDicy(rootFilePath))
+          .then(dicy => { secondResult = dicy })
+      )
+
+      runs(() => {
+        expect(firstResult).toBeDefined()
+        expect(secondResult).toBe(firstResult)
+      })
+    })
+
+    it('verifies that Dicy builder is not cached if ignoreCache is enabled', () => {
+      let firstResult, secondResult
+
+      waitsForPromise(() =>
+        composer.getDicy(rootFilePath)
+          .then(dicy => { firstResult = dicy })
+          .then(() => composer.getDicy(rootFilePath, { ignoreCache: true }))
+          .then(dicy => { secondResult = dicy })
+      )
+
+      runs(() => {
+        expect(firstResult).toBeDefined()
+        expect(secondResult).toBeDefined()
+        expect(secondResult).not.toBe(firstResult)
+      })
+    })
+  })
 })

--- a/spec/composer-spec.js
+++ b/spec/composer-spec.js
@@ -173,7 +173,7 @@ describe('Composer', () => {
       const targetPath = path.join(fixturesPath, 'file.pdf')
 
       initializeSpies(filePath)
-      atom.config.set('latex.builder', 'dicy')
+      atom.config.set('latex.useDicy', true)
 
       waitsForPromise(() => {
         return composer.build().catch(r => r)
@@ -191,7 +191,7 @@ describe('Composer', () => {
       const targetPath = path.join(fixturesPath, 'filename with spaces.pdf')
 
       initializeSpies(filePath)
-      atom.config.set('latex.builder', 'dicy')
+      atom.config.set('latex.useDicy', true)
 
       waitsForPromise(() => {
         return composer.build().catch(r => r)
@@ -208,7 +208,7 @@ describe('Composer', () => {
       const filePath = path.join(fixturesPath, 'error-warning.tex')
 
       initializeSpies(filePath)
-      atom.config.set('latex.builder', 'dicy')
+      atom.config.set('latex.useDicy', true)
 
       waitsForPromise(() => {
         return composer.build().catch(r => r)
@@ -226,7 +226,7 @@ describe('Composer', () => {
       const targetPath = path.join(fixturesPath, 'knitr', 'file.pdf')
 
       initializeSpies(filePath)
-      atom.config.set('latex.builder', 'dicy')
+      atom.config.set('latex.useDicy', true)
 
       waitsForPromise(() => {
         return composer.build().catch(r => r)

--- a/spec/composer-spec.js
+++ b/spec/composer-spec.js
@@ -41,6 +41,7 @@ describe('Composer', () => {
       spyOn(composer, 'showResult').andReturn()
       spyOn(composer, 'showError').andReturn()
       fixturesPath = helpers.cloneFixtures()
+      atom.config.set('latex.loggingLevel', 'error')
     })
 
     it('does nothing for new, unsaved files', () => {

--- a/spec/parsers/log-parser-spec.js
+++ b/spec/parsers/log-parser-spec.js
@@ -54,7 +54,7 @@ describe('LogParser', () => {
         type: 'error',
         logRange: [[196, 0], [196, 84]],
         filePath: texFile,
-        range: [[9, 0], [9, 65536]],
+        range: [[9, 0], [9, Number.MAX_SAFE_INTEGER]],
         logPath: logFile,
         text: '\\begin{gather*} on input line 8 ended by \\end{gather}'
       })


### PR DESCRIPTION
Add support for [DiCy](https://yitzchak.github.io/dicy/) without changing current behavior of atom-latex.

- [x] Basic support for DiCy
- [x] Add `latex:kill` support
- [x] Add `texPath` support
- [x] Specs