### PR TITLE
Fix pdf-view focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased][] / YYYY-MM-DD
+### Added
+- Support for opening result in background with `pdf-view`. Resolves
+  [413](https://github.com/thomasjo/atom-latex/pull/413).  
+    ~ [#416](https://github.com/thomasjo/atom-latex/pull/416)
+    / [@nisargjhaveri](https://github.com/nisargjhaveri)
+
 ## [0.47.0][] / 2017-09-14
 ### Added
 - Support for literate Haskell, literate Agda and Pweave via DiCy upgrade.
@@ -643,6 +650,7 @@ minor release.
 - First release.
 
 <!--- refs --->
+[Unreleased]: https://github.com/thomasjo/atom-latex/compare/v0.47.0...master
 [0.47.0]: https://github.com/thomasjo/atom-latex/compare/v0.46.0...v0.47.0
 [0.46.0]: https://github.com/thomasjo/atom-latex/compare/v0.45.0...v0.46.0
 [0.45.0]: https://github.com/thomasjo/atom-latex/compare/v0.44.1...v0.45.0

--- a/lib/openers/pdf-view-opener.js
+++ b/lib/openers/pdf-view-opener.js
@@ -6,6 +6,7 @@ import { isPdfFile } from '../werkzeug'
 export default class PdfViewOpener extends Opener {
   async open (filePath, texPath, lineNumber) {
     const texPane = atom.workspace.paneForURI(texPath)
+    const previousActivePane = atom.workspace.getActivePane()
 
     // This prevents splitting the right pane multiple times
     if (texPane) {
@@ -20,6 +21,10 @@ export default class PdfViewOpener extends Opener {
     const item = await atom.workspace.open(filePath, options)
     if (item && item.forwardSync) {
       item.forwardSync(texPath, lineNumber)
+    }
+
+    if (previousActivePane && this.shouldOpenInBackground()) {
+      previousActivePane.activate()
     }
 
     return true


### PR DESCRIPTION
Respect `openInBackground` setting by saving and re-activating previous pane. Resolves #413