### PR TITLE
Show Name of Undefined Control Sequence (macro)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,18 @@ some important features.
 
 Any and all help is greatly appreciated!
 
+**NOTE:** `latexmk` does not support file paths containing special characters such as `~`. To partially circumvent this, add `useRelativePaths: true` to your config file like so
+```cson
+# config.cson
+"*":
+  latex:
+    useRelativePaths: true
+```
+When set, this package will use a relative path in place of an absolute one. This will allow `latexmk` to compile projects stored in directories that contain special characters. Note that the project itself must not contain special characters in its directory or file names.
+
+This feature has not been fully tested yet, and there are no guarantees it will work in all cases. Please raise an issue if you find a case where it fails.
+
+
 <!--refs-->
 [appveyor svg]: https://ci.appveyor.com/api/projects/status/oc2v06stfwgd3bkn/branch/master?svg=true
 [appveyor]: https://ci.appveyor.com/project/thomasjo/atom-latex/branch/master

--- a/lib/builders/latexmk.js
+++ b/lib/builders/latexmk.js
@@ -27,8 +27,15 @@ export default class LatexmkBuilder extends Builder {
   }
 
   async execLatexmk (directoryPath, args, type) {
-    const command = `${this.executable} ${args.join(' ')}`
     const options = this.constructChildProcessOptions(directoryPath, { max_print_line: 1000 })
+
+    if (atom.config.get('latex.useRelativePaths') && options.cwd) {
+      const absPath = args[args.length - 1].slice(1, -1)
+      const relPath = path.relative(options.cwd, absPath)
+      args[args.length - 1] = `"${relPath}"`
+    }
+
+    const command = `${this.executable} ${args.join(' ')}`
 
     return latex.process.executeChildProcess(command, options)
   }

