### PR TITLE
Provide auto toggle option

### DIFF
--- a/lib/views/log-dock.js
+++ b/lib/views/log-dock.js
@@ -24,6 +24,14 @@ export default class LogDock {
   render () {
     let content = latex.log.getMessages().map(message => <LogMessage message={message} filePath={this.properties.filePath} position={this.properties.position} />)
 
+    if (atom.config.get('latex.autoToggleDock')) {
+      if (content.length === 0) {
+        atom.workspace.hide(this)
+      } else {
+        atom.workspace.open(this, { searchAllPanes: true })
+      }
+    }
+
     return (
       <div className='latex-log' ref='body'>
         <div className='log-block expand'>

--- a/package.json
+++ b/package.json
@@ -145,6 +145,12 @@
       "default": "warning",
       "order": 8
     },
+    "autoToggleDock": {
+      "description": "Controls the behaviour of the log errors dock",
+      "type": "boolean",
+      "default": false,
+      "order": 9
+    },
     "cleanPatterns": {
       "description": "The files and directories to remove during a LaTeX clean. Basic glob patterns are understood and named properties such as {jobname} are replaced with the current build properties. Patterns that start with `/` or `\\` are matched against any file in the same directory as the source file. All other patterns are matched against generated files in the output directory. More information can be found on the Atom LaTeX wiki.",
       "type": "array",
@@ -181,13 +187,13 @@
         "/texput.log",
         "/texput.aux"
       ],
-      "order": 9
+      "order": 10
     },
     "outputDirectory": {
       "description": "All files generated during a build will be redirected here. Leave blank if you want the build output to be stored in the same directory as the TeX document.",
       "type": "string",
       "default": "",
-      "order": 10
+      "order": 11
     },
     "outputFormat": {
       "description": "Output file format. DVI and PS currently only supported for latexmk.",
@@ -198,7 +204,7 @@
         "ps"
       ],
       "default": "pdf",
-      "order": 11
+      "order": 12
     },
     "producer": {
       "title": "PDF Producer",
@@ -211,33 +217,33 @@
         "ps2pdf"
       ],
       "default": "dvipdfmx",
-      "order": 12
+      "order": 13
     },
     "moveResultToSourceDirectory": {
       "title": "Move Result to Source Directory",
       "description": "Ensures that the output file produced by a successful build is stored together with the TeX document that produced it.",
       "type": "boolean",
       "default": true,
-      "order": 13
+      "order": 14
     },
     "buildOnSave": {
       "title": "Build on Save",
       "description": "Automatically run builds when files are saved.",
       "type": "boolean",
       "default": false,
-      "order": 14
+      "order": 15
     },
     "openResultAfterBuild": {
       "title": "Open Result after Successful Build",
       "type": "boolean",
       "default": true,
-      "order": 15
+      "order": 16
     },
     "openResultInBackground": {
       "title": "Open Result in Background",
       "type": "boolean",
       "default": true,
-      "order": 16
+      "order": 17
     },
     "opener": {
       "type": "string",
@@ -258,7 +264,7 @@
         "custom"
       ],
       "default": "automatic",
-      "order": 17
+      "order": 18
     },
     "pdfViewSplitDirection": {
       "description": "Pane split direction to use for pdf-view.",
@@ -270,45 +276,45 @@
         "down"
       ],
       "default": "right",
-      "order": 18
+      "order": 19
     },
     "skimPath": {
       "description": "Full application path to Skim (macOS).",
       "type": "string",
       "default": "/Applications/Skim.app",
-      "order": 19
+      "order": 20
     },
     "sumatraPath": {
       "title": "SumatraPDF Path",
       "description": "Full application path to SumatraPDF (Windows).",
       "type": "string",
       "default": "C:\\Program Files (x86)\\SumatraPDF\\SumatraPDF.exe",
-      "order": 20
+      "order": 21
     },
     "okularPath": {
       "description": "Full application path to Okular (*nix).",
       "type": "string",
       "default": "/usr/bin/okular",
-      "order": 21
+      "order": 22
     },
     "zathuraPath": {
       "description": "Full application path to Zathura (*nix).",
       "type": "string",
       "default": "/usr/bin/zathura",
-      "order": 22
+      "order": 23
     },
     "qpdfviewPath": {
       "description": "Full application path to qpdfview (*nix).",
       "type": "string",
       "default": "/usr/bin/qpdfview",
-      "order": 23
+      "order": 24
     },
     "viewerPath": {
       "title": "Custom PDF Viewer Path",
       "description": "Full application path to your PDF viewer. Overrides Skim and SumatraPDF options.",
       "type": "string",
       "default": "",
-      "order": 24
+      "order": 25
     }
   }
 }


### PR DESCRIPTION
This let's the dock open and close itself, based on if it's got messages or not.

I was considering making the control finer, by allowing auto close and auto open to be separately configured (could be rolled into a single enum choice). Honestly, it still sounds good to me.

The open / close logic is based on [the toggle logic](https://github.com/atom/atom/blob/2791572cd20b1d8c84a100e8308dcce57d1853d7/src/workspace.js#L1039).

Also fixes #506 