### PR TITLE
Add openResultAfterBuild "magic" TeX comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ for compatibility. More details can found at [Overridding Build Settings][].
 | `jobNames`, `jobnames` or `jobname`     | comma separated names, e.g. `foo, bar`         | Control the number and names of build jobs. Only a single name can be used for `jobname`. |
 | `outputDirectory` or `output_directory` | directory path, e.g. `build`                   | Specify the output directory that should be used.                                         |
 | `producer`                              | `dvipdf`, `dvipdfmx`, `xdvipdfmx` or `ps2pdf`  | Override the PDF producer                                                                 |
-| `root`                                  | file path, e.g. `../file.tex`                  | Specify the root file that should be built. Only available via "magic" TeX comments.      |
+| `openResultAfterBuild`                  | `yes`, `no`, `true` or `false`                 | Override open result after build (not available for DiCy)                                                                  |
+| `root`                                  | file path, e.g. `../file.tex`                  | Specify the root file that should be built. Only available via "magic" TeX comments.      |        
 
 There are additional settings that may be configured for the DiCy builder that
 may not be accessible from this package's setting page, but can be set via a

--- a/lib/build-state.js
+++ b/lib/build-state.js
@@ -85,6 +85,10 @@ class JobState {
     return this.parent.getEnableExtendedBuildMode()
   }
 
+  getOpenResultAfterBuild () {
+    return this.parent.getOpenResultAfterBuild()
+  }
+
   getEngine () {
     return this.parent.getEngine()
   }
@@ -118,6 +122,7 @@ export default class BuildState {
     this.setEnableSynctex(false)
     this.setEnableShellEscape(false)
     this.setEnableExtendedBuildMode(false)
+    this.setOpenResultAfterBuild(false)
     this.subfiles = new Set()
   }
 
@@ -175,6 +180,14 @@ export default class BuildState {
 
   setEnableExtendedBuildMode (value) {
     this.enableExtendedBuildMode = toBoolean(value)
+  }
+
+  getOpenResultAfterBuild () {
+    return this.openResultAfterBuild
+  }
+
+  setOpenResultAfterBuild (value) {
+    this.openResultAfterBuild = toBoolean(value)
   }
 
   getEngine () {

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -112,6 +112,10 @@ export default class Composer extends Disposable {
       state.setJobNames([properties.jobname])
     }
 
+    if ('openResultAfterBuild' in properties) {
+      state.setOpenResultAfterBuild(properties.openResultAfterBuild)
+    }
+
     if (properties.customEngine) {
       state.setEngine(properties.customEngine)
     } else if (properties.engine) {
@@ -573,7 +577,7 @@ export default class Composer extends Disposable {
   }
 
   async showResult (filePath, lineNumber, jobState) {
-    if (!this.shouldOpenResult()) { return }
+    if (!jobState.getOpenResultAfterBuild()) { return }
 
     await latex.opener.open(jobState.getOutputFilePath(), filePath, lineNumber)
   }


### PR DESCRIPTION
This commit adds the "openResultAfterBuild" magic comment while leaving the normal config functionality intact. 

This magic comment will not work with DiCy as far as I know but its functionality shouldn't impact DiCy since DiCy doesn't appear to use any of the functions I've modified.

It would be great if any experienced users could help me out with testing this. I'm a novice with Javascript so I don't really understand whats going on in the spec folder enough to test my contributions. I've implemented this on my personal copy and I've been using it successfully for a few months and I figured the community could benefit even though it's an incomplete commit as far as testing is concerned.