### PR TITLE
Add building for additional DiCy file types

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,7 +15,7 @@ environment:
     MIKTEX_HOME: '%PROGRAMFILES%\MiKTeX 2.9'
     R_HOME: '%PROGRAMFILES%\R'
     R_LIBS_USER: '%USERPROFILE%\R\library'
-    APM_TEST_PACKAGES: "language-latex pdf-view"
+    APM_TEST_PACKAGES: "language-agda language-haskell language-latex language-r language-weave pdf-view"
   matrix:
     - ATOM_CHANNEL: stable
     - ATOM_CHANNEL: beta

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
   global:
     - MAKE="make -j8"
     - R_LIBS_USER=${HOME}/R/library
-    - APM_TEST_PACKAGES="language-latex pdf-view"
+    - APM_TEST_PACKAGES="language-agda language-haskell language-latex language-r language-weave pdf-view"
   matrix:
     - ATOM_CHANNEL=stable
     - ATOM_CHANNEL=beta

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -321,7 +321,9 @@ export default class Composer extends Disposable {
   async build (shouldRebuild) {
     await this.kill()
 
-    const { editor, filePath, lineNumber } = getEditorDetails()
+    const { editor, filePath, lineNumber, isLatex } = getEditorDetails()
+
+    if (!isLatex) return false
 
     if (!filePath) {
       latex.log.warning('File needs to be saved to disk before it can be TeXified.')
@@ -388,8 +390,8 @@ export default class Composer extends Disposable {
   }
 
   async sync () {
-    const { filePath, lineNumber } = getEditorDetails()
-    if (!filePath || !this.isTexFile(filePath)) {
+    const { filePath, lineNumber, isLatex } = getEditorDetails()
+    if (!filePath || !isLatex) {
       return
     }
 
@@ -416,8 +418,8 @@ export default class Composer extends Disposable {
   }
 
   async clean () {
-    const { filePath } = getEditorDetails()
-    if (!filePath || !this.isTexFile(filePath)) {
+    const { filePath, isLatex } = getEditorDetails()
+    if (!filePath || !isLatex) {
       return false
     }
 
@@ -555,11 +557,6 @@ export default class Composer extends Disposable {
     } else if (!jobState.getOutputFilePath()) {
       latex.log.error('No output file detected.')
     }
-  }
-
-  isTexFile (filePath) {
-    // TODO: Improve will suffice for the time being.
-    return !filePath || filePath.search(/\.(tex|lhs|[rs]nw)$/i) > 0
   }
 
   alterParentPath (targetPath, originalPath) {

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -246,7 +246,6 @@ export default class Composer extends Disposable {
     // any command line versions of DiCy have the same error reporting level.
     const options = _.pick(atom.config.get('latex'), [
       'customEngine',
-      'enableShellEscape',
       'enableSynctex',
       'engine',
       'loggingLevel',
@@ -264,6 +263,11 @@ export default class Composer extends Disposable {
 
     // Convert property expansion to DiCy's conventions
     options.cleanPatterns = cleanPatterns.map(pattern => replacePropertiesInString(pattern, properties))
+
+    // Only enable shell escape if explicitly requested. This allows the
+    // configuration in texmf-dist to take precedence.
+    const enableShellEscape = atom.config.get('latex.enableShellEscape')
+    if (enableShellEscape) options.shellEscape = 'enabled'
 
     // DiCy manages intermediate PostScript production itself, without the
     // wrapper dvipdf since it is not available on Windows.
@@ -318,7 +322,7 @@ export default class Composer extends Disposable {
     latex.status.setIdle()
   }
 
-  async build (shouldRebuild) {
+  async build (shouldRebuild = false) {
     await this.kill()
 
     const { editor, filePath, lineNumber, isLatex } = getEditorDetails()
@@ -335,7 +339,7 @@ export default class Composer extends Disposable {
     }
 
     if (this.shouldUseDiCy()) {
-      return this.runDiCy(['load', 'build', 'log', 'save'], { ignoreCache: shouldRebuild },
+      return this.runDiCy(['load', 'build', 'log', 'save'], { ignoreCache: !!shouldRebuild },
         this.shouldOpenResult(), true)
     }
 

--- a/lib/werkzeug.js
+++ b/lib/werkzeug.js
@@ -28,7 +28,9 @@ export default {
     const filePath = editor.getPath()
     const position = editor.getCursorBufferPosition()
     const lineNumber = position.row + 1
-    const isLatex = editor.getRootScopeDescriptor().some(scope => scope.includes('latex'))
+    const scopeDescriptor = editor.getRootScopeDescriptor()
+    const scopesArray = scopeDescriptor.getScopesArray()
+    const isLatex = scopesArray.some(scope => scope.includes('latex'))
 
     return { editor, filePath, position, lineNumber, isLatex }
   },

--- a/lib/werkzeug.js
+++ b/lib/werkzeug.js
@@ -28,8 +28,9 @@ export default {
     const filePath = editor.getPath()
     const position = editor.getCursorBufferPosition()
     const lineNumber = position.row + 1
+    const isLatex = editor.getRootScopeDescriptor().some(scope => scope.includes('latex'))
 
-    return { editor, filePath, position, lineNumber }
+    return { editor, filePath, position, lineNumber, isLatex }
   },
 
   replacePropertiesInString (text, properties) {
@@ -37,7 +38,7 @@ export default {
   },
 
   isTexFile (filePath) {
-    return filePath && !!filePath.match(/\.(?:tex|lhs)$/i)
+    return filePath && !!filePath.match(/\.(?:tex|lhs|lagda)$/i)
   },
 
   isKnitrFile (filePath) {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "main": "./lib/main",
   "repository": "https://github.com/thomasjo/atom-latex",
   "dependencies": {
-    "@dicy/core": "^0.8.0",
+    "@dicy/core": "^0.9.0",
     "dbus-native": "^0.2.1",
     "etch": "0.12.4",
     "fs-plus": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "main": "./lib/main",
   "repository": "https://github.com/thomasjo/atom-latex",
   "dependencies": {
-    "@dicy/core": "^0.9.0",
+    "@dicy/core": "^0.9.1",
     "dbus-native": "^0.2.1",
     "etch": "0.12.4",
     "fs-plus": "^3.0.0",

--- a/spec/build-registry-spec.js
+++ b/spec/build-registry-spec.js
@@ -11,7 +11,6 @@ describe('BuilderRegistry', () => {
   beforeEach(() => {
     waitsForPromise(() => helpers.activatePackages())
 
-    atom.config.set('latex.builder', 'latexmk')
     builderRegistry = new BuilderRegistry()
   })
 
@@ -21,8 +20,23 @@ describe('BuilderRegistry', () => {
       expect(builderRegistry.getBuilderImplementation(state)).toBeNull()
     })
 
+    it('returns null when passed a Pweave file', () => {
+      const state = new BuildState('foo.Pnw')
+      expect(builderRegistry.getBuilderImplementation(state)).toBeNull()
+    })
+
     it('returns the configured builder when given a regular .tex file', () => {
       const state = new BuildState('foo.tex')
+      expect(builderRegistry.getBuilderImplementation(state).name).toEqual('LatexmkBuilder')
+    })
+
+    it('returns the configured builder when given a literate Haskell file', () => {
+      const state = new BuildState('foo.lhs')
+      expect(builderRegistry.getBuilderImplementation(state).name).toEqual('LatexmkBuilder')
+    })
+
+    it('returns the configured builder when given a literate Agda file', () => {
+      const state = new BuildState('foo.lagda')
       expect(builderRegistry.getBuilderImplementation(state).name).toEqual('LatexmkBuilder')
     })
 
@@ -40,10 +54,6 @@ describe('BuilderRegistry', () => {
   })
 
   describe('getBuilder', () => {
-    beforeEach(() => {
-      atom.config.set('latex.builder', 'latexmk')
-    })
-
     it('returns null when passed an unhandled file type', () => {
       const state = new BuildState('quux.txt')
       expect(builderRegistry.getBuilder(state)).toBeNull()
@@ -57,6 +67,21 @@ describe('BuilderRegistry', () => {
     it('returns a builder instance as configured for knitr files', () => {
       const state = new BuildState('bar.Rnw')
       expect(builderRegistry.getBuilder(state).constructor.name).toEqual('KnitrBuilder')
+    })
+
+    it('returns a builder instance as configured for literate Haskell files', () => {
+      const state = new BuildState('foo.lhs')
+      expect(builderRegistry.getBuilder(state).constructor.name).toEqual('LatexmkBuilder')
+    })
+
+    it('returns a builder instance as configured for literate Agda files', () => {
+      const state = new BuildState('foo.lagda')
+      expect(builderRegistry.getBuilder(state).constructor.name).toEqual('LatexmkBuilder')
+    })
+
+    it('returns null when passed an Pweave file', () => {
+      const state = new BuildState('foo.Pnw')
+      expect(builderRegistry.getBuilder(state)).toBeNull()
     })
   })
 })

--- a/spec/composer-spec.js
+++ b/spec/composer-spec.js
@@ -20,7 +20,7 @@ describe('Composer', () => {
       spyOn(composer, 'initializeBuildStateFromMagic').andCallFake(state => {
         state.setJobNames(jobNames)
       })
-      spyOn(werkzeug, 'getEditorDetails').andReturn({ editor, filePath, lineNumber: 1 })
+      spyOn(werkzeug, 'getEditorDetails').andReturn({ editor, filePath, lineNumber: 1, isLatex: true })
 
       builder = jasmine.createSpyObj('MockBuilder', ['run', 'constructArgs', 'parseLogAndFdbFiles'])
       builder.run.andCallFake(() => {
@@ -247,7 +247,7 @@ describe('Composer', () => {
       spyOn(composer, 'initializeBuildStateFromMagic').andCallFake(state => {
         state.setJobNames(jobNames)
       })
-      spyOn(werkzeug, 'getEditorDetails').andReturn({ filePath })
+      spyOn(werkzeug, 'getEditorDetails').andReturn({ filePath, isLatex: true })
       spyOn(composer, 'getGeneratedFileList').andCallFake((builder, state) => {
         let { dir, name } = path.parse(state.getFilePath())
         if (state.getOutputDirectory()) {
@@ -422,7 +422,7 @@ describe('Composer', () => {
     })
 
     it('logs a warning and returns when an output file cannot be resolved', () => {
-      spyOn(werkzeug, 'getEditorDetails').andReturn({ filePath: 'file.tex', lineNumber: 1 })
+      spyOn(werkzeug, 'getEditorDetails').andReturn({ filePath: 'file.tex', lineNumber: 1, isLatex: true })
       spyOn(composer, 'resolveOutputFilePath').andReturn()
       spyOn(latex.opener, 'open').andReturn(true)
       spyOn(latex.log, 'warning').andCallThrough()
@@ -439,7 +439,7 @@ describe('Composer', () => {
       const filePath = 'file.tex'
       const lineNumber = 1
       const outputFilePath = 'file.pdf'
-      spyOn(werkzeug, 'getEditorDetails').andReturn({ filePath, lineNumber })
+      spyOn(werkzeug, 'getEditorDetails').andReturn({ filePath, lineNumber, isLatex: true })
       spyOn(composer, 'resolveOutputFilePath').andReturn(outputFilePath)
 
       spyOn(latex.opener, 'open').andReturn(true)
@@ -456,7 +456,7 @@ describe('Composer', () => {
       const lineNumber = 1
       const jobNames = ['foo', 'bar']
 
-      spyOn(werkzeug, 'getEditorDetails').andReturn({ filePath, lineNumber })
+      spyOn(werkzeug, 'getEditorDetails').andReturn({ filePath, lineNumber, isLatex: true })
       spyOn(composer, 'resolveOutputFilePath').andCallFake((builder, state) => state.getJobName() + '.pdf')
       spyOn(composer, 'initializeBuildStateFromMagic').andCallFake(state => {
         state.setJobNames(jobNames)
@@ -877,7 +877,7 @@ describe('Composer', () => {
       outputPath = path.join(fixturesPath, outputBaseName)
       synctexPath = path.join(fixturesPath, synctexBaseName)
       spyOn(composer, 'getDiCy').andCallFake(() => Promise.resolve(dicy))
-      spyOn(werkzeug, 'getEditorDetails').andReturn({ filePath: sourcePath, lineNumber: 1 })
+      spyOn(werkzeug, 'getEditorDetails').andReturn({ filePath: sourcePath, lineNumber: 1, isLatex: true })
       spyOn(latex.opener, 'open').andCallFake(() => Promise.resolve(true))
     }
 

--- a/spec/fixtures/literate/file.Pnw
+++ b/spec/fixtures/literate/file.Pnw
@@ -1,0 +1,28 @@
+\documentclass{article}
+
+\usepackage{color}
+\usepackage{fancyvrb}
+\usepackage{graphicx}
+\usepackage{xstring}
+
+\IfStrEqCase*{\jobname}{%
+  {job-2}{\usepackage{minted}}}
+
+\begin{document}
+
+<<>>=
+print("Hello world!")
+@
+
+<<caption='foo'>>=
+import matplotlib.pyplot as plt
+import numpy as np
+
+t = np.arange(0.0, 2.0, 0.01)
+s = 1 + np.sin(2*np.pi*t)
+plt.plot(t, s)
+plt.grid(True)
+plt.show()
+@
+
+\end{document}

--- a/spec/fixtures/literate/file.lagda
+++ b/spec/fixtures/literate/file.lagda
@@ -1,0 +1,19 @@
+\documentclass{article}
+
+\def\textmu{}
+
+\IfStrEq*{\jobname}{none}%
+  {\newenvironment{code}{\verbatim}{\endverbatim}}%
+
+%include agda.fmt
+
+\begin{document}
+
+The identity function:
+
+\begin{code}
+id : {S : Set} -> S -> S
+id {S} x = x
+\end{code}
+
+\end{document}

--- a/spec/fixtures/literate/file.lhs
+++ b/spec/fixtures/literate/file.lhs
@@ -1,0 +1,22 @@
+\documentclass{article}
+
+%include polycode.fmt
+
+\usepackage{verbatim,xstring}
+
+\IfStrEq*{\jobname}{none}%
+  {\newenvironment{code}{\verbatim}{\endverbatim}}%
+
+\begin{document}
+
+Euclid's algorithm in Haskell.
+
+\begin{code}
+gcd :: (Integral a) => a -> a -> a
+gcd 0 0 =  error "gcd 0 0 is undefined"
+gcd x y =  gcd' (abs x) (abs y) where
+  gcd' a 0  =  a
+  gcd' a b  =  gcd' b (a `rem` b)
+\end{code}
+
+\end{document}

--- a/spec/werkzeug-spec.js
+++ b/spec/werkzeug-spec.js
@@ -1,0 +1,126 @@
+/** @babel */
+
+import path from 'path'
+import helpers from './spec-helpers'
+import werkzeug from '../lib/werkzeug'
+
+describe('werkzeug', () => {
+  let fixturesPath
+
+  beforeEach(() => {
+    waitsForPromise(() => {
+      return helpers.activatePackages()
+    })
+    fixturesPath = helpers.cloneFixtures()
+  })
+
+  describe('getEditorDetails', () => {
+    it('verifies correct file is analyzed and identified as a LaTeX source when passed LaTeX document', () => {
+      const filePath = path.join(fixturesPath, 'file.tex')
+
+      waitsForPromise(() => {
+        return atom.workspace.open(filePath)
+      })
+
+      runs(() => {
+        const { editor, ...rest } = werkzeug.getEditorDetails()
+        expect(rest).toEqual({
+          filePath,
+          position: { row: 0, column: 0 },
+          lineNumber: 1,
+          isLatex: true
+        })
+      })
+    })
+
+    it('verifies correct file is analyzed and identified as a LaTeX source when passed R-noweb document', () => {
+      const filePath = path.join(fixturesPath, 'knitr', 'file.Rnw')
+
+      waitsForPromise(() => {
+        return atom.workspace.open(filePath)
+      })
+
+      runs(() => {
+        const { editor, ...rest } = werkzeug.getEditorDetails()
+        expect(rest).toEqual({
+          filePath,
+          position: { row: 0, column: 0 },
+          lineNumber: 1,
+          isLatex: true
+        })
+      })
+    })
+
+    it('verifies correct file is analyzed and identified as a LaTeX source when passed literate Agda document', () => {
+      const filePath = path.join(fixturesPath, 'literate', 'file.lagda')
+
+      waitsForPromise(() => {
+        return atom.workspace.open(filePath)
+      })
+
+      runs(() => {
+        const { editor, ...rest } = werkzeug.getEditorDetails()
+        expect(rest).toEqual({
+          filePath,
+          position: { row: 0, column: 0 },
+          lineNumber: 1,
+          isLatex: true
+        })
+      })
+    })
+
+    it('verifies correct file is analyzed and identified as a LaTeX source when passed P-noweb document', () => {
+      const filePath = path.join(fixturesPath, 'literate', 'file.Pnw')
+
+      waitsForPromise(() => {
+        return atom.workspace.open(filePath)
+      })
+
+      runs(() => {
+        const { editor, ...rest } = werkzeug.getEditorDetails()
+        expect(rest).toEqual({
+          filePath,
+          position: { row: 0, column: 0 },
+          lineNumber: 1,
+          isLatex: true
+        })
+      })
+    })
+
+    it('verifies correct file is analyzed and identified as a LaTeX source when passed literate Haskell document', () => {
+      const filePath = path.join(fixturesPath, 'literate', 'file.lhs')
+
+      waitsForPromise(() => {
+        return atom.workspace.open(filePath)
+      })
+
+      runs(() => {
+        const { editor, ...rest } = werkzeug.getEditorDetails()
+        expect(rest).toEqual({
+          filePath,
+          position: { row: 0, column: 0 },
+          lineNumber: 1,
+          isLatex: true
+        })
+      })
+    })
+
+    it('verifies correct file is analyzed and identified as not a LaTeX source when passed non-source file', () => {
+      const filePath = path.join(fixturesPath, 'file.fdb_latexmk')
+
+      waitsForPromise(() => {
+        return atom.workspace.open(filePath)
+      })
+
+      runs(() => {
+        const { editor, ...rest } = werkzeug.getEditorDetails()
+        expect(rest).toEqual({
+          filePath,
+          position: { row: 0, column: 0 },
+          lineNumber: 1,
+          isLatex: false
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
- [x] Update DiCy
- [ ] Add lagda support
- [ ] Add lhs support
- [ ] Add Pweave support

Our key bindings require `latex` to be in the grammar scope. This PR uses the same logic in 
`Composer`. One advantage to this would be that we could support LaTeX, knitr, literate Haskell and literate Agda (banacorn/language-agda#7) right out of the box.

## Current Build Paths
| Type             | Builder  | Setting                         | Preprocessor | Processor |
|------------------|----------|---------------------------------|--------------|-----------|
| LaTeX            | Built-in |                                 |              | latexmk   |
| LaTeX            | DiCy     |                                 |              | latex     |
| knitr            | Built-in |                                 | knitr        | latexmk   |
| knitr            | DiCy     |                                 | knitr        | latex     |
| Literate Haskell | Built-in |                                 |              | latexmk   |
| Literate Haskell | DiCy     | literateHaskellEngine = none    |              | latex     |
| Literate Haskell | DiCy     | literateHaskellEngine = lhs2TeX | lhs2TeX      | latex     |
| Literate Agda    | Built-in |                                 |              | latexmk   |
| Literate Agda    | DiCy     | literateAgdaEngine = none       |              | latex     |
| Literate Agda    | DiCy     | literateAgdaEngine = lhs2TeX    | lhs2TeX      | latex     |
| Literate Agda    | DiCy     | literateAgdaEngine = agda       | agda         | latex     |

## Root Scopes
- `text.tex.latex`
  - [language-latex](https://atom.io/packages/language-latex)
  - [language-latexsimple](https://atom.io/packages/language-latexsimple)
  - [language-tex](https://atom.io/packages/language-tex)
  - [language-latex2e](https://atom.io/packages/language-latex2e)
  - [language-eoalatex](https://atom.io/packages/language-eoalatex)
- `text.tex.latex.knitr`
  - [language-knitr](https://atom.io/packages/language-knitr)
- `text.tex.latex.haskell`
  - [language-haskell](https://atom.io/packages/language-haskell)
- `text.tex.latex.agda`
  - [language-agda](https://atom.io/packages/language-agda)
- `source.pweave.latex`
  - [language-weave](https://atom.io/packages/language-weave)
- `source.weave.latex`
  - [language-weave](https://atom.io/packages/language-weave)
