### PR TITLE
Dependency version bumps and log toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 npm-debug.log
 node_modules
+package-lock.json

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -15,7 +15,7 @@ export default class Parser {
       throw new Error(`No such file: ${this.filePath}`)
     }
 
-    const rawFile = fs.readFileSync(this.filePath, {encoding: 'utf-8'})
+    const rawFile = fs.readFileSync(this.filePath, { encoding: 'utf-8' })
     const lines = rawFile.replace(/(\r\n)|\r/g, '\n').split('\n')
     return lines
   }

--- a/lib/views/status-label.js
+++ b/lib/views/status-label.js
@@ -19,7 +19,7 @@ export default class StatusLabel {
 
   render () {
     return (
-      <div className={this.getClassNames()} onclick={() => latex.log.show()}>
+      <div className={this.getClassNames()} onclick={() => latex.log.toggle()}>
         <span className='icon icon-sync busy' />
         <a href='#'>LaTeX</a>
         <MessageCount type='error' />
@@ -49,6 +49,6 @@ export default class StatusLabel {
       this.tooltip.dispose()
       this.tooltip = null
     }
-    this.tooltip = atom.tooltips.add(this.element, { title: 'Click to show LaTeX log' })
+    this.tooltip = atom.tooltips.add(this.element, { title: 'Click to toggle LaTeX log' })
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,20 +19,20 @@
   "dependencies": {
     "@dicy/client": "^0.13.0",
     "dbus-native": "^0.2.1",
-    "etch": "0.12.6",
+    "etch": "^0.14.0",
     "fs-plus": "^3.0.0",
     "glob": "^7.1.1",
     "js-yaml": "^3.11.0",
-    "lodash": "^4.17.4",
+    "lodash": "^4.17.11",
     "minimatch": "^3.0.4",
     "temp": "^0.8.3",
     "tree-kill": "^1.1.0",
     "wrench": "^1.5.9"
   },
   "devDependencies": {
-    "babel-eslint": "^8.2.2",
-    "snazzy": "^7.1.1",
-    "standard": "^11.0.0"
+    "babel-eslint": "^10.0.1",
+    "snazzy": "^8.0.0",
+    "standard": "^12.0.0"
   },
   "engines": {
     "atom": ">=1.19.0 <2.0.0"

--- a/spec/spec-helpers.js
+++ b/spec/spec-helpers.js
@@ -8,7 +8,7 @@ export default {
   cloneFixtures () {
     const tempPath = fs.realpathSync(temp.mkdirSync('latex'))
     let fixturesPath = atom.project.getPaths()[0]
-    wrench.copyDirSyncRecursive(fixturesPath, tempPath, {forceDelete: true})
+    wrench.copyDirSyncRecursive(fixturesPath, tempPath, { forceDelete: true })
     atom.project.setPaths([tempPath])
     fixturesPath = tempPath
 
@@ -16,7 +16,7 @@ export default {
   },
 
   overridePlatform (name) {
-    Object.defineProperty(process, 'platform', {__proto__: null, value: name})
+    Object.defineProperty(process, 'platform', { __proto__: null, value: name })
   },
 
   setTimeoutInterval (interval) {


### PR DESCRIPTION
- Bump dependencies to:
  - Satisfy David
  - Avoid `lodash`'s prototype pollution vulnerability
- Change status click activity to toggle in order to make log review and dismissal faster in terms of workflow

All package commands were tested with an IEEEtran LaTeX template on the following platforms for stability:
- [x] Arch Linux (Kernel 4.18.12-arch1-1-ARCH)
- [x] Windows 10 (1803)