### PR TITLE
Convert "pdf-view" opener to "atom"

### DIFF
--- a/lib/openers/atom-opener.js
+++ b/lib/openers/atom-opener.js
@@ -3,7 +3,7 @@
 import Opener from '../opener'
 import { isPdfFile } from '../werkzeug'
 
-export default class PdfViewOpener extends Opener {
+export default class AtomOpener extends Opener {
   async open (filePath, texPath, lineNumber) {
     const texPane = atom.workspace.paneForURI(texPath)
     const previousActivePane = atom.workspace.getActivePane()
@@ -31,6 +31,6 @@ export default class PdfViewOpener extends Opener {
   }
 
   canOpen (filePath) {
-    return isPdfFile(filePath) && atom.packages.isPackageActive('pdf-view')
+    return isPdfFile(filePath)
   }
 }

--- a/package.json
+++ b/package.json
@@ -243,10 +243,10 @@
       "type": "string",
       "enum": [
         "automatic",
+        "atom",
         "atril",
         "evince",
         "okular",
-        "pdf-view",
         "preview",
         "qpdfview",
         "shell-open",


### PR DESCRIPTION
This generalises the Atom opener to whatever PDF package they may have installed, instead of restricting it to `pdf-view`. Cross ref https://github.com/Aerijo/atom-pdf-view-plus/issues/5.

It just renames the opener and removes the active package check. This check doesn't work when other packages are providing the PDF view, so removing it decreases the coupling between this package and any particular viewer.

This does mean that it could potentially open the PDF as a text file if the user has no viewer packages, but I would consider this acceptable.