### PR TITLE
Only show the status bar label for latex files

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -45,7 +45,9 @@ export default {
     }
 
     atom.workspace.onDidChangeActivePaneItem((editor: AtomCore.IEditor) => {
-      this.checkStatusLabel(editor.getPath())
+      if (typeof editor.getPath === 'function') {
+        this.checkStatusLabel(editor.getPath())
+      }
     })
   },
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,6 +1,7 @@
 /** @babel */
 
 import { CompositeDisposable, Disposable } from 'atom'
+import { getEditorDetails, isSourceFile } from './werkzeug'
 
 export default {
   activate (serialized) {
@@ -65,7 +66,7 @@ export default {
   },
 
   checkStatusLabel (filepath) {
-    if (filepath.split('.').pop().includes('tex')) {
+    if (isSourceFile(filepath)) {
       latex.status.attachStatusBar()
     } else {
       latex.status.detachStatusBar()
@@ -75,10 +76,8 @@ export default {
   consumeStatusBar (statusBar) {
     this.bootstrap()
     latex.status.consumeStatusBar(statusBar)
-    const filepath = atom.workspace.getActivePaneItem().buffer.file.path
-    if (filepath) {
-      this.checkStatusLabel(filepath)
-    }
+    const { filepath } = getEditorDetails()
+    this.checkStatusLabel(filepath)
     return new Disposable(() => {
       if (global.latex) {
         global.latex.status.detachStatusBar()

--- a/lib/main.js
+++ b/lib/main.js
@@ -63,7 +63,7 @@ export default {
   },
 
   checkStatusLabel (filepath) {
-    if (filepath.split('.').pop().includes("tex")) {
+    if (filepath.split('.').pop().includes('tex')) {
       latex.status.attachStatusBar()
     } else {
       latex.status.detachStatusBar()

--- a/lib/main.js
+++ b/lib/main.js
@@ -43,6 +43,10 @@ export default {
       const checkConfigAndMigrate = require('./config-migrator')
       checkConfigAndMigrate()
     }
+
+    atom.workspace.onDidChangeActivePaneItem((editor: AtomCore.IEditor) => {
+      this.checkStatusLabel(editor.getPath())
+    })
   },
 
   deactivate () {
@@ -58,9 +62,21 @@ export default {
     return { messages: latex.log.getMessages(false) }
   },
 
+  checkStatusLabel (filepath) {
+    if (filepath.split('.').pop().includes("tex")) {
+      latex.status.attachStatusBar()
+    } else {
+      latex.status.detachStatusBar()
+    }
+  },
+
   consumeStatusBar (statusBar) {
     this.bootstrap()
-    latex.status.attachStatusBar(statusBar)
+    latex.status.consumeStatusBar(statusBar)
+    const filepath = atom.workspace.getActivePaneItem().buffer.file.path
+    if (filepath) {
+      this.checkStatusLabel(filepath)
+    }
     return new Disposable(() => {
       if (global.latex) {
         global.latex.status.detachStatusBar()

--- a/lib/status-indicator.js
+++ b/lib/status-indicator.js
@@ -13,7 +13,7 @@ export default class StatusIndicator extends Disposable {
   }
 
   attachStatusBar () {
-    if ( this.consumedBar && !this.statusTile){
+    if (this.consumedBar && !this.statusTile) {
       this.statusLabel = new StatusLabel()
       this.statusTile = this.consumedBar.addLeftTile({
         item: this.statusLabel,
@@ -23,7 +23,7 @@ export default class StatusIndicator extends Disposable {
   }
 
   detachStatusBar () {
-    if (this.consumedBar){
+    if (this.consumedBar) {
       if (this.statusTile) {
         this.statusTile.destroy()
         this.statusTile = null

--- a/lib/status-indicator.js
+++ b/lib/status-indicator.js
@@ -8,22 +8,30 @@ export default class StatusIndicator extends Disposable {
     super(() => this.detachStatusBar())
   }
 
-  attachStatusBar (statusBar) {
-    this.statusLabel = new StatusLabel()
-    this.statusTile = statusBar.addLeftTile({
-      item: this.statusLabel,
-      priority: 9001
-    })
+  consumeStatusBar (statusBar) {
+    this.consumedBar = statusBar
+  }
+
+  attachStatusBar () {
+    if ( this.consumedBar && !this.statusTile){
+      this.statusLabel = new StatusLabel()
+      this.statusTile = this.consumedBar.addLeftTile({
+        item: this.statusLabel,
+        priority: 9001
+      })
+    }
   }
 
   detachStatusBar () {
-    if (this.statusTile) {
-      this.statusTile.destroy()
-      this.statusTile = null
-    }
-    if (this.statusLabel) {
-      this.statusLabel.destroy()
-      this.statusLabel = null
+    if (this.consumedBar){
+      if (this.statusTile) {
+        this.statusTile.destroy()
+        this.statusTile = null
+      }
+      if (this.statusLabel) {
+        this.statusLabel.destroy()
+        this.statusLabel = null
+      }
     }
   }
 


### PR DESCRIPTION
Should help with issue #406:

Whenever the active editor is changed, this decides to attach/detach label from the status bar based on the filepath of the editor. Specifically, if the path extension contains "tex".

(This is my first pull request to an atom package, feedback is very welcome, in case I've broken the best practices)