### PR TITLE
Fix Log References for Knitr

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -37,7 +37,7 @@ export default class Builder {
   parseLogFile (jobState) {
     const logFilePath = this.resolveLogFilePath(jobState)
     if (fs.existsSync(logFilePath)) {
-      const parser = this.getLogParser(logFilePath, jobState.getFilePath())
+      const parser = this.getLogParser(logFilePath, jobState.getTexFilePath())
       const result = parser.parse()
       if (result) {
         if (result.messages) {


### PR DESCRIPTION
`Builder` currently assumes that the main file path in `JobState` is the file path referred to in the log file produced by LaTeX. We could parse the concordance file and link to the original source like Rstudio. This will probably require changes to the log messaging format so it is probably best to leave that as an enhancement PR.

Fixes #370.

- [x] Reference TeX file not original source