### PR TITLE
Parse input source markers in log

### DIFF
--- a/lib/parsers/log-parser.js
+++ b/lib/parsers/log-parser.js
@@ -56,9 +56,11 @@ export default class LogParser extends Parser {
     }
     const sourcePaths = [this.texFilePath]
 
-    // Ignore the first line because it has some confusing patterns
-    const lines = this.getLines().slice(1)
+    const lines = this.getLines()
     lines.forEach((line, index) => {
+      // Ignore the first line because it has some confusing patterns
+      if (index === 0) return
+
       // Simplest Thing That Works™ and KISS®
       const logRange = [[index, 0], [index, line.length]]
       let match = line.match(OUTPUT_PATTERN)

--- a/lib/parsers/log-parser.js
+++ b/lib/parsers/log-parser.js
@@ -36,7 +36,10 @@ const WARNING_INFO_PATTERN = new RegExp('' +
 const INCOMPLETE_FONT_PATTERN = /^LaTeX Font .*[^.]$/
 
 // Pattern for \input markers which are sorrounded by parenthesis.
-const INPUT_FILE_PATTERN = /(\([^)[]+|\))/g
+const INPUT_FILE_PATTERN = /(\([^()[]+|\))/g
+
+// Pattern to remove leading and trailing spaces, quotes and left parathesis.
+const INPUT_FILE_TRIM_PATTERN = /(^\([\s"]*|[\s"]+$)/g
 
 export default class LogParser extends Parser {
   constructor (filePath, texFilePath) {
@@ -115,7 +118,7 @@ export default class LogParser extends Parser {
             // Avoid popping texFilePath off of the stack.
             if (sourcePaths.length > 0) sourcePaths.shift()
           } else {
-            sourcePaths.unshift(path.resolve(this.projectPath, token.replace(/(^\([\s"]*|[\s"]+$)/g, '')))
+            sourcePaths.unshift(path.resolve(this.projectPath, token.replace(INPUT_FILE_TRIM_PATTERN, '')))
           }
         }
       }

--- a/lib/parsers/log-parser.js
+++ b/lib/parsers/log-parser.js
@@ -35,6 +35,8 @@ const WARNING_INFO_PATTERN = new RegExp('' +
 // located in the log file.
 const INCOMPLETE_FONT_PATTERN = /^LaTeX Font .*[^.]$/
 
+const INPUT_FILE_PATTERN = /(\([^)\s]+|\))/g
+
 export default class LogParser extends Parser {
   constructor (filePath, texFilePath) {
     super(filePath)
@@ -48,6 +50,7 @@ export default class LogParser extends Parser {
       outputFilePath: null,
       messages: []
     }
+    const sourcePaths = [this.texFilePath]
 
     const lines = this.getLines()
     lines.forEach((line, index) => {
@@ -66,7 +69,7 @@ export default class LogParser extends Parser {
         result.messages.push({
           type: 'error',
           text: (match[3] && match[3] !== 'LaTeX') ? match[3] + ': ' + match[4] : match[4],
-          filePath: match[1] ? path.resolve(this.projectPath, match[1]) : this.texFilePath,
+          filePath: match[1] ? path.resolve(this.projectPath, match[1]) : sourcePaths[0],
           range: lineNumber ? [[lineNumber - 1, 0], [lineNumber - 1, Number.MAX_SAFE_INTEGER]] : undefined,
           logPath: this.filePath,
           logRange: logRange
@@ -79,7 +82,7 @@ export default class LogParser extends Parser {
         result.messages.push({
           type: 'warning',
           text: match[1],
-          filePath: this.texFilePath,
+          filePath: sourcePaths[0],
           range: [[parseInt(match[2], 10) - 1, 0], [parseInt(match[3], 10) - 1, Number.MAX_SAFE_INTEGER]],
           logPath: this.filePath,
           logRange: logRange
@@ -93,11 +96,23 @@ export default class LogParser extends Parser {
         result.messages.push({
           type: match[2].toLowerCase(),
           text: ((match[1] !== 'LaTeX') ? match[1] + ': ' + match[3] : match[3]).replace(/\s+/g, ' '),
-          filePath: this.texFilePath,
+          filePath: sourcePaths[0],
           range: lineNumber ? [[lineNumber - 1, 0], [lineNumber - 1, Number.MAX_SAFE_INTEGER]] : undefined,
           logPath: this.filePath,
           logRange: logRange
         })
+      }
+
+      match = line.match(INPUT_FILE_PATTERN)
+      if (match) {
+        for (const token of match) {
+          if (token === ')') {
+            if (sourcePaths.length > 0) sourcePaths.shift()
+          } else {
+            sourcePaths.unshift(path.resolve(this.projectPath, token.substring(1)))
+          }
+        }
+        console.log(sourcePaths)
       }
     })
 

--- a/lib/parsers/log-parser.js
+++ b/lib/parsers/log-parser.js
@@ -35,10 +35,10 @@ const WARNING_INFO_PATTERN = new RegExp('' +
 // located in the log file.
 const INCOMPLETE_FONT_PATTERN = /^LaTeX Font .*[^.]$/
 
-// Pattern for \input markers which are sorrounded by parenthesis.
+// Pattern for \input markers which are surrounded by parentheses.
 const INPUT_FILE_PATTERN = /(\([^()[]+|\))/g
 
-// Pattern to remove leading and trailing spaces, quotes and left parathesis.
+// Pattern to remove leading and trailing spaces, quotes and left parenthesis.
 const INPUT_FILE_TRIM_PATTERN = /(^\([\s"]*|[\s"]+$)/g
 
 export default class LogParser extends Parser {
@@ -56,7 +56,8 @@ export default class LogParser extends Parser {
     }
     const sourcePaths = [this.texFilePath]
 
-    const lines = this.getLines()
+    // Ignore the first line because it has some confusing patterns
+    const lines = this.getLines().slice(1)
     lines.forEach((line, index) => {
       // Simplest Thing That Works™ and KISS®
       const logRange = [[index, 0], [index, line.length]]
@@ -116,7 +117,7 @@ export default class LogParser extends Parser {
         for (const token of match) {
           if (token === ')') {
             // Avoid popping texFilePath off of the stack.
-            if (sourcePaths.length > 0) sourcePaths.shift()
+            if (sourcePaths.length > 1) sourcePaths.shift()
           } else {
             sourcePaths.unshift(path.resolve(this.projectPath, token.replace(INPUT_FILE_TRIM_PATTERN, '')))
           }

--- a/lib/parsers/log-parser.js
+++ b/lib/parsers/log-parser.js
@@ -35,7 +35,8 @@ const WARNING_INFO_PATTERN = new RegExp('' +
 // located in the log file.
 const INCOMPLETE_FONT_PATTERN = /^LaTeX Font .*[^.]$/
 
-const INPUT_FILE_PATTERN = /(\([^)\s]+|\))/g
+// Pattern for \input markers which are sorrounded by parenthesis.
+const INPUT_FILE_PATTERN = /(\([^)[]+|\))/g
 
 export default class LogParser extends Parser {
   constructor (filePath, texFilePath) {
@@ -103,16 +104,20 @@ export default class LogParser extends Parser {
         })
       }
 
+      // Keep a stack of source paths indicated by input parentheses. We may
+      // capture phrases that are enclosed in parathesis that are not paths, but
+      // this should ignored safely since the closing paratheses will pop the
+      // path right back off of the source path stack.
       match = line.match(INPUT_FILE_PATTERN)
       if (match) {
         for (const token of match) {
           if (token === ')') {
+            // Avoid popping texFilePath off of the stack.
             if (sourcePaths.length > 0) sourcePaths.shift()
           } else {
-            sourcePaths.unshift(path.resolve(this.projectPath, token.substring(1)))
+            sourcePaths.unshift(path.resolve(this.projectPath, token.substring(1).trim()))
           }
         }
-        console.log(sourcePaths)
       }
     })
 

--- a/lib/parsers/log-parser.js
+++ b/lib/parsers/log-parser.js
@@ -115,7 +115,7 @@ export default class LogParser extends Parser {
             // Avoid popping texFilePath off of the stack.
             if (sourcePaths.length > 0) sourcePaths.shift()
           } else {
-            sourcePaths.unshift(path.resolve(this.projectPath, token.substring(1).trim()))
+            sourcePaths.unshift(path.resolve(this.projectPath, token.replace(/(^\([\s"]*|[\s"]+$)/g, '')))
           }
         }
       }

--- a/spec/builders/latexmk-spec.js
+++ b/spec/builders/latexmk-spec.js
@@ -248,7 +248,7 @@ describe('LatexmkBuilder', () => {
         // since there will likely be font messages which may be dependent on
         // which TeX distribution is being used or which fonts are currently
         // installed.
-        console.log(logMessages)
+        console.log(JSON.stringify(logMessages))
         for (const message of messages) {
           expect(logMessages.some(
             logMessage => message.type === logMessage.type && message.text === logMessage.text && message.filePath === logMessage.filePath)).toBe(true, `Message = ${message.text}`)

--- a/spec/builders/latexmk-spec.js
+++ b/spec/builders/latexmk-spec.js
@@ -226,20 +226,20 @@ describe('LatexmkBuilder', () => {
       runs(() => {
         const logMessages = jobState.getLogMessages()
         const messages = [
-          { type: 'error', text: 'There\'s no line here to end' },
-          { type: 'error', text: 'Argument of \\@sect has an extra }' },
-          { type: 'error', text: 'Paragraph ended before \\@sect was complete' },
-          { type: 'error', text: 'Extra alignment tab has been changed to \\cr' },
-          { type: 'warning', text: 'Reference `tab:snafu\' on page 1 undefined' },
-          { type: 'error', text: 'Class foo: Significant class issue' },
-          { type: 'warning', text: 'Class foo: Class issue' },
-          { type: 'warning', text: 'Class foo: Nebulous class issue' },
-          { type: 'info', text: 'Class foo: Insignificant class issue' },
-          { type: 'error', text: 'Package bar: Significant package issue' },
-          { type: 'warning', text: 'Package bar: Package issue' },
-          { type: 'warning', text: 'Package bar: Nebulous package issue' },
-          { type: 'info', text: 'Package bar: Insignificant package issue' },
-          { type: 'warning', text: 'There were undefined references' }
+          { type: 'error', text: 'There\'s no line here to end', filePath },
+          { type: 'error', text: 'Argument of \\@sect has an extra }', filePath },
+          { type: 'error', text: 'Paragraph ended before \\@sect was complete', filePath },
+          { type: 'error', text: 'Extra alignment tab has been changed to \\cr', filePath },
+          { type: 'warning', text: 'Reference `tab:snafu\' on page 1 undefined', filePath: subFilePath },
+          { type: 'error', text: 'Class foo: Significant class issue', filePath },
+          { type: 'warning', text: 'Class foo: Class issue', filePath },
+          { type: 'warning', text: 'Class foo: Nebulous class issue', filePath },
+          { type: 'info', text: 'Class foo: Insignificant class issue', filePath },
+          { type: 'error', text: 'Package bar: Significant package issue', filePath: subFilePath },
+          { type: 'warning', text: 'Package bar: Package issue', filePath: subFilePath },
+          { type: 'warning', text: 'Package bar: Nebulous package issue', filePath: subFilePath },
+          { type: 'info', text: 'Package bar: Insignificant package issue', filePath: subFilePath },
+          { type: 'warning', text: 'There were undefined references', filePath }
         ]
 
         // Loop through the required messages and make sure that each one appears
@@ -249,7 +249,7 @@ describe('LatexmkBuilder', () => {
         // installed.
         for (const message of messages) {
           expect(logMessages.some(
-            logMessage => message.type === logMessage.type && message.text === logMessage.text)).toBe(true, `Message = ${message.text}`)
+            logMessage => message.type === logMessage.type && message.text === logMessage.text && message.filePath === logMessage.filePath)).toBe(true, `Message = ${message.text}`)
         }
 
         expect(logMessages.every(

--- a/spec/builders/latexmk-spec.js
+++ b/spec/builders/latexmk-spec.js
@@ -215,6 +215,7 @@ describe('LatexmkBuilder', () => {
       filePath = path.join(fixturesPath, 'error-warning.tex')
       state.setFilePath(filePath)
       const subFilePath = path.join(fixturesPath, 'sub', 'wibble.tex')
+      const spacesFilePath = path.join(fixturesPath, 'sub', 'foo bar.tex')
 
       waitsForPromise(() => {
         return builder.run(jobState).then(code => {
@@ -231,10 +232,10 @@ describe('LatexmkBuilder', () => {
           { type: 'error', text: 'Paragraph ended before \\@sect was complete', filePath },
           { type: 'error', text: 'Extra alignment tab has been changed to \\cr', filePath },
           { type: 'warning', text: 'Reference `tab:snafu\' on page 1 undefined', filePath: subFilePath },
-          { type: 'error', text: 'Class foo: Significant class issue', filePath },
-          { type: 'warning', text: 'Class foo: Class issue', filePath },
-          { type: 'warning', text: 'Class foo: Nebulous class issue', filePath },
-          { type: 'info', text: 'Class foo: Insignificant class issue', filePath },
+          { type: 'error', text: 'Class foo: Significant class issue', filePath: spacesFilePath },
+          { type: 'warning', text: 'Class foo: Class issue', filePath: spacesFilePath },
+          { type: 'warning', text: 'Class foo: Nebulous class issue', filePath: spacesFilePath },
+          { type: 'info', text: 'Class foo: Insignificant class issue', filePath: spacesFilePath },
           { type: 'error', text: 'Package bar: Significant package issue', filePath: subFilePath },
           { type: 'warning', text: 'Package bar: Package issue', filePath: subFilePath },
           { type: 'warning', text: 'Package bar: Nebulous package issue', filePath: subFilePath },
@@ -253,7 +254,7 @@ describe('LatexmkBuilder', () => {
         }
 
         expect(logMessages.every(
-          logMessage => !logMessage.filePath || logMessage.filePath === filePath || logMessage.filePath === subFilePath))
+          logMessage => !logMessage.filePath || logMessage.filePath === filePath || logMessage.filePath === subFilePath || logMessage.filePath === spacesFilePath))
           .toBe(true, 'Incorrect file path resolution in log.')
 
         expect(builder.logStatusCode).toHaveBeenCalled()

--- a/spec/builders/latexmk-spec.js
+++ b/spec/builders/latexmk-spec.js
@@ -248,6 +248,7 @@ describe('LatexmkBuilder', () => {
         // since there will likely be font messages which may be dependent on
         // which TeX distribution is being used or which fonts are currently
         // installed.
+        console.log(logMessages)
         for (const message of messages) {
           expect(logMessages.some(
             logMessage => message.type === logMessage.type && message.text === logMessage.text && message.filePath === logMessage.filePath)).toBe(true, `Message = ${message.text}`)

--- a/spec/builders/latexmk-spec.js
+++ b/spec/builders/latexmk-spec.js
@@ -248,7 +248,6 @@ describe('LatexmkBuilder', () => {
         // since there will likely be font messages which may be dependent on
         // which TeX distribution is being used or which fonts are currently
         // installed.
-        console.log(JSON.stringify(logMessages))
         for (const message of messages) {
           expect(logMessages.some(
             logMessage => message.type === logMessage.type && message.text === logMessage.text && message.filePath === logMessage.filePath)).toBe(true, `Message = ${message.text}`)

--- a/spec/fixtures/error-warning.tex
+++ b/spec/fixtures/error-warning.tex
@@ -31,13 +31,7 @@
   \ClassWarningNoLine{foo}{Nebulous class issue}
   \ClassInfo{foo}{Insignificant class issue}
 
-  % Package errors, warnings, etc.
-  \PackageError{bar}{Significant package issue}{RTFM!}
-  \PackageWarning{bar}{Package issue}
-  \PackageWarningNoLine{bar}{Nebulous package issue}
-  \PackageInfo{bar}{Insignificant package issue}
-
-  % Generate an error in a subfile located in another directory
+  % Generate errors and warnings in a subfile located in another directory
   \input{sub/wibble}
 
 \end{document}

--- a/spec/fixtures/error-warning.tex
+++ b/spec/fixtures/error-warning.tex
@@ -25,11 +25,8 @@
     Foo & Bar & Snafu \\
   \end{tabular}
 
-  % Class errors, warnings, etc.
-  \ClassError{foo}{Significant class issue}{RTFM!}
-  \ClassWarning{foo}{Class issue}
-  \ClassWarningNoLine{foo}{Nebulous class issue}
-  \ClassInfo{foo}{Insignificant class issue}
+  % Generate errors and warnings in a subfile with spaces
+  \input{"sub/foo bar.tex"}
 
   % Generate errors and warnings in a subfile located in another directory
   \input{sub/wibble}

--- a/spec/fixtures/sub/foo bar.tex
+++ b/spec/fixtures/sub/foo bar.tex
@@ -1,0 +1,5 @@
+% Class errors, warnings, etc.
+\ClassError{foo}{Significant class issue}{RTFM!}
+\ClassWarning{foo}{Class issue}
+\ClassWarningNoLine{foo}{Nebulous class issue}
+\ClassInfo{foo}{Insignificant class issue}

--- a/spec/fixtures/sub/wibble.tex
+++ b/spec/fixtures/sub/wibble.tex
@@ -1,2 +1,8 @@
+% Package errors, warnings, etc.
+\PackageError{bar}{Significant package issue}{RTFM!}
+\PackageWarning{bar}{Package issue}
+\PackageWarningNoLine{bar}{Nebulous package issue}
+\PackageInfo{bar}{Insignificant package issue}
+
 % Undefined references
 \ref{tab:snafu}


### PR DESCRIPTION
This is an experimental PR that attempts to (somewhat naively) parse the markers in the log from `\input` and `\include` so as to more accurately determine the source file for warning messages.

The motivating issue is #430.
