### PR TITLE
Update dbus-native to v0.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "main": "./lib/main",
   "repository": "https://github.com/thomasjo/atom-latex",
   "dependencies": {
-    "dbus-native": "^0.2.0",
+    "dbus-native": "^0.2.1",
     "etch": "0.12.4",
     "fs-plus": "^3.0.0",
     "glob": "^7.1.1",


### PR DESCRIPTION
New version has `abstract-socket` as an optional dependency.