### PR TITLE
Fix forward sync during build for multiple job names

### DIFF
--- a/lib/composer.js
+++ b/lib/composer.js
@@ -321,7 +321,7 @@ export default class Composer extends Disposable {
   async build (shouldRebuild) {
     await this.kill()
 
-    const { editor, filePath } = getEditorDetails()
+    const { editor, filePath, lineNumber } = getEditorDetails()
 
     if (!filePath) {
       latex.log.warning('File needs to be saved to disk before it can be TeXified.')
@@ -349,14 +349,14 @@ export default class Composer extends Disposable {
     latex.log.clear()
     latex.status.setBusy()
 
-    const jobs = state.getJobStates().map(jobState => this.buildJob(builder, jobState))
+    const jobs = state.getJobStates().map(jobState => this.buildJob(filePath, lineNumber, builder, jobState))
 
     await Promise.all(jobs)
 
     latex.status.setIdle()
   }
 
-  async buildJob (builder, jobState) {
+  async buildJob (filePath, lineNumber, builder, jobState) {
     try {
       const statusCode = await builder.run(jobState)
       builder.parseLogAndFdbFiles(jobState)
@@ -543,10 +543,9 @@ export default class Composer extends Disposable {
     return outputFilePath
   }
 
-  async showResult (jobState) {
+  async showResult (filePath, lineNumber, jobState) {
     if (!this.shouldOpenResult()) { return }
 
-    const { filePath, lineNumber } = getEditorDetails()
     await latex.opener.open(jobState.getOutputFilePath(), filePath, lineNumber)
   }
 

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -372,7 +372,7 @@ export default class Composer extends Disposable {
         if (this.shouldMoveResult(jobState)) {
           this.moveResult(jobState)
         }
-        this.showResult(jobState)
+        this.showResult(filePath, lineNumber, jobState)
       }
     } catch (error) {
       latex.log.error(error.message)


### PR DESCRIPTION
If editor focus changes during the build then calls to the opener in `showResult` may get the wrong `filePath` and `lineNumber` so call `getEditorDetails` just once before the build begins.