### PR TITLE
Ignore missing LaTeX file during log parsing

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -37,7 +37,12 @@ export default class Builder {
   parseLogFile (jobState) {
     const logFilePath = this.resolveLogFilePath(jobState)
     if (fs.existsSync(logFilePath)) {
-      const parser = this.getLogParser(logFilePath, jobState.getTexFilePath())
+      let filePath = jobState.getTexFilePath()
+      // Use main source path if the generated LaTeX file is missing. This will
+      // enable log parsing and finding the project root to continue without the
+      // generated LaTeX file.
+      if (!filePath) filePath = jobState.getFilePath()
+      const parser = this.getLogParser(logFilePath, filePath)
       const result = parser.parse()
       if (result) {
         if (result.messages) {


### PR DESCRIPTION
Use the main knitr source file if the generated LaTeX file is missing. Resolves #386
