### PR TITLE
Adjust to upstream async API changes

### DIFF
--- a/lib/composer.js
+++ b/lib/composer.js
@@ -173,7 +173,7 @@ export default class Composer extends Disposable {
     }
 
     if (editor.isModified()) {
-      editor.save() // TODO: Make this configurable?
+      await editor.save() // TODO: Make this configurable?
     }
 
     const { builder, state } = this.initializeBuild(filePath)

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     ]
   },
   "engines": {
-    "atom": ">=1.17.0 <2.0.0"
+    "atom": ">=1.19.0 <2.0.0"
   },
   "activationCommands": {
     "atom-workspace": [


### PR DESCRIPTION
Atom's `TextEditor.save` is now async, and this PR addresses that change.
Since the change will land in Atom v1.19, the engine requirement was also updated accordingly.

Resolves #385 