### PR TITLE
Add relative path support

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,18 @@ some important features.
 
 Any and all help is greatly appreciated!
 
+**NOTE:** `latexmk` does not support file paths containing special characters such as `~`. To partially circumvent this, add `useRelativePaths: true` to your config file like so
+```cson
+# config.cson
+"*":
+  "atom-latex":
+    useRelativePaths: true
+```
+When set, this package will use a relative path in place of an absolute one. This will allow `latexmk` to compile projects stored in directories that contain special characters. Note that the project itself must not contain special characters in its directory or file names.
+
+This feature has not been fully tested yet, and there are no guarantees it will work in all cases. Please raise an issue if you find a case where it fails.
+
+
 <!--refs-->
 [appveyor svg]: https://ci.appveyor.com/api/projects/status/oc2v06stfwgd3bkn/branch/master?svg=true
 [appveyor]: https://ci.appveyor.com/project/thomasjo/atom-latex/branch/master

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Any and all help is greatly appreciated!
 ```cson
 # config.cson
 "*":
-  "atom-latex":
+  latex:
     useRelativePaths: true
 ```
 When set, this package will use a relative path in place of an absolute one. This will allow `latexmk` to compile projects stored in directories that contain special characters. Note that the project itself must not contain special characters in its directory or file names.

--- a/lib/builders/latexmk.js
+++ b/lib/builders/latexmk.js
@@ -27,8 +27,15 @@ export default class LatexmkBuilder extends Builder {
   }
 
   async execLatexmk (directoryPath, args, type) {
-    const command = `${this.executable} ${args.join(' ')}`
     const options = this.constructChildProcessOptions(directoryPath, { max_print_line: 1000 })
+
+    if (atom.config.get('latex.useRelativePaths') && options.cwd) {
+      const absPath = args[args.length - 1].slice(1, -1)
+      const relPath = path.relative(options.cwd, absPath)
+      args[args.length - 1] = `"${relPath}"`
+    }
+
+    const command = `${this.executable} ${args.join(' ')}`
 
     return latex.process.executeChildProcess(command, options)
   }

--- a/package.json
+++ b/package.json
@@ -309,12 +309,6 @@
       "type": "string",
       "default": "",
       "order": 24
-    },
-    "useRelativePaths": {
-      "description": "Execute compilation commands using relative paths from the main file",
-      "type": "boolean",
-      "default": false,
-      "order": 25
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -309,6 +309,12 @@
       "type": "string",
       "default": "",
       "order": 24
+    },
+    "useRelativePaths": {
+      "description": "Execute compilation commands using relative paths from the main file",
+      "type": "boolean",
+      "default": false,
+      "order": 25
     }
   }
 }


### PR DESCRIPTION
(tries to) Fixes https://github.com/thomasjo/atom-latex/issues/480

Honestly, I have only tried this with a single file and no included / inputed / other fancy projects. That's why I want to leave the option disabled by default, but there if a user experiences the same issue as above.

I will report back with more attempts to break it, but I don't think I can test all combinations of files this package supports (sage, knitr, etc.). It doesn't help that these tests are failing anyway for me (I suppose it's because I don't have those programs installed? IDK).