### PR TITLE
Fix incorrect glob pattern used to populate list of generated files.

### DIFF
--- a/lib/composer.js
+++ b/lib/composer.js
@@ -509,7 +509,7 @@ export default class Composer extends Disposable {
       builder.parseLogAndFdbFiles(jobState)
     }
 
-    const pattern = path.resolve(dir, jobState.getOutputDirectory(), `${jobState.getJobName() || name}*`)
+    const pattern = path.resolve(dir, jobState.getOutputDirectory(), `${jobState.getJobName() || name}.*`)
     const files = new Set(glob.sync(pattern))
     const fdb = jobState.getFileDatabase()
 

--- a/spec/composer-spec.js
+++ b/spec/composer-spec.js
@@ -292,6 +292,18 @@ describe('Composer', () => {
       expect(fs.removeSync).toHaveBeenCalledWith(path.join(fixturesPath, '_minted-wibble'))
     })
 
+    it('does not unintentionally delete other files with the same leading name', async () => {
+      atom.config.unset('latex.cleanPatterns')
+      initializeSpies(path.join(fixturesPath, 'file.tex'))
+      composer.getGeneratedFileList.andCallThrough()
+
+      try { await composer.clean() } catch (error) { console.log(error) }
+
+      expect(fs.removeSync).toHaveBeenCalledWith(path.join(fixturesPath, 'file.aux'))
+      expect(fs.removeSync).toHaveBeenCalledWith(path.join(fixturesPath, 'file.log'))
+      expect(fs.removeSync).not.toHaveBeenCalledWith(path.join(fixturesPath, 'filename with spaces.log'))
+    })
+
     it('stops immediately if the file is not a TeX document', async () => {
       const filePath = 'foo.bar'
       initializeSpies(filePath, [])

--- a/spec/fixtures/file.fdb_latexmk
+++ b/spec/fixtures/file.fdb_latexmk
@@ -1,5 +1,5 @@
 # Fdb version 3
-["pdflatex"] 1474559881 "file.tex" "/foo/output/file.pdf" "file" 1474559881
+["pdflatex"] 1474559881 "file.tex" "/foo/file.pdf" "file" 1474559881
   "/foo/output/file.aux" 1474559881 78 176b9809a80d53064f21009e02135ec4 ""
   "/usr/local/texlive/2016/texmf-dist/fonts/map/fontname/texfonts.map" 1272929888 3287 e6b82fe08f5336d4d5ebc73fb1152e87 ""
   "/usr/local/texlive/2016/texmf-dist/fonts/tfm/public/cm/cmbx10.tfm" 1136768653 1328 c834bbb027764024c09d3d2bf908b5f0 ""
@@ -17,11 +17,11 @@
   "/usr/local/texlive/2016/texmf-var/web2c/pdftex/pdflatex.fmt" 1471547796 3873677 271c6d05ce0a4f4e34be832490419ac2 ""
   "/usr/local/texlive/2016/texmf.cnf" 1465311657 1020 2966fa5b7c5b86b293259f0ebdcea22d ""
   "file.tex" 1474559763 108 e2f7eacca0e6c4d22260c2d4b1150d46 ""
-  "output/file.aux" 1474559881 78 176b9809a80d53064f21009e02135ec4 ""
+  "file.aux" 1474559881 78 176b9809a80d53064f21009e02135ec4 ""
   (generated)
-  "/foo/output/file.pdfsync"
-  "/foo/output/file.pdf"
-  "output/file.log"
-  "output/file.pdf"
-  "/foo/output/file.log"
-  "output/file.aux"
+  "/foo/file.pdfsync"
+  "/foo/file.pdf"
+  "file.log"
+  "file.pdf"
+  "/foo/file.log"
+  "file.aux"


### PR DESCRIPTION
Bug discovered by @Doekab in #462. This bug has been around for a very long time, but somehow nobody has encountered it before now. The basis gist of the bug is as follows;

1. Given that `file.tex` is a valid LaTeX document that compiles, and that the build process produces some auxiliary files, of which one is `file.pdf`.
2. Rename `file.pdf` to `file x.pdf`.
3. When executing the `latex:clean` command, the renamed `file x.pdf` is incorrectly cleaned due to the overzealous glob pattern.

The proposed fix is simply replacing the very greedy glob pattern with a slightly less greedy pattern that only does wildcard matching on file extensions. Note that strictly speaking, the proposed fix is probably still susceptible to issues with files named e.g. `file.some.thing.log`, but that will have to be verified and fixed at some later stage.