### PR TITLE
Migrate specs to use async helpers

### DIFF
--- a/script/install-knitr
+++ b/script/install-knitr
@@ -8,6 +8,10 @@ shopt -s nocasematch
 
 ensure_r_installed() {
   if [[ "${APPVEYOR:-}" == true ]]; then
+    # TODO: Remove when 'R.Project' package adds it as a dependency.
+    echo "Installing chocolatey-core.extension..."
+    choco install chocolatey-core.extension
+
     echo "Installing R..."
     choco install R.Project --allow-empty-checksums --ia="/DIR=\"${R_HOME}\""
 

--- a/spec/async-spec-helpers.js
+++ b/spec/async-spec-helpers.js
@@ -1,0 +1,106 @@
+/** @babel */
+
+// This file has shamelessly been procured from
+// https://raw.githubusercontent.com/atom/atom/master/spec/async-spec-helpers.js
+
+export function beforeEach (fn) {
+  global.beforeEach(function () {
+    const result = fn()
+    if (result instanceof Promise) {
+      waitsForPromise(() => result)
+    }
+  })
+}
+
+export function afterEach (fn) {
+  global.afterEach(function () {
+    const result = fn()
+    if (result instanceof Promise) {
+      waitsForPromise(() => result)
+    }
+  })
+}
+
+['it', 'fit', 'ffit', 'fffit'].forEach(function (name) {
+  module.exports[name] = function (description, fn) {
+    if (fn === undefined) {
+      global[name](description)
+      return
+    }
+
+    global[name](description, function () {
+      const result = fn()
+      if (result instanceof Promise) {
+        waitsForPromise(() => result)
+      }
+    })
+  }
+})
+
+export async function conditionPromise (condition, description = 'anonymous condition') {
+  const startTime = Date.now()
+
+  while (true) {
+    await timeoutPromise(100)
+
+    if (await condition()) {
+      return
+    }
+
+    if (Date.now() - startTime > 5000) {
+      throw new Error('Timed out waiting on ' + description)
+    }
+  }
+}
+
+export function timeoutPromise (timeout) {
+  return new Promise(function (resolve) {
+    global.setTimeout(resolve, timeout)
+  })
+}
+
+function waitsForPromise (fn) {
+  const promise = fn()
+  global.waitsFor('spec promise to resolve', function (done) {
+    promise.then(done, function (error) {
+      jasmine.getEnv().currentSpec.fail(error)
+      done()
+    })
+  })
+}
+
+export function emitterEventPromise (emitter, event, timeout = 15000) {
+  return new Promise((resolve, reject) => {
+    const timeoutHandle = setTimeout(() => {
+      reject(new Error(`Timed out waiting for '${event}' event`))
+    }, timeout)
+    emitter.once(event, () => {
+      clearTimeout(timeoutHandle)
+      resolve()
+    })
+  })
+}
+
+export function promisify (original) {
+  return function (...args) {
+    return new Promise((resolve, reject) => {
+      args.push((err, ...results) => {
+        if (err) {
+          reject(err)
+        } else {
+          resolve(...results)
+        }
+      })
+
+      return original(...args)
+    })
+  }
+}
+
+export function promisifySome (obj, fnNames) {
+  const result = {}
+  for (const fnName of fnNames) {
+    result[fnName] = promisify(obj[fnName])
+  }
+  return result
+}

--- a/spec/build-registry-spec.js
+++ b/spec/build-registry-spec.js
@@ -1,15 +1,18 @@
 /** @babel */
 
-import helpers from './spec-helpers'
+// eslint-disable-next-line no-unused-vars
+import { afterEach, beforeEach, it, fit } from './async-spec-helpers'
+import { activatePackages } from './spec-helpers'
 import { NullBuilder } from './stubs'
+
 import BuilderRegistry from '../lib/builder-registry'
 import BuildState from '../lib/build-state'
 
 describe('BuilderRegistry', () => {
   let builderRegistry
 
-  beforeEach(() => {
-    waitsForPromise(() => helpers.activatePackages())
+  beforeEach(async () => {
+    await activatePackages()
 
     atom.config.set('latex.builder', 'latexmk')
     builderRegistry = new BuilderRegistry()

--- a/spec/builder-spec.js
+++ b/spec/builder-spec.js
@@ -1,6 +1,9 @@
 /** @babel */
 
-import helpers from './spec-helpers'
+// eslint-disable-next-line no-unused-vars
+import { afterEach, beforeEach, it, fit } from './async-spec-helpers'
+import { cloneFixtures } from './spec-helpers'
+
 import path from 'path'
 import Builder from '../lib/builder'
 import BuildState from '../lib/build-state'
@@ -10,7 +13,7 @@ describe('Builder', () => {
 
   beforeEach(() => {
     builder = new Builder()
-    fixturesPath = helpers.cloneFixtures()
+    fixturesPath = cloneFixtures()
     filePath = path.join(fixturesPath, 'file.tex')
     logFilePath = path.join(fixturesPath, 'file.log')
     fdbFilePath = path.join(fixturesPath, 'file.fdb_latexmk')
@@ -136,22 +139,12 @@ describe('Builder', () => {
 
   describe('parseLogAndFdbFiles', () => {
     it('verifies that the correct output file is selected when using various latexmk modes', () => {
-      const switches = [{
-        name: 'pdf',
-        format: 'pdf'
-      }, {
-        name: 'pdfdvi',
-        format: 'pdf'
-      }, {
-        name: 'pdfps',
-        format: 'pdf'
-      }, {
-        name: 'ps',
-        format: 'ps'
-      }, {
-        name: 'dvi',
-        format: 'dvi'
-      }]
+      const switches = [
+        { name: 'pdf', format: 'pdf' },
+        { name: 'pdfdvi', format: 'pdf' },
+        { name: 'pdfps', format: 'pdf' },
+        { name: 'ps', format: 'ps' },
+        { name: 'dvi', format: 'dvi' }]
       state.setOutputDirectory('log-parse')
 
       for (const { name, format } of switches) {

--- a/spec/latex-spec.js
+++ b/spec/latex-spec.js
@@ -1,12 +1,12 @@
 /** @babel */
 
-import helpers from './spec-helpers'
+// eslint-disable-next-line no-unused-vars
+import { afterEach, beforeEach, it, fit } from './async-spec-helpers'
+import { activatePackages } from './spec-helpers'
 
 describe('Latex', () => {
-  beforeEach(() => {
-    waitsForPromise(() => {
-      return helpers.activatePackages()
-    })
+  beforeEach(async () => {
+    await activatePackages()
   })
 
   describe('initialize', () => {

--- a/spec/logger-spec.js
+++ b/spec/logger-spec.js
@@ -1,6 +1,8 @@
 /** @babel */
 
-import './spec-helpers'
+// eslint-disable-next-line no-unused-vars
+import { afterEach, beforeEach, it, fit } from './async-spec-helpers'
+
 import Logger from '../lib/logger'
 import werkzeug from '../lib/werkzeug'
 
@@ -23,43 +25,38 @@ describe('Logger', () => {
     it('verifies no messages filtered when logging level set to info', () => {
       initialize('info')
 
-      expect(logger.getMessages()).toEqual([{
-        type: 'info'
-      }, {
-        type: 'warning'
-      }, {
-        type: 'error'
-      }])
+      expect(logger.getMessages()).toEqual([
+        { type: 'info' },
+        { type: 'warning' },
+        { type: 'error' }
+      ])
     })
 
     it('verifies info messages filtered when logging level set to warning', () => {
       initialize('warning')
 
-      expect(logger.getMessages()).toEqual([{
-        type: 'warning'
-      }, {
-        type: 'error'
-      }])
+      expect(logger.getMessages()).toEqual([
+        { type: 'warning' },
+        { type: 'error' }
+      ])
     })
 
     it('verifies warning and info messages filtered when logging level set to error', () => {
       initialize('error')
 
-      expect(logger.getMessages()).toEqual([{
-        type: 'error'
-      }])
+      expect(logger.getMessages()).toEqual([
+        { type: 'error' }
+      ])
     })
 
     it('verifies no messages filtered when useFilters is false', () => {
       initialize('error')
 
-      expect(logger.getMessages(false)).toEqual([{
-        type: 'info'
-      }, {
-        type: 'warning'
-      }, {
-        type: 'error'
-      }])
+      expect(logger.getMessages(false)).toEqual([
+        { type: 'info' },
+        { type: 'warning' },
+        { type: 'error' }
+      ])
     })
   })
 
@@ -94,34 +91,31 @@ describe('Logger', () => {
 
     function initializeSpies (filePath, position) {
       initialize()
+
       logDock = jasmine.createSpyObj('LogDock', ['update'])
       spyOn(logger, 'show').andCallFake(() => Promise.resolve(logDock))
       spyOn(werkzeug, 'getEditorDetails').andReturn({ filePath, position })
     }
 
-    it('silently does nothing when the current editor is transient', () => {
+    it('silently does nothing when the current editor is transient', async () => {
       initializeSpies(null, null)
 
-      waitsForPromise(() => logger.sync())
+      await logger.sync()
 
-      runs(() => {
-        expect(logger.show).not.toHaveBeenCalled()
-        expect(logDock.update).not.toHaveBeenCalled()
-      })
+      expect(logger.show).not.toHaveBeenCalled()
+      expect(logDock.update).not.toHaveBeenCalled()
     })
 
-    it('shows and updates the log panel with the file path and position', () => {
+    it('shows and updates the log panel with the file path and position', async () => {
       const filePath = 'file.tex'
       const position = [[0, 0], [0, 10]]
 
       initializeSpies(filePath, position)
 
-      waitsForPromise(() => logger.sync())
+      await logger.sync()
 
-      runs(() => {
-        expect(logger.show).toHaveBeenCalled()
-        expect(logDock.update).toHaveBeenCalledWith({ filePath, position })
-      })
+      expect(logger.show).toHaveBeenCalled()
+      expect(logDock.update).toHaveBeenCalledWith({ filePath, position })
     })
   })
 

--- a/spec/marker-manager-spec.js
+++ b/spec/marker-manager-spec.js
@@ -1,22 +1,23 @@
 /** @babel */
 
-import helpers from './spec-helpers'
+// eslint-disable-next-line no-unused-vars
+import { afterEach, beforeEach, it, fit } from './async-spec-helpers'
+import { activatePackages } from './spec-helpers'
+
 import MarkerManager from '../lib/marker-manager'
 
 describe('MarkerManager', () => {
-  beforeEach(() => {
-    waitsForPromise(() => {
-      return helpers.activatePackages()
-    })
+  beforeEach(async () => {
+    await activatePackages()
   })
 
   describe('addMarkers', () => {
-    let editor, manager
+    let manager
 
     beforeEach(() => {
-      editor = {
+      const editor = {
         getPath: () => 'foo.tex',
-        onDidDestroy: () => { return { dispose: () => null } }
+        onDidDestroy: () => ({ dispose: () => {} })
       }
       manager = new MarkerManager(editor)
       spyOn(manager, 'addMarker')
@@ -24,19 +25,11 @@ describe('MarkerManager', () => {
     })
 
     it('verifies that only messages that have a range and a matching file path are marked', () => {
-      const messages = [{
-        type: 'error',
-        range: [[0, 0], [0, 1]],
-        filePath: 'foo.tex'
-      }, {
-        type: 'warning',
-        range: [[0, 0], [0, 1]],
-        filePath: 'bar.tex'
-      }, {
-        type: 'info',
-        filePath: 'foo.tex'
-      }]
-
+      const messages = [
+        { type: 'error', range: [[0, 0], [0, 1]], filePath: 'foo.tex' },
+        { type: 'warning', range: [[0, 0], [0, 1]], filePath: 'bar.tex' },
+        { type: 'info', filePath: 'foo.tex' }
+      ]
       manager.addMarkers(messages, false)
 
       expect(manager.addMarker).toHaveBeenCalledWith('error', 'foo.tex', [[0, 0], [0, 1]])

--- a/spec/opener-registry-spec.js
+++ b/spec/opener-registry-spec.js
@@ -1,30 +1,39 @@
 /** @babel */
 
-import helpers from './spec-helpers'
+// eslint-disable-next-line no-unused-vars
+import { afterEach, beforeEach, it, fit } from './async-spec-helpers'
+import { activatePackages } from './spec-helpers'
 
 describe('OpenerRegistry', () => {
   const filePath = 'wibble.pdf'
   // The various viewers
   let cannotOpen, canOpen, canOpenInBackground, canOpenWithSynctex
 
-  beforeEach(() => {
-    waitsForPromise(() => {
-      return helpers.activatePackages()
-    })
+  beforeEach(async () => {
+    await activatePackages()
   })
 
   function createOpener (name, canOpen, hasSynctex, canOpenInBackground) {
-    const instance = jasmine.createSpyObj(name, ['canOpen', 'open', 'hasSynctex', 'canOpenInBackground'])
-    instance.canOpen.andReturn(canOpen)
-    instance.open.andCallFake(() => Promise.resolve(undefined))
-    instance.hasSynctex.andReturn(hasSynctex)
-    instance.canOpenInBackground.andReturn(canOpenInBackground)
-    latex.opener.openers.set(name, instance)
-    return instance
+    const opener = jasmine.createSpyObj(name, [
+      'open',
+      'canOpen',
+      'hasSynctex',
+      'canOpenInBackground'
+    ])
+
+    opener.open.andCallFake(() => Promise.resolve())
+    opener.canOpen.andReturn(canOpen)
+    opener.hasSynctex.andReturn(hasSynctex)
+    opener.canOpenInBackground.andReturn(canOpenInBackground)
+
+    latex.opener.openers.set(name, opener)
+
+    return opener
   }
 
   beforeEach(() => {
     latex.opener.openers.clear()
+
     // The opener names have to conform to latex.opener schema
     cannotOpen = createOpener('skim', false, true, true)
     canOpen = createOpener('xdg-open', true, false, false)
@@ -33,49 +42,43 @@ describe('OpenerRegistry', () => {
   })
 
   describe('open', () => {
-    it('opens using preferred viewer even if it does not have requested features', () => {
+    it('opens using preferred viewer even if it does not have requested features', async () => {
       atom.config.set('latex.enableSynctex', true)
       atom.config.set('latex.openResultInBackground', true)
       atom.config.set('latex.opener', 'xdg-open')
 
-      waitsForPromise(() => latex.opener.open(filePath))
+      await latex.opener.open(filePath)
 
-      runs(() => {
-        expect(cannotOpen.open).not.toHaveBeenCalled()
-        expect(canOpen.open).toHaveBeenCalled()
-        expect(canOpenInBackground.open).not.toHaveBeenCalled()
-        expect(canOpenWithSynctex.open).not.toHaveBeenCalled()
-      })
+      expect(cannotOpen.open).not.toHaveBeenCalled()
+      expect(canOpen.open).toHaveBeenCalled()
+      expect(canOpenInBackground.open).not.toHaveBeenCalled()
+      expect(canOpenWithSynctex.open).not.toHaveBeenCalled()
     })
 
-    it('opens viewer that supports SyncTeX when enabled', () => {
+    it('opens viewer that supports SyncTeX when enabled', async () => {
       atom.config.set('latex.enableSynctex', true)
       atom.config.set('latex.openResultInBackground', true)
       atom.config.set('latex.opener', 'automatic')
 
-      waitsForPromise(() => latex.opener.open(filePath))
+      await latex.opener.open(filePath)
 
-      runs(() => {
-        expect(cannotOpen.open).not.toHaveBeenCalled()
-        expect(canOpen.open).not.toHaveBeenCalled()
-        expect(canOpenInBackground.open).not.toHaveBeenCalled()
-        expect(canOpenWithSynctex.open).toHaveBeenCalled()
-      })
+      expect(cannotOpen.open).not.toHaveBeenCalled()
+      expect(canOpen.open).not.toHaveBeenCalled()
+      expect(canOpenInBackground.open).not.toHaveBeenCalled()
+      expect(canOpenWithSynctex.open).toHaveBeenCalled()
     })
 
-    it('opens viewer that supports background opening when enabled', () => {
+    it('opens viewer that supports background opening when enabled', async () => {
       atom.config.set('latex.enableSynctex', false)
       atom.config.set('latex.openResultInBackground', true)
       atom.config.set('latex.opener', 'automatic')
 
-      waitsForPromise(() => latex.opener.open(filePath))
+      await latex.opener.open(filePath)
 
-      runs(() => {
-        expect(cannotOpen.open).not.toHaveBeenCalled()
-        expect(canOpen.open).not.toHaveBeenCalled()
-        expect(canOpenInBackground.open).toHaveBeenCalled()
-        expect(canOpenWithSynctex.open).not.toHaveBeenCalled()
-      })
+      expect(cannotOpen.open).not.toHaveBeenCalled()
+      expect(canOpen.open).not.toHaveBeenCalled()
+      expect(canOpenInBackground.open).toHaveBeenCalled()
+      expect(canOpenWithSynctex.open).not.toHaveBeenCalled()
     })
   })
 })

--- a/spec/parsers/fdb-parser-spec.js
+++ b/spec/parsers/fdb-parser-spec.js
@@ -1,6 +1,7 @@
 /** @babel */
 
-import '../spec-helpers'
+// eslint-disable-next-line no-unused-vars
+import { afterEach, beforeEach, it, fit } from '../async-spec-helpers'
 
 import path from 'path'
 import FdbParser from '../../lib/parsers/fdb-parser'

--- a/spec/parsers/log-parser-spec.js
+++ b/spec/parsers/log-parser-spec.js
@@ -1,6 +1,7 @@
 /** @babel */
 
-import '../spec-helpers'
+// eslint-disable-next-line no-unused-vars
+import { afterEach, beforeEach, it, fit } from '../async-spec-helpers'
 
 import _ from 'lodash'
 import path from 'path'

--- a/spec/parsers/magic-parser-spec.js
+++ b/spec/parsers/magic-parser-spec.js
@@ -1,5 +1,8 @@
 /** @babel */
 
+// eslint-disable-next-line no-unused-vars
+import { afterEach, beforeEach, it, fit } from '../async-spec-helpers'
+
 import path from 'path'
 import MagicParser from '../../lib/parsers/magic-parser'
 

--- a/spec/process-manager-spec.js
+++ b/spec/process-manager-spec.js
@@ -1,8 +1,11 @@
 /** @babel */
 
+// eslint-disable-next-line no-unused-vars
+import { afterEach, beforeEach, it, fit } from './async-spec-helpers'
+
 import fs from 'fs-plus'
-import temp from 'temp'
 import path from 'path'
+import temp from 'temp'
 import ProcessManager from '../lib/process-manager'
 
 describe('ProcessManager', () => {
@@ -18,30 +21,28 @@ describe('ProcessManager', () => {
     processManager = new ProcessManager()
   })
 
-  describe('ProcessManager', () => {
-    it('kills latexmk when given non-existant file', () => {
-      let killed = false
+  it('kills latexmk when given non-existant file', () => {
+    let killed = false
 
-      processManager.executeChildProcess(constructCommand('foo.tex'), { allowKill: true }).then(result => { killed = true })
+    processManager.executeChildProcess(constructCommand('foo.tex'), { allowKill: true }).then(result => { killed = true })
+    processManager.killChildProcesses()
+
+    waitsFor(() => killed, 5000)
+  })
+
+  it('kills old latexmk instances, but not ones created after the kill command', () => {
+    let oldKilled = false
+    let newKilled = false
+
+    processManager.executeChildProcess(constructCommand('old.tex'), { allowKill: true }).then(result => { oldKilled = true })
+    processManager.killChildProcesses()
+    processManager.executeChildProcess(constructCommand('new.tex'), { allowKill: true }).then(result => { newKilled = true })
+
+    waitsFor(() => oldKilled, 5000)
+
+    runs(() => {
+      expect(newKilled).toBe(false)
       processManager.killChildProcesses()
-
-      waitsFor(() => killed, 5000)
-    })
-
-    it('kills old latexmk instances, but not ones created after the kill command', () => {
-      let oldKilled = false
-      let newKilled = false
-
-      processManager.executeChildProcess(constructCommand('old.tex'), { allowKill: true }).then(result => { oldKilled = true })
-      processManager.killChildProcesses()
-      processManager.executeChildProcess(constructCommand('new.tex'), { allowKill: true }).then(result => { newKilled = true })
-
-      waitsFor(() => oldKilled, 5000)
-
-      runs(() => {
-        expect(newKilled).toBe(false)
-        processManager.killChildProcesses()
-      })
     })
   })
 })


### PR DESCRIPTION
I shamelessly procured the [`async-spec-helpers.js`](https://raw.githubusercontent.com/atom/atom/master/spec/async-spec-helpers.js) file from Atom, and migrated all of our specs to leverage those async helpers.

This PR represents a small step towards eventually upgrading Jasmine to a modern release, or perhaps migrating to Mocha + Sinon and what not.

All specs (except SageTeX and Asymptote) are green on my Ubuntu 17.04 system, using TeX Live 2017.