### PR TITLE
Fix pdf-view opener splitting

### DIFF
--- a/lib/openers/pdf-view-opener.js
+++ b/lib/openers/pdf-view-opener.js
@@ -3,10 +3,6 @@
 import Opener from '../opener'
 import { isPdfFile } from '../werkzeug'
 
-function sleep (time) {
-  return new Promise(resolve => setTimeout(resolve, time))
-}
-
 export default class PdfViewOpener extends Opener {
   async open (filePath, texPath, lineNumber) {
     const texPane = atom.workspace.paneForURI(texPath)
@@ -22,14 +18,8 @@ export default class PdfViewOpener extends Opener {
     }
 
     const item = await atom.workspace.open(filePath, options)
-    const pane = atom.workspace.paneForItem(item)
-    if (pane && item && item.forwardSync) {
+    if (item && item.forwardSync) {
       item.forwardSync(texPath, lineNumber)
-      // If we don't wait for pdf-view to do it's first update then it will just
-      // display a blank page when there are multiple jobs.
-      while (item.updating) {
-        await sleep(100)
-      }
     }
 
     return true

--- a/lib/openers/pdf-view-opener.js
+++ b/lib/openers/pdf-view-opener.js
@@ -3,24 +3,34 @@
 import Opener from '../opener'
 import { isPdfFile } from '../werkzeug'
 
-function forwardSync (pdfView, texPath, lineNumber) {
-  if (pdfView != null && pdfView.forwardSync != null) {
-    pdfView.forwardSync(texPath, lineNumber)
-  }
+function sleep (time) {
+  return new Promise(resolve => setTimeout(resolve, time))
 }
 
 export default class PdfViewOpener extends Opener {
   async open (filePath, texPath, lineNumber) {
-    const openPaneItems = atom.workspace.getPaneItems()
-    for (const openPaneItem of openPaneItems) {
-      if (openPaneItem.filePath === filePath) {
-        forwardSync(openPaneItem, texPath, lineNumber)
-        return true
-      }
+    const texPane = atom.workspace.paneForURI(texPath)
+
+    // This prevents splitting the right pane multiple times
+    if (texPane) {
+      texPane.activate()
     }
 
-    // TODO: Make this configurable?
-    atom.workspace.open(filePath, {'split': 'right'}).then(pane => forwardSync(pane, texPath, lineNumber))
+    const options = {
+      searchAllPanes: true,
+      split: atom.config.get('latex.openerSplit')
+    }
+
+    const item = await atom.workspace.open(filePath, options)
+    const pane = atom.workspace.paneForItem(item)
+    if (pane && item && item.forwardSync) {
+      item.forwardSync(texPath, lineNumber)
+      // If we don't wait for pdf-view to do it's first update then it will just
+      // display a blank page when there are multiple jobs.
+      while (item.updating) {
+        await sleep(100)
+      }
+    }
 
     return true
   }

--- a/lib/openers/pdf-view-opener.js
+++ b/lib/openers/pdf-view-opener.js
@@ -14,7 +14,7 @@ export default class PdfViewOpener extends Opener {
 
     const options = {
       searchAllPanes: true,
-      split: atom.config.get('latex.openerSplit')
+      split: atom.config.get('latex.pdfViewSplitDirection')
     }
 
     const item = await atom.workspace.open(filePath, options)

--- a/package.json
+++ b/package.json
@@ -255,37 +255,49 @@
       "default": "automatic",
       "order": 17
     },
+    "openerSplit": {
+      "description": "Split direction to use for embedded viewers. Currently this is only applicable for `pdf-view`.",
+      "type": "string",
+      "enum": [
+        "left",
+        "right",
+        "up",
+        "down"
+      ],
+      "default": "right",
+      "order": 18
+    },
     "skimPath": {
       "description": "Full application path to Skim (macOS).",
       "type": "string",
       "default": "/Applications/Skim.app",
-      "order": 18
+      "order": 19
     },
     "sumatraPath": {
       "title": "SumatraPDF Path",
       "description": "Full application path to SumatraPDF (Windows).",
       "type": "string",
       "default": "C:\\Program Files (x86)\\SumatraPDF\\SumatraPDF.exe",
-      "order": 19
+      "order": 20
     },
     "okularPath": {
       "description": "Full application path to Okular (*nix).",
       "type": "string",
       "default": "/usr/bin/okular",
-      "order": 20
+      "order": 21
     },
     "zathuraPath": {
       "description": "Full application path to Zathura (*nix).",
       "type": "string",
       "default": "/usr/bin/zathura",
-      "order": 21
+      "order": 22
     },
     "viewerPath": {
       "title": "Custom PDF Viewer Path",
       "description": "Full application path to your PDF viewer. Overrides Skim and SumatraPDF options.",
       "type": "string",
       "default": "",
-      "order": 22
+      "order": 23
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -255,8 +255,8 @@
       "default": "automatic",
       "order": 17
     },
-    "openerSplit": {
-      "description": "Split direction to use for embedded viewers. Currently this is only applicable for `pdf-view`.",
+    "pdfViewSplitDirection": {
+      "description": "Pane split direction to use for pdf-view.",
       "type": "string",
       "enum": [
         "left",


### PR DESCRIPTION
Prevent multiple splitting of pdf-view and add `pdfViewSplitDirection` configuration. Fixes #397.