### PR TITLE
Add TeX Live 2017 and remove 2014

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ following search paths on Linux and macOS
 
 and on Windows it uses
 
-1. `%SystemDrive%\texlive\2016\bin\win32`
-2. `%SystemDrive%\texlive\2015\bin\win32`
-3. `%SystemDrive%\texlive\2014\bin\win32`
+1. `%SystemDrive%\texlive\2017\bin\win32`
+2. `%SystemDrive%\texlive\2016\bin\win32`
+3. `%SystemDrive%\texlive\2015\bin\win32`
 4. `%ProgramFiles%\MiKTeX 2.9\miktex\bin\x64`
 5. `%ProgramFiles(x86)%\MiKTeX 2.9\miktex\bin`
 

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -90,9 +90,9 @@ export default class Builder {
   defaultTexPath (platform) {
     if (platform === 'win32') {
       return [
+        '%SystemDrive%\\texlive\\2017\\bin\\win32',
         '%SystemDrive%\\texlive\\2016\\bin\\win32',
         '%SystemDrive%\\texlive\\2015\\bin\\win32',
-        '%SystemDrive%\\texlive\\2014\\bin\\win32',
         '%ProgramFiles%\\MiKTeX 2.9\\miktex\\bin\\x64',
         '%ProgramFiles(x86)%\\MiKTeX 2.9\\miktex\\bin'
       ].join(';')


### PR DESCRIPTION
TeX Live 2017 was published on June 4, so update our search path.