--- a/lib/parsers/log-parser.js
+++ b/lib/parsers/log-parser.js
@@ -21,7 +21,7 @@ const ERROR_PATTERN = new RegExp('' +
 // Pattern for obtaining the last macro in a line
 // Meant for catching the undefined control sequence
 const LAST_MACRO_PATTERN = new RegExp('' +
-  '(\\\\[a-zA-Z@]+)$' // Macro name
+  '(\\\\[^\\\\]+)$' // Macro name
 )
 
 // Pattern for overfull/underfull boxes

--- a/lib/parsers/log-parser.js
+++ b/lib/parsers/log-parser.js
@@ -85,27 +85,28 @@ export default class LogParser extends Parser {
 
       match = line.match(ERROR_PATTERN)
       if (match) {
-        let outMessageText
+        // Will contain the entire message that is going to be shown to the user
+        let outputMessage
         const lineNumber = match[2] ? parseInt(match[2], 10) : undefined
         // Check if the error is "Undefined control sequence"
-        let errMessageText = match[4]
-        if (errMessageText === UNDEF_CONTROL_SEQ_TEXT) {
+        const errorMessage = match[4]
+        if (errorMessage === UNDEF_CONTROL_SEQ_TEXT) {
           // The actual macro is the last thing
           // in the sentence of the next line
-          let nextLine = lines[index + 1]
-          let macroMatch = nextLine.match(LAST_MACRO_PATTERN)
+          const nextLine = lines[index + 1]
+          const macroMatch = nextLine.match(LAST_MACRO_PATTERN)
           // Check if there is a match
           if (macroMatch) {
-            outMessageText = errMessageText + ': ' + macroMatch[1]
+            outputMessage = `${errorMessage}: ${macroMatch[1]}`
           } else {
-            outMessageText = 'Unknown undefined controlsequence'
+            outputMessage = 'Unknown undefined controlsequence'
           }
         } else {
-          outMessageText = (match[3] && match[3] !== 'LaTeX') ? match[3] + ': ' + match[4] : match[4]
+          outputMessage = (match[3] && match[3] !== 'LaTeX') ? match[3] + ': ' + match[4] : match[4]
         }
         result.messages.push({
           type: 'error',
-          text: outMessageText,
+          text: outputMessage,
           filePath: match[1] ? path.resolve(this.projectPath, match[1]) : sourcePaths[0],
           range: lineNumber ? [[lineNumber - 1, 0], [lineNumber - 1, Number.MAX_SAFE_INTEGER]] : undefined,
           logPath: this.filePath,

--- a/lib/parsers/log-parser.js
+++ b/lib/parsers/log-parser.js
@@ -21,7 +21,7 @@ const ERROR_PATTERN = new RegExp('' +
 // Pattern for obtaining the last macro in a line
 // Meant for catching the undefined control sequence
 const LAST_MACRO_PATTERN = new RegExp('' +
-  '[^\\\\]*(\\\\[a-zA-Z@]+)$' // Macro name
+  '(\\\\[a-zA-Z@]+)$' // Macro name
 )
 
 // Pattern for overfull/underfull boxes

--- a/lib/parsers/log-parser.js
+++ b/lib/parsers/log-parser.js
@@ -18,6 +18,12 @@ const ERROR_PATTERN = new RegExp('' +
   '(.+?)\\.?$'           // Message text, the ending period is optional for MiKTeX
 )
 
+// Pattern for obtaining the last macro in a line
+// Meant for catching the undefined control sequence
+const LAST_MACRO_PATTERN = new RegExp('' +
+  '[^\\\\]*(\\\\[a-zA-Z@]+)$' // Macro name
+)
+
 // Pattern for overfull/underfull boxes
 const BOX_PATTERN = new RegExp('' +
   '^((?:Over|Under)full \\\\[vh]box \\([^)]*\\))' + // Message text
@@ -31,6 +37,9 @@ const WARNING_INFO_PATTERN = new RegExp('' +
   '(.*?)' +                                           // Message text
   '(?: on input line (\\d+))?\\.$'                    // Line number
 )
+
+// LaTeX log text when macro is undefined
+const UNDEF_CONTROL_SEQ_TEXT = 'Undefined control sequence'
 
 /* eslint-enable no-multi-spaces */
 
@@ -76,10 +85,22 @@ export default class LogParser extends Parser {
 
       match = line.match(ERROR_PATTERN)
       if (match) {
+        var outMessageText
         const lineNumber = match[2] ? parseInt(match[2], 10) : undefined
+        // Check if the error is "Undefined control sequence"
+        var errMessageText = match[4]
+        if (errMessageText === UNDEF_CONTROL_SEQ_TEXT) {
+          // The actual macro is the last thing
+          // in the sentence of the next line
+          var nextLine = lines[index + 1]
+          var macroName = nextLine.match(LAST_MACRO_PATTERN)[1]
+          outMessageText = errMessageText + ': ' + macroName
+        } else {
+          outMessageText = (match[3] && match[3] !== 'LaTeX') ? match[3] + ': ' + match[4] : match[4]
+        }
         result.messages.push({
           type: 'error',
-          text: (match[3] && match[3] !== 'LaTeX') ? match[3] + ': ' + match[4] : match[4],
+          text: outMessageText,
           filePath: match[1] ? path.resolve(this.projectPath, match[1]) : sourcePaths[0],
           range: lineNumber ? [[lineNumber - 1, 0], [lineNumber - 1, Number.MAX_SAFE_INTEGER]] : undefined,
           logPath: this.filePath,

--- a/lib/parsers/log-parser.js
+++ b/lib/parsers/log-parser.js
@@ -90,7 +90,9 @@ export default class LogParser extends Parser {
         const lineNumber = match[2] ? parseInt(match[2], 10) : undefined
         // Check if the error is "Undefined control sequence"
         const errorMessage = match[4]
-        if (errorMessage === UNDEF_CONTROL_SEQ_TEXT) {
+        // Even though there _should_ be a next line (with the macro name)
+        // we do a test to not go out of bounds
+        if (errorMessage === UNDEF_CONTROL_SEQ_TEXT && lines.length > index+1) {
           // The actual macro is the last thing
           // in the sentence of the next line
           const nextLine = lines[index + 1]

--- a/lib/parsers/log-parser.js
+++ b/lib/parsers/log-parser.js
@@ -85,7 +85,7 @@ export default class LogParser extends Parser {
 
       match = line.match(ERROR_PATTERN)
       if (match) {
-        var outMessageText
+        let outMessageText
         const lineNumber = match[2] ? parseInt(match[2], 10) : undefined
         // Check if the error is "Undefined control sequence"
         var errMessageText = match[4]
@@ -93,8 +93,13 @@ export default class LogParser extends Parser {
           // The actual macro is the last thing
           // in the sentence of the next line
           var nextLine = lines[index + 1]
-          var macroName = nextLine.match(LAST_MACRO_PATTERN)[1]
-          outMessageText = errMessageText + ': ' + macroName
+          let macroMatch = nextLine.match(LAST_MACRO_PATTERN)
+          // Check if there is a match
+          if (macroMatch) {
+            outMessageText = errMessageText + ': ' + macroMatch[1]
+          } else {
+            outMessageText = 'Unknown undefined controlsequence'
+          }
         } else {
           outMessageText = (match[3] && match[3] !== 'LaTeX') ? match[3] + ': ' + match[4] : match[4]
         }

--- a/lib/parsers/log-parser.js
+++ b/lib/parsers/log-parser.js
@@ -92,7 +92,7 @@ export default class LogParser extends Parser {
         const errorMessage = match[4]
         // Even though there _should_ be a next line (with the macro name)
         // we do a test to not go out of bounds
-        if (errorMessage === UNDEF_CONTROL_SEQ_TEXT && lines.length > index+1) {
+        if (errorMessage === UNDEF_CONTROL_SEQ_TEXT && lines.length > index + 1) {
           // The actual macro is the last thing
           // in the sentence of the next line
           const nextLine = lines[index + 1]

--- a/lib/parsers/log-parser.js
+++ b/lib/parsers/log-parser.js
@@ -88,11 +88,11 @@ export default class LogParser extends Parser {
         let outMessageText
         const lineNumber = match[2] ? parseInt(match[2], 10) : undefined
         // Check if the error is "Undefined control sequence"
-        var errMessageText = match[4]
+        let errMessageText = match[4]
         if (errMessageText === UNDEF_CONTROL_SEQ_TEXT) {
           // The actual macro is the last thing
           // in the sentence of the next line
-          var nextLine = lines[index + 1]
+          let nextLine = lines[index + 1]
           let macroMatch = nextLine.match(LAST_MACRO_PATTERN)
           // Check if there is a match
           if (macroMatch) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "latex",
-  "version": "0.50.1",
+  "version": "0.50.2",
   "description": "Compile LaTeX documents from within Atom",
   "keywords": [
     "tex",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "latex",
-  "version": "0.50.0",
+  "version": "0.50.1",
   "description": "Compile LaTeX documents from within Atom",
   "keywords": [
     "tex",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "main": "./lib/main",
   "dependencies": {
     "@dicy/client": "^0.13.0",
-    "dbus-native": "^0.2.1",
+    "dbus-native": "^0.4.0",
     "etch": "0.12.6",
     "fs-plus": "^3.0.0",
     "glob": "^7.1.1",

--- a/spec/process-manager-spec.js
+++ b/spec/process-manager-spec.js
@@ -27,7 +27,7 @@ describe('ProcessManager', () => {
     processManager.executeChildProcess(constructCommand('foo.tex'), { allowKill: true }).then(result => { killed = true })
     processManager.killChildProcesses()
 
-    waitsFor(() => killed, 10000)
+    waitsFor(() => killed, 5000)
   })
 
   it('kills old latexmk instances, but not ones created after the kill command', () => {
@@ -38,7 +38,7 @@ describe('ProcessManager', () => {
     processManager.killChildProcesses()
     processManager.executeChildProcess(constructCommand('new.tex'), { allowKill: true }).then(result => { newKilled = true })
 
-    waitsFor(() => oldKilled, 10000)
+    waitsFor(() => oldKilled, 5000)
 
     runs(() => {
       expect(newKilled).toBe(false)

--- a/spec/process-manager-spec.js
+++ b/spec/process-manager-spec.js
@@ -27,7 +27,7 @@ describe('ProcessManager', () => {
     processManager.executeChildProcess(constructCommand('foo.tex'), { allowKill: true }).then(result => { killed = true })
     processManager.killChildProcesses()
 
-    waitsFor(() => killed, 5000)
+    waitsFor(() => killed, 10000)
   })
 
   it('kills old latexmk instances, but not ones created after the kill command', () => {
@@ -38,7 +38,7 @@ describe('ProcessManager', () => {
     processManager.killChildProcesses()
     processManager.executeChildProcess(constructCommand('new.tex'), { allowKill: true }).then(result => { newKilled = true })
 
-    waitsFor(() => oldKilled, 5000)
+    waitsFor(() => oldKilled, 10000)
 
     runs(() => {
       expect(newKilled).toBe(false)


### PR DESCRIPTION
When LaTeX complains about undefined control sequence, this plugin does
not show the name of said macro, which is what this commit attempts to
fix.