### PR TITLE
Use global reference to latex in dispose

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -62,7 +62,9 @@ export default {
     this.bootstrap()
     latex.status.attachStatusBar(statusBar)
     return new Disposable(() => {
-      if (latex) latex.status.detachStatusBar()
+      if (global.latex) {
+        global.latex.status.detachStatusBar()
+      }
     })
   },
 


### PR DESCRIPTION
In Atom 1.21, the package disposal appears to be happening before the status bar disposes of our indicator.  Using `global.latex` in the disposal function resolves this. Fixes #417.