### PR TITLE
Fix marker reset issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
     ~ [#416](https://github.com/thomasjo/atom-latex/pull/416)
     / [@nisargjhaveri](https://github.com/nisargjhaveri)
 
+### Fixed
+- Reset of error markers in source files after a new build. Fixes
+  [#419](https://github.com/thomasjo/atom-latex/pull/419).
+
 ## [0.47.0][] / 2017-09-14
 ### Added
 - Support for literate Haskell, literate Agda and Pweave via DiCy upgrade.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Reset of error markers in source files after a new build. Fixes
-  [#419](https://github.com/thomasjo/atom-latex/pull/419).
+  [#419](https://github.com/thomasjo/atom-latex/issues/419).
 
 ## [0.47.0][] / 2017-09-14
 ### Added

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -46,7 +46,7 @@ export default class Logger extends Disposable {
     message = Object.assign({ timestamp: Date.now() }, _.pickBy(message))
     this.messages.push(message)
     if (this.messageTypeIsVisible(message.type)) {
-      this.emitter.emit('messages', [message], false)
+      this.emitter.emit('messages', { messages: [message], reset: false })
     }
   }
 
@@ -56,7 +56,7 @@ export default class Logger extends Disposable {
   }
 
   refresh () {
-    this.emitter.emit('messages', this.getMessages(), true)
+    this.emitter.emit('messages', { messages: this.getMessages(), reset: true })
   }
 
   getMessages (useFilters = true) {
@@ -67,7 +67,7 @@ export default class Logger extends Disposable {
 
   setMessages (messages) {
     this.messages = messages
-    this.emitter.emit('messages', messages, true)
+    this.emitter.emit('messages', { messages, reset: true })
   }
 
   messageTypeIsVisible (type) {

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -43,7 +43,7 @@ export default class Logger extends Disposable {
   }
 
   showMessage (message) {
-    message = Object.assign({ timestamp: Date.now() }, _.pickBy(message))
+    message = _.pickBy(message)
     this.messages.push(message)
     if (this.messageTypeIsVisible(message.type)) {
       this.emitter.emit('messages', { messages: [message], reset: false })

--- a/lib/marker-manager.js
+++ b/lib/marker-manager.js
@@ -11,7 +11,7 @@ export default class MarkerManager extends Disposable {
     this.editor = editor
     this.markers = []
 
-    this.disposables.add(latex.log.onMessages((messages, reset) => this.addMarkers(messages, reset)))
+    this.disposables.add(latex.log.onMessages(({ messages, reset }) => this.addMarkers(messages, reset)))
     this.disposables.add(new Disposable(() => this.clear()))
     this.disposables.add(this.editor.onDidDestroy(() => this.dispose()))
     this.disposables.add(atom.config.onDidChange('latex.loggingLevel', () => this.update()))

--- a/spec/logger-spec.js
+++ b/spec/logger-spec.js
@@ -176,6 +176,17 @@ describe('Logger', () => {
         reset: false
       })
     })
+
+    it('verifies a new message list is sent when the logging level is changed', () => {
+      initialize('info')
+
+      atom.config.set('latex.loggingLevel', 'error')
+
+      expect(messagesListener).toHaveBeenCalledWith({
+        messages: [{ type: 'error' }],
+        reset: true
+      })
+    })
   })
 
   describe('setMessages', () => {

--- a/spec/logger-spec.js
+++ b/spec/logger-spec.js
@@ -1,64 +1,71 @@
 /** @babel */
 
-import _ from 'lodash'
 import './spec-helpers'
 import Logger from '../lib/logger'
 import werkzeug from '../lib/werkzeug'
 
 describe('Logger', () => {
-  let logger, counts
+  let logger, messagesListener
 
-  beforeEach(() => {
+  function initialize (loggingLevel = 'warning') {
     logger = new Logger()
-  })
+    messagesListener = jasmine.createSpy('onMessagesListener')
+    logger.onMessages(messagesListener)
+
+    atom.config.set('latex.loggingLevel', loggingLevel)
+
+    logger.info()
+    logger.warning()
+    logger.error()
+  }
 
   describe('getMessages', () => {
-    beforeEach(() => {
-      logger.info()
-      logger.warning()
-      logger.error()
-    })
-
     it('verifies no messages filtered when logging level set to info', () => {
-      atom.config.set('latex.loggingLevel', 'info')
-      counts = _.countBy(logger.getMessages(), 'type')
+      initialize('info')
 
-      expect(counts.error).toBeDefined()
-      expect(counts.warning).toBeDefined()
-      expect(counts.info).toBeDefined()
+      expect(logger.getMessages()).toEqual([{
+        type: 'info'
+      }, {
+        type: 'warning'
+      }, {
+        type: 'error'
+      }])
     })
 
     it('verifies info messages filtered when logging level set to warning', () => {
-      atom.config.set('latex.loggingLevel', 'warning')
-      counts = _.countBy(logger.getMessages(), 'type')
+      initialize('warning')
 
-      expect(counts.error).toBeDefined()
-      expect(counts.warning).toBeDefined()
-      expect(counts.info).toBeUndefined()
+      expect(logger.getMessages()).toEqual([{
+        type: 'warning'
+      }, {
+        type: 'error'
+      }])
     })
 
     it('verifies warning and info messages filtered when logging level set to error', () => {
-      atom.config.set('latex.loggingLevel', 'error')
-      counts = _.countBy(logger.getMessages(), 'type')
+      initialize('error')
 
-      expect(counts.error).toBeDefined()
-      expect(counts.warning).toBeUndefined()
-      expect(counts.info).toBeUndefined()
+      expect(logger.getMessages()).toEqual([{
+        type: 'error'
+      }])
     })
 
     it('verifies no messages filtered when useFilters is false', () => {
-      atom.config.set('latex.loggingLevel', 'error')
-      counts = _.countBy(logger.getMessages(false), 'type')
+      initialize('error')
 
-      expect(counts.error).toBeDefined()
-      expect(counts.warning).toBeDefined()
-      expect(counts.info).toBeDefined()
+      expect(logger.getMessages(false)).toEqual([{
+        type: 'info'
+      }, {
+        type: 'warning'
+      }, {
+        type: 'error'
+      }])
     })
   })
 
   describe('messageTypeIsVisible', () => {
     it('verifies messageTypeIsVisible is true for all levels when logging level set to info', () => {
-      atom.config.set('latex.loggingLevel', 'info')
+      initialize('info')
 
       expect(logger.messageTypeIsVisible('info')).toBe(true)
       expect(logger.messageTypeIsVisible('warning')).toBe(true)
@@ -66,7 +73,7 @@ describe('Logger', () => {
     })
 
     it('verifies messageTypeIsVisible is false for info when logging level set to warning', () => {
-      atom.config.set('latex.loggingLevel', 'warning')
+      initialize('warning')
 
       expect(logger.messageTypeIsVisible('info')).toBe(false)
       expect(logger.messageTypeIsVisible('warning')).toBe(true)
@@ -74,7 +81,7 @@ describe('Logger', () => {
     })
 
     it('verifies messageTypeIsVisible is false for info when logging level set to warning', () => {
-      atom.config.set('latex.loggingLevel', 'error')
+      initialize('error')
 
       expect(logger.messageTypeIsVisible('info')).toBe(false)
       expect(logger.messageTypeIsVisible('warning')).toBe(false)
@@ -86,6 +93,7 @@ describe('Logger', () => {
     let logDock
 
     function initializeSpies (filePath, position) {
+      initialize()
       logDock = jasmine.createSpyObj('LogDock', ['update'])
       spyOn(logger, 'show').andCallFake(() => Promise.resolve(logDock))
       spyOn(werkzeug, 'getEditorDetails').andReturn({ filePath, position })
@@ -114,6 +122,92 @@ describe('Logger', () => {
         expect(logger.show).toHaveBeenCalled()
         expect(logDock.update).toHaveBeenCalledWith({ filePath, position })
       })
+    })
+  })
+
+  describe('onMessages', () => {
+    it('verifies no messages filtered when logging level set to info', () => {
+      initialize('info')
+
+      expect(messagesListener).toHaveBeenCalledWith({
+        messages: [{ type: 'info' }],
+        reset: false
+      })
+      expect(messagesListener).toHaveBeenCalledWith({
+        messages: [{ type: 'warning' }],
+        reset: false
+      })
+      expect(messagesListener).toHaveBeenCalledWith({
+        messages: [{ type: 'error' }],
+        reset: false
+      })
+    })
+
+    it('verifies info messages filtered when logging level set to warning', () => {
+      initialize('warning')
+
+      expect(messagesListener).not.toHaveBeenCalledWith({
+        messages: [{ type: 'info' }],
+        reset: false
+      })
+      expect(messagesListener).toHaveBeenCalledWith({
+        messages: [{ type: 'warning' }],
+        reset: false
+      })
+      expect(messagesListener).toHaveBeenCalledWith({
+        messages: [{ type: 'error' }],
+        reset: false
+      })
+    })
+
+    it('verifies warning and info messages filtered when logging level set to error', () => {
+      initialize('error')
+
+      expect(messagesListener).not.toHaveBeenCalledWith({
+        messages: [{ type: 'info' }],
+        reset: false
+      })
+      expect(messagesListener).not.toHaveBeenCalledWith({
+        messages: [{ type: 'warning' }],
+        reset: false
+      })
+      expect(messagesListener).toHaveBeenCalledWith({
+        messages: [{ type: 'error' }],
+        reset: false
+      })
+    })
+  })
+
+  describe('setMessages', () => {
+    it('replaces message list and sends reset signal when called', () => {
+      const messages = [{ type: 'error', text: 'foo' }]
+
+      initialize('info')
+      logger.setMessages(messages)
+
+      expect(messagesListener).toHaveBeenCalledWith({ messages, reset: true })
+      expect(logger.getMessages(false)).toEqual(messages)
+    })
+  })
+
+  describe('clear', () => {
+    it('empties message list and sends reset signal when called', () => {
+      initialize('info')
+      logger.clear()
+
+      expect(messagesListener).toHaveBeenCalledWith({ messages: [], reset: true })
+      expect(logger.getMessages(false)).toEqual([])
+    })
+  })
+
+  describe('refresh', () => {
+    it('sends reset signal when called', () => {
+      const messages = [{ type: 'error' }]
+
+      initialize('error')
+      logger.refresh()
+
+      expect(messagesListener).toHaveBeenCalledWith({ messages, reset: true })
     })
   })
 })

--- a/spec/marker-manager-spec.js
+++ b/spec/marker-manager-spec.js
@@ -11,12 +11,19 @@ describe('MarkerManager', () => {
   })
 
   describe('addMarkers', () => {
-    it('verifies that only messages that have a range and a matching file path are marked', () => {
-      const editor = {
+    let editor, manager
+
+    beforeEach(() => {
+      editor = {
         getPath: () => 'foo.tex',
         onDidDestroy: () => { return { dispose: () => null } }
       }
-      const manager = new MarkerManager(editor)
+      manager = new MarkerManager(editor)
+      spyOn(manager, 'addMarker')
+      spyOn(manager, 'clear')
+    })
+
+    it('verifies that only messages that have a range and a matching file path are marked', () => {
       const messages = [{
         type: 'error',
         range: [[0, 0], [0, 1]],
@@ -29,12 +36,18 @@ describe('MarkerManager', () => {
         type: 'info',
         filePath: 'foo.tex'
       }]
-      spyOn(manager, 'addMarker')
 
       manager.addMarkers(messages, false)
 
       expect(manager.addMarker).toHaveBeenCalledWith('error', 'foo.tex', [[0, 0], [0, 1]])
       expect(manager.addMarker.calls.length).toEqual(1)
+      expect(manager.clear).not.toHaveBeenCalled()
+    })
+
+    it('verifies that clear is called when reset flag is set', () => {
+      manager.addMarkers([], true)
+
+      expect(manager.clear).toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
The reset flag is getting lost because Atom's Emitter only handles one event value. Fix this by wrapping the event data with a single object and destructure in the event handlers. Fixes #419.